### PR TITLE
Refit parity PSD and MTF baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@
   - issue `#4` 的 parity re-fit benchmark 狀態、已驗證無效的修正方向、以及目前阻塞點
 - [docs/parity_input_pipeline_candidates.md](docs/parity_input_pipeline_candidates.md)
   - issue `#10` 的 input-path benchmark、目前鎖定的 parity input pipeline、以及被排除的候選路徑
+- [docs/parity_psd_mtf_refit.md](docs/parity_psd_mtf_refit.md)
+  - issue `#11` 的 parity PSD/MTF refit、基線與新 profile 比較、以及後續 validation 邊界
 - [algo/README.md](/Users/kevinhuang/work/acutance/algo/README.md)
   - 演算法原型、數學流程、校準與 benchmark 記錄
 - [release/deadleaf_13b10_release/README.md](/Users/kevinhuang/work/acutance/release/deadleaf_13b10_release/README.md)

--- a/algo/benchmark_parity_psd_mtf.py
+++ b/algo/benchmark_parity_psd_mtf.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import re
+
+import numpy as np
+
+from .dead_leaves import (
+    BayerMode,
+    BayerPattern,
+    IMATEST_REFERENCE_BINS,
+    RoiBounds,
+    acutance_curve_from_mtf,
+    acutance_presets_from_mtf,
+    apply_frequency_scale,
+    compare_acutance_curves,
+    compare_acutance_presets,
+    compute_mtf_metrics,
+    detect_texture_roi,
+    estimate_dead_leaves_mtf,
+    extract_analysis_plane,
+    interpolate_threshold,
+    load_ideal_psd_calibration,
+    load_raw_u16,
+    normalize_for_analysis,
+    parse_imatest_random_csv,
+)
+
+BANDS = (
+    ("low", 0.01, 0.08),
+    ("mid", 0.08, 0.2),
+    ("high", 0.2, 0.35),
+    ("top", 0.35, 0.5),
+)
+
+
+@dataclass(frozen=True)
+class Profile:
+    name: str
+    calibration_file: str
+    gamma: float = 1.0
+    bayer_pattern: str = BayerPattern.RGGB.value
+    bayer_mode: str = BayerMode.DEMOSAIC_RED.value
+    roi_source: str = "fixed"
+    roi_width: int = 1655
+    roi_height: int = 1673
+    frequency_scale: float = 1.0
+    normalization_band_lo: float = 0.01
+    normalization_band_hi: float = 0.03
+    normalization_mode: str = "max"
+    acutance_band_lo: float = 0.017
+    acutance_band_hi: float = 0.035
+    acutance_band_mode: str = "mean"
+    signal_psd_correction_gain: float = 0.0
+    signal_psd_correction_start_cpp: float = 0.08
+    signal_psd_correction_peak_cpp: float = 0.15
+    signal_psd_correction_stop_cpp: float = 0.22
+    noise_psd_model: str = "empirical"
+    noise_psd_log_polynomial_degree: int = 2
+
+
+def load_profile(path: Path) -> Profile:
+    return Profile(**json.loads(path.read_text(encoding="utf-8")))
+
+
+def classify_csv(csv_path: Path, dataset_root: Path) -> str:
+    relative = csv_path.relative_to(dataset_root)
+    parts = relative.parts
+    if "OV13B10_AI_NR_OV13B10_ori" in parts:
+        return "ori"
+    parent = csv_path.parent.parent.name
+    match = re.search(r"_ppqpkl_([0-9.]+)$", parent)
+    return match.group(1) if match else "unknown"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Benchmark parity PSD/MTF profiles.")
+    parser.add_argument("dataset_root", type=Path)
+    parser.add_argument("profiles", nargs="+", type=Path)
+    parser.add_argument("--width", type=int, default=4032)
+    parser.add_argument("--height", type=int, default=3024)
+    parser.add_argument("--output", type=Path)
+    return parser
+
+
+def choose_roi(profile: Profile, reference, image: np.ndarray) -> RoiBounds:
+    if profile.roi_source == "reference":
+        return reference.lrtb.clamp(image.shape[1], image.shape[0])
+    detected = detect_texture_roi(image)
+    return RoiBounds.centered(
+        center_x=(detected.left + detected.right) // 2,
+        center_y=(detected.top + detected.bottom) // 2,
+        width=profile.roi_width,
+        height=profile.roi_height,
+        image_width=image.shape[1],
+        image_height=image.shape[0],
+    )
+
+
+def resample_curve(
+    source_frequencies: np.ndarray,
+    source_values: np.ndarray,
+    reference_frequencies: np.ndarray,
+) -> np.ndarray:
+    source_f = np.asarray(source_frequencies, dtype=np.float64)
+    source_v = np.asarray(source_values, dtype=np.float64)
+    reference_f = np.asarray(reference_frequencies, dtype=np.float64)
+    return np.interp(
+        reference_f,
+        source_f,
+        source_v,
+        left=float(source_v[0]),
+        right=float(source_v[-1]),
+    )
+
+
+def mean_abs_signed_rel(summary: dict[str, dict[str, float]]) -> float:
+    return float(np.mean([abs(summary[name]["signed_rel_mean"]) for name, _, _ in BANDS]))
+
+
+def band_error_summary(
+    frequencies: np.ndarray,
+    estimate: np.ndarray,
+    reference: np.ndarray,
+) -> dict[str, dict[str, float]]:
+    summary: dict[str, dict[str, float]] = {}
+    for label, lo, hi in BANDS:
+        band = (frequencies >= lo) & (frequencies < hi)
+        if not np.any(band):
+            continue
+        est = np.asarray(estimate[band], dtype=np.float64)
+        ref = np.asarray(reference[band], dtype=np.float64)
+        abs_err = np.abs(est - ref)
+        rel_err = abs_err / np.maximum(np.abs(ref), 1e-12)
+        signed_rel = (est - ref) / np.maximum(np.abs(ref), 1e-12)
+        summary[label] = {
+            "mae_mean": float(np.mean(abs_err)),
+            "mre_mean": float(np.mean(rel_err)),
+            "signed_rel_mean": float(np.mean(signed_rel)),
+        }
+    return summary
+
+
+def profile_payload(
+    *,
+    dataset_root: Path,
+    profile_path: Path,
+    profile: Profile,
+    width: int,
+    height: int,
+) -> dict[str, object]:
+    calibration = load_ideal_psd_calibration(profile.calibration_file)
+    csv_paths = sorted(dataset_root.glob("**/Results/*_R_Random.csv"))
+    curve_mae: list[float] = []
+    preset_errors: dict[str, list[float]] = {}
+    mtf50_errors: list[float] = []
+    mtf30_errors: list[float] = []
+    mtf20_errors: list[float] = []
+    band_rows: list[dict[str, dict[str, float]]] = []
+    by_mixup: dict[str, list[float]] = {}
+
+    for csv_path in csv_paths:
+        raw_path = csv_path.parent.parent / csv_path.name.replace("_R_Random.csv", ".raw")
+        if not raw_path.exists():
+            continue
+
+        reference = parse_imatest_random_csv(csv_path)
+        raw = load_raw_u16(raw_path, width, height)
+        plane = extract_analysis_plane(
+            raw,
+            bayer_pattern=BayerPattern(profile.bayer_pattern),
+            mode=BayerMode(profile.bayer_mode),
+        )
+        image = normalize_for_analysis(plane, gamma=profile.gamma)
+        roi = choose_roi(profile, reference, image)
+        estimate = estimate_dead_leaves_mtf(
+            image,
+            num_bins=len(IMATEST_REFERENCE_BINS),
+            ideal_psd_mode="calibrated_log",
+            ideal_psd_calibration=calibration,
+            bin_centers=IMATEST_REFERENCE_BINS,
+            roi_override=roi,
+            normalization_band=(profile.normalization_band_lo, profile.normalization_band_hi),
+            normalization_mode=profile.normalization_mode,
+            acutance_reference_band=(profile.acutance_band_lo, profile.acutance_band_hi),
+            acutance_reference_mode=profile.acutance_band_mode,
+            signal_psd_correction_gain=profile.signal_psd_correction_gain,
+            signal_psd_correction_start_cpp=profile.signal_psd_correction_start_cpp,
+            signal_psd_correction_peak_cpp=profile.signal_psd_correction_peak_cpp,
+            signal_psd_correction_stop_cpp=profile.signal_psd_correction_stop_cpp,
+            noise_psd_model=profile.noise_psd_model,
+            noise_psd_log_polynomial_degree=profile.noise_psd_log_polynomial_degree,
+        )
+        scaled_frequencies = apply_frequency_scale(
+            estimate.frequencies_cpp,
+            scale=profile.frequency_scale,
+        )
+        metrics = compute_mtf_metrics(scaled_frequencies, estimate.mtf)
+        mtf50_errors.append(
+            abs(metrics.mtf50 - interpolate_threshold(reference.frequencies_cpp, reference.mtf, 0.5))
+        )
+        mtf30_errors.append(
+            abs(metrics.mtf30 - interpolate_threshold(reference.frequencies_cpp, reference.mtf, 0.3))
+        )
+        mtf20_errors.append(
+            abs(metrics.mtf20 - interpolate_threshold(reference.frequencies_cpp, reference.mtf, 0.2))
+        )
+
+        curve = acutance_curve_from_mtf(
+            scaled_frequencies,
+            estimate.mtf_for_acutance,
+            picture_height_cm=40.0,
+            viewing_distances_cm=np.arange(1.0, 101.0, 1.0),
+            pixels_along_picture_height=estimate.roi.height,
+        )
+        curve_cmp = compare_acutance_curves(curve, reference.acutance_table)
+        if curve_cmp.get("count", 0):
+            curve_mae.append(float(curve_cmp["mae"]))
+            key = classify_csv(csv_path, dataset_root)
+            by_mixup.setdefault(key, []).append(float(curve_cmp["mae"]))
+
+        presets = acutance_presets_from_mtf(
+            scaled_frequencies,
+            estimate.mtf_for_acutance,
+            pixels_along_picture_height=estimate.roi.height,
+        )
+        preset_cmp = compare_acutance_presets(presets, reference.reported_acutance)
+        for key, values in preset_cmp.items():
+            preset_errors.setdefault(key, []).append(float(values["abs_error"]))
+
+        estimate_on_reference = resample_curve(
+            scaled_frequencies,
+            estimate.mtf,
+            reference.frequencies_cpp,
+        )
+        band_rows.append(
+            band_error_summary(reference.frequencies_cpp, estimate_on_reference, reference.mtf)
+        )
+
+    mtf_summary = {
+        label: {
+            "mae_mean": float(np.mean([row[label]["mae_mean"] for row in band_rows])),
+            "mre_mean": float(np.mean([row[label]["mre_mean"] for row in band_rows])),
+            "signed_rel_mean": float(np.mean([row[label]["signed_rel_mean"] for row in band_rows])),
+        }
+        for label, _, _ in BANDS
+    }
+    return {
+        "profile_path": str(profile_path),
+        "analysis_pipeline": {
+            "gamma": profile.gamma,
+            "bayer_pattern": profile.bayer_pattern,
+            "bayer_mode": profile.bayer_mode,
+            "roi_source": profile.roi_source,
+            "frequency_scale": profile.frequency_scale,
+            "signal_psd_correction_gain": profile.signal_psd_correction_gain,
+            "calibration_file": profile.calibration_file,
+        },
+        "overall": {
+            "curve_mae_mean": float(np.mean(curve_mae)),
+            "preset_mae": {
+                key: float(np.mean(values))
+                for key, values in sorted(preset_errors.items())
+            },
+            "mtf_threshold_mae": {
+                "mtf50": float(np.mean(mtf50_errors)),
+                "mtf30": float(np.mean(mtf30_errors)),
+                "mtf20": float(np.mean(mtf20_errors)),
+            },
+            "mtf_bands": mtf_summary,
+            "mtf_abs_signed_rel_mean": mean_abs_signed_rel(mtf_summary),
+        },
+        "by_mixup_curve_mae_mean": {
+            key: float(np.mean(values))
+            for key, values in sorted(by_mixup.items())
+        },
+    }
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    results = []
+    for profile_path in args.profiles:
+        profile = load_profile(profile_path)
+        results.append(
+            profile_payload(
+                dataset_root=args.dataset_root,
+                profile_path=profile_path,
+                profile=profile,
+                width=args.width,
+                height=args.height,
+            )
+        )
+    payload = {
+        "dataset_root": str(args.dataset_root),
+        "profiles": results,
+    }
+    text = json.dumps(payload, indent=2, sort_keys=True)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text + "\n", encoding="utf-8")
+    else:
+        print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/algo/deadleaf_13b10_locked_input_baseline_profile.json
+++ b/algo/deadleaf_13b10_locked_input_baseline_profile.json
@@ -1,0 +1,12 @@
+{
+  "name": "deadleaf_13b10_locked_input_baseline",
+  "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+  "gamma": 1.0,
+  "bayer_pattern": "RGGB",
+  "bayer_mode": "demosaic_red",
+  "roi_source": "fixed",
+  "roi_width": 1655,
+  "roi_height": 1673,
+  "frequency_scale": 1.0,
+  "signal_psd_correction_gain": 0.0
+}

