### PR TITLE
Validate parity acutance and quality loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@
   - issue `#10` 的 input-path benchmark、目前鎖定的 parity input pipeline、以及被排除的候選路徑
 - [docs/parity_psd_mtf_refit.md](docs/parity_psd_mtf_refit.md)
   - issue `#11` 的 parity PSD/MTF refit、基線與新 profile 比較、以及後續 validation 邊界
+- [docs/parity_acutance_quality_loss_validation.md](docs/parity_acutance_quality_loss_validation.md)
+  - issue `#12` 的 Acutance / Quality Loss validation、整體改善、以及 `Phone` preset 殘餘回歸
 - [algo/README.md](/Users/kevinhuang/work/acutance/algo/README.md)
   - 演算法原型、數學流程、校準與 benchmark 記錄
 - [release/deadleaf_13b10_release/README.md](/Users/kevinhuang/work/acutance/release/deadleaf_13b10_release/README.md)

--- a/algo/benchmark_parity_acutance_quality_loss.py
+++ b/algo/benchmark_parity_acutance_quality_loss.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import re
+
+import numpy as np
+
+from .dead_leaves import (
+    ACUTANCE_HF_NOISE_SHARE_BAND,
+    ACUTANCE_HF_NOISE_SHARE_SCALE_COEFFICIENTS,
+    BayerMode,
+    BayerPattern,
+    IMATEST_REFERENCE_BINS,
+    MTF_SHAPE_CORRECTION_SHARE_GATE,
+    RoiBounds,
+    acutance_curve_from_mtf,
+    acutance_presets_from_mtf,
+    apply_frequency_scale,
+    apply_mtf_shape_correction,
+    compare_acutance_curves,
+    compare_acutance_presets,
+    estimate_dead_leaves_mtf,
+    extract_analysis_plane,
+    load_ideal_psd_calibration,
+    load_raw_u16,
+    normalize_for_analysis,
+    parse_imatest_random_csv,
+    quality_loss_presets_from_acutance,
+)
+
+FOCUS_ACUTANCE_PRESETS = (
+    '5.5" Phone Display Acutance',
+    "Computer Monitor Acutance",
+    "UHDTV Display Acutance",
+    "Small Print Acutance",
+    "Large Print Acutance",
+)
+
+FOCUS_QUALITY_PRESETS = (
+    '5.5" Phone Display Quality Loss',
+    "Computer Monitor Quality Loss",
+    "UHDTV Display Quality Loss",
+    "Small Print Quality Loss",
+    "Large Print Quality Loss",
+)
+
+
+@dataclass(frozen=True)
+class Profile:
+    name: str
+    calibration_file: str
+    gamma: float = 1.0
+    bayer_pattern: str = BayerPattern.RGGB.value
+    bayer_mode: str = BayerMode.DEMOSAIC_RED.value
+    roi_source: str = "fixed"
+    roi_width: int = 1655
+    roi_height: int = 1673
+    frequency_scale: float = 1.0
+    normalization_band_lo: float = 0.01
+    normalization_band_hi: float = 0.03
+    normalization_mode: str = "max"
+    acutance_band_lo: float = 0.017
+    acutance_band_hi: float = 0.035
+    acutance_band_mode: str = "mean"
+    signal_psd_correction_gain: float = 0.0
+    signal_psd_correction_start_cpp: float = 0.08
+    signal_psd_correction_peak_cpp: float = 0.15
+    signal_psd_correction_stop_cpp: float = 0.22
+    noise_psd_model: str = "empirical"
+    noise_psd_log_polynomial_degree: int = 2
+    noise_psd_scale: float = 1.0
+    noise_psd_scale_for_acutance: float | None = None
+    acutance_noise_scale_mode: str = "fixed"
+    acutance_noise_share_band_lo: float = ACUTANCE_HF_NOISE_SHARE_BAND[0]
+    acutance_noise_share_band_hi: float = ACUTANCE_HF_NOISE_SHARE_BAND[1]
+    acutance_noise_share_scale_coefficients: tuple[float, float, float] = (
+        ACUTANCE_HF_NOISE_SHARE_SCALE_COEFFICIENTS
+    )
+    high_frequency_guard_start_cpp: float | None = None
+    high_frequency_guard_stop_cpp: float = 0.5
+    mtf_shape_correction_mode: str = "none"
+    mtf_shape_correction_gain: float = 0.035
+    mtf_shape_correction_share_gate_lo: float = MTF_SHAPE_CORRECTION_SHARE_GATE[0]
+    mtf_shape_correction_share_gate_hi: float = MTF_SHAPE_CORRECTION_SHARE_GATE[1]
+    mtf_shape_correction_mid_start_cpp: float = 0.095
+    mtf_shape_correction_mid_peak_cpp: float = 0.145
+    mtf_shape_correction_mid_stop_cpp: float = 0.19
+    mtf_shape_correction_high_start_cpp: float = 0.36
+    mtf_shape_correction_high_peak_cpp: float = 0.40
+    mtf_shape_correction_high_stop_cpp: float = 0.49
+    mtf_shape_correction_high_weight: float = 0.25
+    quality_loss_om_ceiling: float = 0.8851
+    quality_loss_coefficients: tuple[float, float, float] = (64.99250542, 9.37974246, 0.72233291)
+
+
+def load_profile(path: Path) -> Profile:
+    return Profile(**json.loads(path.read_text(encoding="utf-8")))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Validate acutance and quality loss profiles.")
+    parser.add_argument("dataset_root", type=Path)
+    parser.add_argument("profiles", nargs="+", type=Path)
+    parser.add_argument("--width", type=int, default=4032)
+    parser.add_argument("--height", type=int, default=3024)
+    parser.add_argument("--output", type=Path)
+    return parser
+
+
+def choose_roi(profile: Profile, reference, image: np.ndarray) -> RoiBounds:
+    if profile.roi_source == "reference":
+        return reference.lrtb.clamp(image.shape[1], image.shape[0])
+    detected = detect_texture_roi(image)
+    return RoiBounds.centered(
+        center_x=(detected.left + detected.right) // 2,
+        center_y=(detected.top + detected.bottom) // 2,
+        width=profile.roi_width,
+        height=profile.roi_height,
+        image_width=image.shape[1],
+        image_height=image.shape[0],
+    )
+
+
+def detect_texture_roi(image: np.ndarray) -> RoiBounds:
+    from .dead_leaves import detect_texture_roi as _detect_texture_roi
+
+    return _detect_texture_roi(image)
+
+
+def classify_csv(csv_path: Path, dataset_root: Path) -> str:
+    relative = csv_path.relative_to(dataset_root)
+    parts = relative.parts
+    if "OV13B10_AI_NR_OV13B10_ori" in parts:
+        return "ori"
+    parent = csv_path.parent.parent.name
+    match = re.search(r"_ppqpkl_([0-9.]+)$", parent)
+    return match.group(1) if match else "unknown"
+
+
+def mean_named_metrics(values: dict[str, list[float]], names: tuple[str, ...]) -> float:
+    return float(np.mean([np.mean(values[name]) for name in names]))
+
+
+def summarize_profile(
+    *,
+    dataset_root: Path,
+    profile_path: Path,
+    profile: Profile,
+    width: int,
+    height: int,
+) -> dict[str, object]:
+    calibration = load_ideal_psd_calibration(profile.calibration_file)
+    csv_paths = sorted(dataset_root.glob("**/Results/*_R_Random.csv"))
+    curve_mae: list[float] = []
+    acutance_preset_errors: dict[str, list[float]] = {}
+    quality_loss_errors: dict[str, list[float]] = {}
+    by_mixup_curve_mae: dict[str, list[float]] = {}
+    by_mixup_quality_loss_mae: dict[str, list[float]] = {}
+
+    for csv_path in csv_paths:
+        raw_path = csv_path.parent.parent / csv_path.name.replace("_R_Random.csv", ".raw")
+        if not raw_path.exists():
+            continue
+        reference = parse_imatest_random_csv(csv_path)
+        raw = load_raw_u16(raw_path, width, height)
+        plane = extract_analysis_plane(
+            raw,
+            bayer_pattern=BayerPattern(profile.bayer_pattern),
+            mode=BayerMode(profile.bayer_mode),
+        )
+        image = normalize_for_analysis(plane, gamma=profile.gamma)
+        roi = choose_roi(profile, reference, image)
+        estimate = estimate_dead_leaves_mtf(
+            image,
+            num_bins=len(IMATEST_REFERENCE_BINS),
+            ideal_psd_mode="calibrated_log",
+            ideal_psd_calibration=calibration,
+            bin_centers=IMATEST_REFERENCE_BINS,
+            roi_override=roi,
+            normalization_band=(profile.normalization_band_lo, profile.normalization_band_hi),
+            normalization_mode=profile.normalization_mode,
+            acutance_reference_band=(profile.acutance_band_lo, profile.acutance_band_hi),
+            acutance_reference_mode=profile.acutance_band_mode,
+            signal_psd_correction_gain=profile.signal_psd_correction_gain,
+            signal_psd_correction_start_cpp=profile.signal_psd_correction_start_cpp,
+            signal_psd_correction_peak_cpp=profile.signal_psd_correction_peak_cpp,
+            signal_psd_correction_stop_cpp=profile.signal_psd_correction_stop_cpp,
+            noise_psd_model=profile.noise_psd_model,
+            noise_psd_log_polynomial_degree=profile.noise_psd_log_polynomial_degree,
+            noise_psd_scale=profile.noise_psd_scale,
+            noise_psd_scale_for_acutance=profile.noise_psd_scale_for_acutance,
+            acutance_noise_scale_model=profile.acutance_noise_scale_mode,
+            acutance_noise_share_band=(
+                profile.acutance_noise_share_band_lo,
+                profile.acutance_noise_share_band_hi,
+            ),
+            acutance_noise_share_scale_coefficients=tuple(
+                profile.acutance_noise_share_scale_coefficients
+            ),
+            high_frequency_guard_start_cpp=profile.high_frequency_guard_start_cpp,
+            high_frequency_guard_stop_cpp=profile.high_frequency_guard_stop_cpp,
+        )
+        scaled_frequencies = apply_frequency_scale(
+            estimate.frequencies_cpp,
+            scale=profile.frequency_scale,
+        )
+        corrected_mtf_for_acutance, _ = apply_mtf_shape_correction(
+            estimate.mtf_for_acutance,
+            scaled_frequencies,
+            mode=profile.mtf_shape_correction_mode,
+            high_frequency_noise_share=estimate.acutance_high_frequency_noise_share,
+            gain=profile.mtf_shape_correction_gain,
+            share_gate_lo=profile.mtf_shape_correction_share_gate_lo,
+            share_gate_hi=profile.mtf_shape_correction_share_gate_hi,
+            mid_start_cpp=profile.mtf_shape_correction_mid_start_cpp,
+            mid_peak_cpp=profile.mtf_shape_correction_mid_peak_cpp,
+            mid_stop_cpp=profile.mtf_shape_correction_mid_stop_cpp,
+            high_start_cpp=profile.mtf_shape_correction_high_start_cpp,
+            high_peak_cpp=profile.mtf_shape_correction_high_peak_cpp,
+            high_stop_cpp=profile.mtf_shape_correction_high_stop_cpp,
+            high_weight=profile.mtf_shape_correction_high_weight,
+        )
+        curve = acutance_curve_from_mtf(
+            scaled_frequencies,
+            corrected_mtf_for_acutance,
+            picture_height_cm=40.0,
+            viewing_distances_cm=np.arange(1.0, 101.0, 1.0),
+            pixels_along_picture_height=estimate.roi.height,
+        )
+        curve_cmp = compare_acutance_curves(curve, reference.acutance_table)
+        if curve_cmp.get("count", 0):
+            curve_mae.append(float(curve_cmp["mae"]))
+            by_mixup_curve_mae.setdefault(classify_csv(csv_path, dataset_root), []).append(
+                float(curve_cmp["mae"])
+            )
+        acutance = acutance_presets_from_mtf(
+            scaled_frequencies,
+            corrected_mtf_for_acutance,
+            pixels_along_picture_height=estimate.roi.height,
+        )
+        acutance_cmp = compare_acutance_presets(acutance, reference.reported_acutance)
+        for name, values in acutance_cmp.items():
+            acutance_preset_errors.setdefault(name, []).append(float(values["abs_error"]))
+
+        quality_loss = quality_loss_presets_from_acutance(
+            acutance,
+            om_ceiling=profile.quality_loss_om_ceiling,
+            coefficients=tuple(profile.quality_loss_coefficients),
+        )
+        quality_abs_errors = {}
+        for name, value in quality_loss.items():
+            abs_error = abs(float(value) - float(reference.reported_quality_loss[name]))
+            quality_loss_errors.setdefault(name, []).append(abs_error)
+            quality_abs_errors[name] = abs_error
+        by_mixup_quality_loss_mae.setdefault(classify_csv(csv_path, dataset_root), []).append(
+            float(np.mean(list(quality_abs_errors.values())))
+        )
+
+    return {
+        "profile_path": str(profile_path),
+        "analysis_pipeline": {
+            "gamma": profile.gamma,
+            "bayer_pattern": profile.bayer_pattern,
+            "bayer_mode": profile.bayer_mode,
+            "roi_source": profile.roi_source,
+            "frequency_scale": profile.frequency_scale,
+            "calibration_file": profile.calibration_file,
+            "acutance_noise_scale_mode": profile.acutance_noise_scale_mode,
+            "high_frequency_guard_start_cpp": profile.high_frequency_guard_start_cpp,
+            "mtf_shape_correction_mode": profile.mtf_shape_correction_mode,
+        },
+        "overall": {
+            "curve_mae_mean": float(np.mean(curve_mae)),
+            "acutance_preset_mae": {
+                key: float(np.mean(values))
+                for key, values in sorted(acutance_preset_errors.items())
+            },
+            "acutance_focus_preset_mae_mean": mean_named_metrics(
+                acutance_preset_errors, FOCUS_ACUTANCE_PRESETS
+            ),
+            "quality_loss_preset_mae": {
+                key: float(np.mean(values))
+                for key, values in sorted(quality_loss_errors.items())
+            },
+            "overall_quality_loss_mae_mean": float(
+                np.mean([np.mean(values) for values in quality_loss_errors.values()])
+            ),
+            "quality_loss_focus_preset_mae_mean": mean_named_metrics(
+                quality_loss_errors, FOCUS_QUALITY_PRESETS
+            ),
+        },
+        "by_mixup_curve_mae_mean": {
+            key: float(np.mean(values))
+            for key, values in sorted(by_mixup_curve_mae.items())
+        },
+        "by_mixup_quality_loss_mae_mean": {
+            key: float(np.mean(values))
+            for key, values in sorted(by_mixup_quality_loss_mae.items())
+        },
+    }
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    profiles = [load_profile(path) for path in args.profiles]
+    results = [
+        summarize_profile(
+            dataset_root=args.dataset_root,
+            profile_path=path,
+            profile=profile,
+            width=args.width,
+            height=args.height,
+        )
+        for path, profile in zip(args.profiles, profiles)
+    ]
+    baseline = results[0]["overall"]
+    for result in results[1:]:
+        overall = result["overall"]
+        result["delta_vs_first_profile"] = {
+            "curve_mae_mean": float(overall["curve_mae_mean"] - baseline["curve_mae_mean"]),
+            "overall_quality_loss_mae_mean": float(
+                overall["overall_quality_loss_mae_mean"] - baseline["overall_quality_loss_mae_mean"]
+            ),
+            "acutance_focus_preset_mae_mean": float(
+                overall["acutance_focus_preset_mae_mean"] - baseline["acutance_focus_preset_mae_mean"]
+            ),
+            "quality_loss_focus_preset_mae_mean": float(
+                overall["quality_loss_focus_preset_mae_mean"]
+                - baseline["quality_loss_focus_preset_mae_mean"]
+            ),
+        }
+    payload = {
+        "dataset_root": str(args.dataset_root),
+        "profiles": results,
+    }
+    text = json.dumps(payload, indent=2, sort_keys=True)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text + "\n", encoding="utf-8")
+    else:
+        print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/algo/deadleaf_13b10_split_workaround_reference_profile.json
+++ b/algo/deadleaf_13b10_split_workaround_reference_profile.json
@@ -1,0 +1,21 @@
+{
+  "name": "deadleaf_13b10_split_workaround_reference",
+  "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+  "gamma": 1.0,
+  "bayer_pattern": "RGGB",
+  "bayer_mode": "demosaic_red",
+  "roi_source": "fixed",
+  "roi_width": 1655,
+  "roi_height": 1673,
+  "frequency_scale": 1.0,
+  "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+  "acutance_noise_share_band_lo": 0.36,
+  "acutance_noise_share_band_hi": 0.5,
+  "acutance_noise_share_scale_coefficients": [
+    521.08180962,
+    -26.62905791,
+    1.59615575
+  ],
+  "high_frequency_guard_start_cpp": 0.36,
+  "high_frequency_guard_stop_cpp": 0.5
+}

--- a/artifacts/parity_acutance_quality_loss_benchmark.json
+++ b/artifacts/parity_acutance_quality_loss_benchmark.json
@@ -1,0 +1,167 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "frequency_scale": 1.0,
+        "gamma": 1.0,
+        "high_frequency_guard_start_cpp": null,
+        "mtf_shape_correction_mode": "none",
+        "roi_source": "fixed"
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.0622343120090446,
+        "0.25": 0.057198175355299564,
+        "0.4": 0.04767289917446428,
+        "0.65": 0.036924043873611694,
+        "0.8": 0.02660295576139359,
+        "ori": 0.025420760894761103
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 2.5178271514780404,
+        "0.25": 2.3815895450392053,
+        "0.4": 2.1273746221054495,
+        "0.65": 2.058623954708096,
+        "0.8": 1.8810098653023173,
+        "ori": 2.1131952780455805
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.034795463537163916,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.006882270413960398,
+          "Computer Monitor Acutance": 0.06497067495156086,
+          "Large Print Acutance": 0.03388383054321927,
+          "Small Print Acutance": 0.03074517484201833,
+          "UHDTV Display Acutance": 0.03749536693506072
+        },
+        "curve_mae_mean": 0.04497614893687769,
+        "overall_quality_loss_mae_mean": 2.19874216006037,
+        "quality_loss_focus_preset_mae_mean": 2.19874216006037,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 0.11741435481300955,
+          "Computer Monitor Quality Loss": 4.837338525475545,
+          "Large Print Quality Loss": 2.2271428971931457,
+          "Small Print Quality Loss": 1.8119635302516492,
+          "UHDTV Display Quality Loss": 1.9998514925685023
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_locked_input_baseline_profile.json"
+    },
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "frequency_scale": 1.17,
+        "gamma": 1.0,
+        "high_frequency_guard_start_cpp": null,
+        "mtf_shape_correction_mode": "none",
+        "roi_source": "fixed"
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.025673827782072948,
+        "0.25": 0.020230526812152965,
+        "0.4": 0.012405734170996701,
+        "0.65": 0.012002787961412935,
+        "0.8": 0.019411063571392433,
+        "ori": 0.029539915614656298
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 1.064799308597913,
+        "0.25": 1.0448021238767673,
+        "0.4": 1.1435812069735452,
+        "0.65": 1.3433767163508576,
+        "0.8": 1.5614406779340824,
+        "ori": 1.7894287947862528
+      },
+      "delta_vs_first_profile": {
+        "acutance_focus_preset_mae_mean": -0.005681217089636918,
+        "curve_mae_mean": -0.025277648111947756,
+        "overall_quality_loss_mae_mean": -0.9225369454701975,
+        "quality_loss_focus_preset_mae_mean": -0.9225369454701975
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.029114246447526998,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.048248216995706236,
+          "Computer Monitor Acutance": 0.024747720107661214,
+          "Large Print Acutance": 0.022229647508049944,
+          "Small Print Acutance": 0.028952087494203603,
+          "UHDTV Display Acutance": 0.021393560132013982
+        },
+        "curve_mae_mean": 0.01969850082492993,
+        "overall_quality_loss_mae_mean": 1.2762052145901726,
+        "quality_loss_focus_preset_mae_mean": 1.2762052145901726,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 0.7316292982758597,
+          "Computer Monitor Quality Loss": 1.7683304037552425,
+          "Large Print Quality Loss": 1.19961405435829,
+          "Small Print Quality Loss": 1.3990701063786954,
+          "UHDTV Display Quality Loss": 1.2823822101827755
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_parity_psd_mtf_profile.json"
+    },
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "frequency_scale": 1.0,
+        "gamma": 1.0,
+        "high_frequency_guard_start_cpp": 0.36,
+        "mtf_shape_correction_mode": "none",
+        "roi_source": "fixed"
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.06378102008289613,
+        "0.25": 0.059100419381098834,
+        "0.4": 0.0501605071015645,
+        "0.65": 0.03999237641159908,
+        "0.8": 0.02849560748175056,
+        "ori": 0.026033247390604905
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 2.5698139134113074,
+        "0.25": 2.450674717313817,
+        "0.4": 2.219747417417767,
+        "0.65": 2.1301806585937637,
+        "0.8": 1.966893704482174,
+        "ori": 2.191663486080589
+      },
+      "delta_vs_first_profile": {
+        "acutance_focus_preset_mae_mean": 0.0009990569204172545,
+        "curve_mae_mean": 0.0019339242528047182,
+        "overall_quality_loss_mae_mean": 0.0748682049320788,
+        "quality_loss_focus_preset_mae_mean": 0.0748682049320788
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.03579452045758117,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.0067709920553639755,
+          "Computer Monitor Acutance": 0.06849272829512854,
+          "Large Print Acutance": 0.033899738656773745,
+          "Small Print Acutance": 0.0306349162873575,
+          "UHDTV Display Acutance": 0.03917422699328207
+        },
+        "curve_mae_mean": 0.046910073189682405,
+        "overall_quality_loss_mae_mean": 2.273610364992449,
+        "quality_loss_focus_preset_mae_mean": 2.273610364992449,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 0.11631420781107131,
+          "Computer Monitor Quality Loss": 5.112060551184991,
+          "Large Print Quality Loss": 2.236736690537176,
+          "Small Print Quality Loss": 1.8107657158310453,
+          "UHDTV Display Quality Loss": 2.0921746595979593
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_split_workaround_reference_profile.json"
+    }
+  ]
+}