--- a/algo/deadleaf_13b10_parity_psd_mtf_profile.json
+++ b/algo/deadleaf_13b10_parity_psd_mtf_profile.json
@@ -1,0 +1,12 @@
+{
+  "name": "deadleaf_13b10_parity_psd_mtf",
+  "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+  "gamma": 1.0,
+  "bayer_pattern": "RGGB",
+  "bayer_mode": "demosaic_red",
+  "roi_source": "fixed",
+  "roi_width": 1655,
+  "roi_height": 1673,
+  "frequency_scale": 1.17,
+  "signal_psd_correction_gain": 0.0
+}

--- a/artifacts/parity_psd_mtf_benchmark.json
+++ b/artifacts/parity_psd_mtf_benchmark.json
@@ -1,0 +1,121 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "frequency_scale": 1.0,
+        "gamma": 1.0,
+        "roi_source": "fixed",
+        "signal_psd_correction_gain": 0.0
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.0622343120090446,
+        "0.25": 0.057198175355299564,
+        "0.4": 0.04767289917446428,
+        "0.65": 0.036924043873611694,
+        "0.8": 0.02660295576139359,
+        "ori": 0.025420760894761103
+      },
+      "overall": {
+        "curve_mae_mean": 0.04497614893687769,
+        "mtf_abs_signed_rel_mean": 0.3301961269108969,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.06788209389112695,
+            "mre_mean": 0.3039261591755178,
+            "signed_rel_mean": -0.3039261591755178
+          },
+          "low": {
+            "mae_mean": 0.07472327731477817,
+            "mre_mean": 0.09352839949870431,
+            "signed_rel_mean": -0.09315912645914094
+          },
+          "mid": {
+            "mae_mean": 0.09717871788037263,
+            "mre_mean": 0.23805383716973952,
+            "signed_rel_mean": -0.23805383716973952
+          },
+          "top": {
+            "mae_mean": 0.2532767819288416,
+            "mre_mean": 0.6856453848391892,
+            "signed_rel_mean": -0.6856453848391892
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.11418549045866118,
+          "mtf30": 0.07118338176569487,
+          "mtf50": 0.03341906068011393
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.006882270413960398,
+          "Computer Monitor Acutance": 0.06497067495156086,
+          "Large Print Acutance": 0.03388383054321927,
+          "Small Print Acutance": 0.03074517484201833,
+          "UHDTV Display Acutance": 0.03749536693506072
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_locked_input_baseline_profile.json"
+    },
+    {
+      "analysis_pipeline": {
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "frequency_scale": 1.17,
+        "gamma": 1.0,
+        "roi_source": "fixed",
+        "signal_psd_correction_gain": 0.0
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.025673827782072948,
+        "0.25": 0.020230526812152965,
+        "0.4": 0.012405734170996701,
+        "0.65": 0.012002787961412935,
+        "0.8": 0.019411063571392433,
+        "ori": 0.029539915614656298
+      },
+      "overall": {
+        "curve_mae_mean": 0.01969850082492993,
+        "mtf_abs_signed_rel_mean": 0.22759253303406912,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.045647557754144585,
+            "mre_mean": 0.20922883557710184,
+            "signed_rel_mean": -0.20921622243130006
+          },
+          "low": {
+            "mae_mean": 0.03729147398888756,
+            "mre_mean": 0.043762691172511844,
+            "signed_rel_mean": -0.029994625523639684
+          },
+          "mid": {
+            "mae_mean": 0.04206713812391215,
+            "mre_mean": 0.09284374699989298,
+            "signed_rel_mean": -0.08460575667510425
+          },
+          "top": {
+            "mae_mean": 0.21280150110229198,
+            "mre_mean": 0.5865535275062325,
+            "signed_rel_mean": -0.5865535275062325
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.11804519815785279,
+          "mtf30": 0.06466880584991799,
+          "mtf50": 0.019311830361967347
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.048248216995706236,
+          "Computer Monitor Acutance": 0.024747720107661214,
+          "Large Print Acutance": 0.022229647508049944,
+          "Small Print Acutance": 0.028952087494203603,
+          "UHDTV Display Acutance": 0.021393560132013982
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_parity_psd_mtf_profile.json"
+    }
+  ]
+}

--- a/docs/parity_psd_mtf_refit.md
+++ b/docs/parity_psd_mtf_refit.md
@@ -1,0 +1,89 @@
+# Parity PSD/MTF Refit
+
+This note records the issue `#11` PSD/MTF refit pass that follows the input-pipeline decision from [parity_input_pipeline_candidates.md](./parity_input_pipeline_candidates.md).
+
+Locked input path from issue `#10`:
+
+- `analysis_gamma = 1.0`
+- `bayer_pattern = RGGB`
+- `bayer_mode = demosaic_red`
+- `roi_source = fixed`
+
+The purpose of this pass is narrower than the full parity umbrella:
+
+- improve the PSD/MTF core under the locked input path
+- produce a parity-fit artifact that later validation issues can use as a stable baseline
+- avoid release-profile claims until downstream Acutance / Quality Loss validation is complete
+
+## Artifacts
+
+- baseline profile:
+  - [../algo/deadleaf_13b10_locked_input_baseline_profile.json](../algo/deadleaf_13b10_locked_input_baseline_profile.json)
+- parity-fit profile:
+  - [../algo/deadleaf_13b10_parity_psd_mtf_profile.json](../algo/deadleaf_13b10_parity_psd_mtf_profile.json)
+- benchmark driver:
+  - [../algo/benchmark_parity_psd_mtf.py](../algo/benchmark_parity_psd_mtf.py)
+- benchmark result:
+  - [../artifacts/parity_psd_mtf_benchmark.json](../artifacts/parity_psd_mtf_benchmark.json)
+
+## What Changed
+
+The selected parity-fit profile keeps the same locked input path and ideal-PSD calibration file as the locked-input baseline, but changes:
+
+- `frequency_scale: 1.0 -> 1.17`
+
+The scale value is not arbitrary:
+
+- the current `demosaic_red` parity path prefers a larger global frequency scale than the older exploratory settings
+- a dedicated sweep under the locked parity path selected approximately `1.17`
+- this change is explainable as a frequency-axis fit, not an opaque post-hoc fudge term
+
+No new signal-PSD correction was adopted in this pass:
+
+- `signal_psd_correction_gain` remains `0.0`
+
+No release profile is changed in this issue.
+
+## Benchmark Summary
+
+From [../artifacts/parity_psd_mtf_benchmark.json](../artifacts/parity_psd_mtf_benchmark.json):
+
+| Profile | `curve_mae_mean` | mean abs band signed-rel | `MTF50` MAE |
+| --- | --- | --- | --- |
+| locked-input baseline | `0.04498` | `0.33020` | `0.03342` |
+| parity-fit candidate | `0.01970` | `0.22759` | `0.01931` |
+
+Band-wise signed relative MTF residuals also improve in every tracked band:
+
+| Band | baseline | parity-fit |
+| --- | --- | --- |
+| low | `-0.09316` | `-0.02999` |
+| mid | `-0.23805` | `-0.08461` |
+| high | `-0.30393` | `-0.20922` |
+| top | `-0.68565` | `-0.58655` |
+
+Interpretation:
+
+- the main residual shape is still biased low at high frequencies
+- but the frequency-axis correction removes a large part of the earlier systematic underfit
+- this is now a materially better PSD/MTF baseline than the locked-input pre-refit profile
+
+## Scope Boundary
+
+This issue intentionally stops at the PSD/MTF baseline.
+
+Known follow-up work that remains outside this issue:
+
+- issue `#12` must revalidate Acutance and Quality Loss on top of this new PSD/MTF baseline
+- the `5.5\" Phone` preset error is worse under the new scaled profile even though the overall curve and MTF metrics improve, so downstream validation still matters
+- issue `#13` should decide whether this profile is good enough for release-facing packaging only after that validation exists
+
+## Reproduction
+
+```bash
+python3 -m algo.benchmark_parity_psd_mtf \
+  20260318_deadleaf_13b10 \
+  algo/deadleaf_13b10_locked_input_baseline_profile.json \
+  algo/deadleaf_13b10_parity_psd_mtf_profile.json \
+  --output artifacts/parity_psd_mtf_benchmark.json
+```