--- a/docs/parity_acutance_quality_loss_validation.md
+++ b/docs/parity_acutance_quality_loss_validation.md
@@ -1,0 +1,107 @@
+# Parity Acutance And Quality Loss Validation
+
+This note records the issue `#12` validation pass on top of the parity PSD/MTF baseline from [parity_psd_mtf_refit.md](./parity_psd_mtf_refit.md).
+
+Profiles compared in [../artifacts/parity_acutance_quality_loss_benchmark.json](../artifacts/parity_acutance_quality_loss_benchmark.json):
+
+1. previous parity baseline
+   - [../algo/deadleaf_13b10_locked_input_baseline_profile.json](../algo/deadleaf_13b10_locked_input_baseline_profile.json)
+2. new parity-fit PSD/MTF baseline
+   - [../algo/deadleaf_13b10_parity_psd_mtf_profile.json](../algo/deadleaf_13b10_parity_psd_mtf_profile.json)
+3. retained split-workaround reference
+   - [../algo/deadleaf_13b10_split_workaround_reference_profile.json](../algo/deadleaf_13b10_split_workaround_reference_profile.json)
+
+All three profiles use the same locked parity input path:
+
+- `analysis_gamma = 1.0`
+- `bayer_pattern = RGGB`
+- `bayer_mode = demosaic_red`
+- fixed ROI
+
+## Summary
+
+The new parity-fit PSD/MTF baseline improves end-to-end Acutance and Quality Loss validation overall.
+
+Compared with the previous parity baseline, it reduces:
+
+- `curve_mae_mean`: `0.04498 -> 0.01970`
+- Acutance focus-preset MAE mean: `0.03480 -> 0.02911`
+- overall Quality Loss MAE mean: `2.19874 -> 1.27621`
+
+Compared with the retained split-workaround reference, it also reduces:
+
+- `curve_mae_mean`: `0.04691 -> 0.01970`
+- Acutance focus-preset MAE mean: `0.03579 -> 0.02911`
+- overall Quality Loss MAE mean: `2.27361 -> 1.27621`
+
+So the parity-fit baseline is now the strongest overall profile in the repo's current benchmark frame.
+
+## Acutance Preset Changes
+
+Previous parity baseline vs parity-fit:
+
+| Preset | previous parity | parity-fit | result |
+| --- | --- | --- | --- |
+| `5.5" Phone` | `0.00688` | `0.04825` | worse |
+| `Computer Monitor` | `0.06497` | `0.02475` | better |
+| `UHDTV` | `0.03750` | `0.02139` | better |
+| `Small Print` | `0.03075` | `0.02895` | slightly better |
+| `Large Print` | `0.03388` | `0.02223` | better |
+
+Interpretation:
+
+- the new parity-fit baseline materially improves the larger-display and print-oriented presets
+- the `Phone` preset is the main regression that remains
+
+## Quality Loss Changes
+
+Previous parity baseline vs parity-fit:
+
+| Preset | previous parity | parity-fit | result |
+| --- | --- | --- | --- |
+| `5.5" Phone` | `0.11741` | `0.73163` | much worse |
+| `Computer Monitor` | `4.83734` | `1.76833` | much better |
+| `UHDTV` | `1.99985` | `1.28238` | better |
+| `Small Print` | `1.81196` | `1.39907` | better |
+| `Large Print` | `2.22714` | `1.19961` | much better |
+
+Interpretation:
+
+- the parity-fit baseline improves four of the five Quality Loss presets
+- the remaining weakness is concentrated in the `Phone` geometry path
+
+## Comparison With The Split Workaround
+
+The retained split-workaround reference was useful historically, but it is no longer the best overall validation result.
+
+Why:
+
+- its `curve_mae_mean` is still worse than the prior parity baseline
+- its overall Quality Loss MAE is also worse than the prior parity baseline
+- the new parity-fit baseline beats it by a wide margin on the overall curve and on most non-phone presets
+
+This means the repo now has a parity-fit baseline that is better than the older workaround in the current measured frame, even though the `Phone` preset still needs follow-up attention.
+
+## Working Conclusion
+
+Issue `#12` does not block the parity-fit line.
+
+The new parity-fit PSD/MTF baseline is now validated as:
+
+- materially better than the previous parity baseline
+- materially better than the retained split-workaround reference overall
+- still carrying one clear downstream caveat:
+  - `5.5" Phone` Acutance and Quality Loss regress relative to the old profiles
+
+That caveat should be carried into the release-facing profile work instead of hidden.
+
+## Reproduction
+
+```bash
+python3 -m algo.benchmark_parity_acutance_quality_loss \
+  20260318_deadleaf_13b10 \
+  algo/deadleaf_13b10_locked_input_baseline_profile.json \
+  algo/deadleaf_13b10_parity_psd_mtf_profile.json \
+  algo/deadleaf_13b10_split_workaround_reference_profile.json \
+  --output artifacts/parity_acutance_quality_loss_benchmark.json
+```