--- a/tests/test_benchmark_parity_psd_mtf.py
+++ b/tests/test_benchmark_parity_psd_mtf.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+
+from algo.benchmark_parity_psd_mtf import band_error_summary, resample_curve
+
+
+class BenchmarkParityPsdMtfTest(unittest.TestCase):
+    def test_resample_curve_interpolates_in_order(self) -> None:
+        source_f = np.array([0.0, 1.0, 2.0], dtype=np.float64)
+        source_v = np.array([1.0, 3.0, 5.0], dtype=np.float64)
+        ref_f = np.array([0.5, 1.5], dtype=np.float64)
+        np.testing.assert_allclose(resample_curve(source_f, source_v, ref_f), [2.0, 4.0])
+
+    def test_band_error_summary_reports_signed_relative_error(self) -> None:
+        frequencies = np.array([0.02, 0.1, 0.25, 0.4], dtype=np.float64)
+        estimate = np.array([0.9, 0.8, 0.7, 0.6], dtype=np.float64)
+        reference = np.array([1.0, 1.0, 1.0, 1.0], dtype=np.float64)
+        summary = band_error_summary(frequencies, estimate, reference)
+        self.assertAlmostEqual(summary["low"]["signed_rel_mean"], -0.1)
+        self.assertAlmostEqual(summary["mid"]["signed_rel_mean"], -0.2)
+        self.assertAlmostEqual(summary["high"]["signed_rel_mean"], -0.3)
+        self.assertAlmostEqual(summary["top"]["signed_rel_mean"], -0.4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs #11

## Summary
- add a parity PSD/MTF benchmark driver and two small profile artifacts for the locked-input baseline and the new parity-fit candidate
- publish the benchmark JSON and refit note showing the selected `frequency_scale = 1.17` profile under `demosaic_red + RGGB`
- add targeted tests for the new benchmark helpers and link the refit note from the root README

## Measured Improvement
- `curve_mae_mean`: `0.04498 -> 0.01970`
- mean absolute band signed-rel MTF residual: `0.33020 -> 0.22759`
- `MTF50` MAE: `0.03342 -> 0.01931`

## Validation
- python3 -m unittest discover -s tests -p 'test_*.py'\n- python3 -m algo.benchmark_parity_psd_mtf 20260318_deadleaf_13b10 algo/deadleaf_13b10_locked_input_baseline_profile.json algo/deadleaf_13b10_parity_psd_mtf_profile.json --output artifacts/parity_psd_mtf_benchmark.json