--- a/tests/test_benchmark_parity_acutance_quality_loss.py
+++ b/tests/test_benchmark_parity_acutance_quality_loss.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import unittest
+
+from algo.benchmark_parity_acutance_quality_loss import mean_named_metrics
+
+
+class BenchmarkParityAcutanceQualityLossTest(unittest.TestCase):
+    def test_mean_named_metrics_averages_named_series(self) -> None:
+        values = {
+            "a": [1.0, 3.0],
+            "b": [2.0, 4.0],
+        }
+        self.assertEqual(mean_named_metrics(values, ("a", "b")), 2.5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs #12

## Summary
- add a validation benchmark driver that compares the previous parity baseline, the new parity-fit PSD/MTF profile, and the retained split-workaround reference
- check in the validation artifact and note documenting both the overall improvement and the remaining `5.5" Phone` regression
- add a targeted helper test and link the validation note from the root README

## Measured Result
- parity-fit vs previous parity baseline:
  - `curve_mae_mean`: `0.04498 -> 0.01970`
  - Acutance focus-preset MAE mean: `0.03480 -> 0.02911`
  - overall Quality Loss MAE mean: `2.19874 -> 1.27621`
- parity-fit vs split-workaround reference:
  - `curve_mae_mean`: `0.04691 -> 0.01970`
  - overall Quality Loss MAE mean: `2.27361 -> 1.27621`
- remaining caveat:
  - `5.5" Phone` Acutance and Quality Loss regress relative to the older profiles, while Monitor/UHDTV/print presets improve

## Validation
- python3 -m unittest discover -s tests -p 'test_*.py'\n- python3 -m algo.benchmark_parity_acutance_quality_loss 20260318_deadleaf_13b10 algo/deadleaf_13b10_locked_input_baseline_profile.json algo/deadleaf_13b10_parity_psd_mtf_profile.json algo/deadleaf_13b10_split_workaround_reference_profile.json --output artifacts/parity_acutance_quality_loss_benchmark.json