### PR TITLE
Audit the matched-ori OECF proxy after PR #30

### DIFF
--- a/algo/benchmark_parity_acutance_quality_loss.py
+++ b/algo/benchmark_parity_acutance_quality_loss.py
@@ -36,9 +36,11 @@ from .dead_leaves import (
     refine_roi_to_texture_support,
 )
 from .parity_benchmark_common import (
+    apply_quantile_transfer_curve,
     apply_reference_correction_curve,
     build_ori_reference_map,
     capture_key_from_stem,
+    derive_quantile_transfer_curve,
     clip_reference_correction_curve,
     derive_reference_acutance_correction_curve,
     derive_reference_correction_curve,
@@ -68,6 +70,9 @@ class Profile:
     gamma: float = 1.0
     linearization_mode: str = "power"
     linearization_toe: float = 0.0
+    matched_ori_oecf_reference: bool = False
+    matched_ori_oecf_strength: float = 1.0
+    matched_ori_oecf_quantiles: tuple[float, ...] = (0.0, 0.1, 0.25, 0.5, 0.75, 0.9, 1.0)
     bayer_pattern: str = BayerPattern.RGGB.value
     bayer_mode: str = BayerMode.DEMOSAIC_RED.value
     roi_source: str = "fixed"
@@ -285,9 +290,15 @@ def summarize_profile(
     include_quality_loss_records: bool = False,
 ) -> dict[str, object]:
     calibration = load_ideal_psd_calibration(profile.calibration_file)
-    ori_reference_map = (
-        build_ori_reference_map(dataset_root) if profile.matched_ori_reference_anchor else {}
+    use_ori_reference = any(
+        (
+            profile.matched_ori_oecf_reference,
+            profile.matched_ori_reference_anchor,
+            profile.matched_ori_acutance_reference_anchor,
+        )
     )
+    ori_reference_map = build_ori_reference_map(dataset_root) if use_ori_reference else {}
+    oecf_curve_cache: dict[str, tuple[np.ndarray, np.ndarray]] = {}
     correction_cache: dict[str, tuple[np.ndarray, np.ndarray]] = {}
     acutance_correction_cache: dict[str, tuple[np.ndarray, np.ndarray]] = {}
     presets = build_acutance_presets(profile.acutance_preset_overrides)
@@ -318,6 +329,40 @@ def summarize_profile(
             toe=profile.linearization_toe,
         )
         roi = choose_roi(profile, reference, image)
+        capture_key = capture_key_from_stem(raw_path.stem)
+        if profile.matched_ori_oecf_reference and capture_key in ori_reference_map:
+            if capture_key not in oecf_curve_cache:
+                ori_csv_path, ori_raw_path = ori_reference_map[capture_key]
+                ori_reference = parse_imatest_random_csv(ori_csv_path)
+                ori_raw = load_raw_u16(ori_raw_path, width, height)
+                ori_plane = extract_analysis_plane(
+                    ori_raw,
+                    bayer_pattern=BayerPattern(profile.bayer_pattern),
+                    mode=BayerMode(profile.bayer_mode),
+                )
+                ori_image = normalize_for_analysis(
+                    ori_plane,
+                    gamma=profile.gamma,
+                    mode=profile.linearization_mode,
+                    toe=profile.linearization_toe,
+                )
+                ori_roi = choose_roi(profile, ori_reference, ori_image)
+                source_values, target_values = derive_quantile_transfer_curve(
+                    image[roi.top : roi.bottom + 1, roi.left : roi.right + 1],
+                    ori_image[
+                        ori_roi.top : ori_roi.bottom + 1,
+                        ori_roi.left : ori_roi.right + 1,
+                    ],
+                    quantiles=profile.matched_ori_oecf_quantiles,
+                )
+                oecf_curve_cache[capture_key] = (source_values, target_values)
+            source_values, target_values = oecf_curve_cache[capture_key]
+            image = apply_quantile_transfer_curve(
+                image,
+                source_values,
+                target_values,
+                strength=profile.matched_ori_oecf_strength,
+            ).astype(np.float32)
         estimate = estimate_dead_leaves_mtf(
             image,
             num_bins=len(IMATEST_REFERENCE_BINS),
@@ -371,7 +416,6 @@ def summarize_profile(
             max_gain=profile.compensation_max_gain,
         )
         if profile.matched_ori_reference_anchor:
-            capture_key = capture_key_from_stem(raw_path.stem)
             if capture_key in ori_reference_map:
                 if capture_key not in correction_cache:
                     ori_csv_path, ori_raw_path = ori_reference_map[capture_key]
@@ -498,7 +542,6 @@ def summarize_profile(
             presets=presets,
         )
         if profile.matched_ori_acutance_reference_anchor:
-            capture_key = capture_key_from_stem(raw_path.stem)
             if capture_key in ori_reference_map:
                 if capture_key not in acutance_correction_cache:
                     ori_csv_path, ori_raw_path = ori_reference_map[capture_key]
@@ -797,6 +840,9 @@ def summarize_profile(
             "gamma": profile.gamma,
             "linearization_mode": profile.linearization_mode,
             "linearization_toe": profile.linearization_toe,
+            "matched_ori_oecf_reference": profile.matched_ori_oecf_reference,
+            "matched_ori_oecf_strength": profile.matched_ori_oecf_strength,
+            "matched_ori_oecf_quantiles": profile.matched_ori_oecf_quantiles,
             "bayer_pattern": profile.bayer_pattern,
             "bayer_mode": profile.bayer_mode,
             "roi_source": profile.roi_source,

--- a/algo/benchmark_parity_psd_mtf.py
+++ b/algo/benchmark_parity_psd_mtf.py
@@ -32,9 +32,11 @@ from .dead_leaves import (
     refine_roi_to_texture_support,
 )
 from .parity_benchmark_common import (
+    apply_quantile_transfer_curve,
     apply_reference_correction_curve,
     build_ori_reference_map,
     capture_key_from_stem,
+    derive_quantile_transfer_curve,
     derive_reference_correction_curve,
 )
 
@@ -53,6 +55,9 @@ class Profile:
     gamma: float = 1.0
     linearization_mode: str = "power"
     linearization_toe: float = 0.0
+    matched_ori_oecf_reference: bool = False
+    matched_ori_oecf_strength: float = 1.0
+    matched_ori_oecf_quantiles: tuple[float, ...] = (0.0, 0.1, 0.25, 0.5, 0.75, 0.9, 1.0)
     bayer_pattern: str = BayerPattern.RGGB.value
     bayer_mode: str = BayerMode.DEMOSAIC_RED.value
     roi_source: str = "fixed"
@@ -255,9 +260,15 @@ def profile_payload(
     height: int,
 ) -> dict[str, object]:
     calibration = load_ideal_psd_calibration(profile.calibration_file)
-    ori_reference_map = (
-        build_ori_reference_map(dataset_root) if profile.matched_ori_reference_anchor else {}
+    use_ori_reference = any(
+        (
+            profile.matched_ori_oecf_reference,
+            profile.matched_ori_reference_anchor,
+            profile.matched_ori_acutance_reference_anchor,
+        )
     )
+    ori_reference_map = build_ori_reference_map(dataset_root) if use_ori_reference else {}
+    oecf_curve_cache: dict[str, tuple[np.ndarray, np.ndarray]] = {}
     correction_cache: dict[str, tuple[np.ndarray, np.ndarray, np.ndarray]] = {}
     csv_paths = sorted(dataset_root.glob("**/Results/*_R_Random.csv"))
     curve_mae: list[float] = []
@@ -287,6 +298,40 @@ def profile_payload(
             toe=profile.linearization_toe,
         )
         roi = choose_roi(profile, reference, image)
+        capture_key = capture_key_from_stem(raw_path.stem)
+        if profile.matched_ori_oecf_reference and capture_key in ori_reference_map:
+            if capture_key not in oecf_curve_cache:
+                ori_csv_path, ori_raw_path = ori_reference_map[capture_key]
+                ori_reference = parse_imatest_random_csv(ori_csv_path)
+                ori_raw = load_raw_u16(ori_raw_path, width, height)
+                ori_plane = extract_analysis_plane(
+                    ori_raw,
+                    bayer_pattern=BayerPattern(profile.bayer_pattern),
+                    mode=BayerMode(profile.bayer_mode),
+                )
+                ori_image = normalize_for_analysis(
+                    ori_plane,
+                    gamma=profile.gamma,
+                    mode=profile.linearization_mode,
+                    toe=profile.linearization_toe,
+                )
+                ori_roi = choose_roi(profile, ori_reference, ori_image)
+                source_values, target_values = derive_quantile_transfer_curve(
+                    image[roi.top : roi.bottom + 1, roi.left : roi.right + 1],
+                    ori_image[
+                        ori_roi.top : ori_roi.bottom + 1,
+                        ori_roi.left : ori_roi.right + 1,
+                    ],
+                    quantiles=profile.matched_ori_oecf_quantiles,
+                )
+                oecf_curve_cache[capture_key] = (source_values, target_values)
+            source_values, target_values = oecf_curve_cache[capture_key]
+            image = apply_quantile_transfer_curve(
+                image,
+                source_values,
+                target_values,
+                strength=profile.matched_ori_oecf_strength,
+            ).astype(np.float32)
         estimate = estimate_dead_leaves_mtf(
             image,
             num_bins=len(IMATEST_REFERENCE_BINS),
@@ -348,7 +393,6 @@ def profile_payload(
             max_gain=profile.compensation_max_gain,
         )
         if profile.matched_ori_reference_anchor:
-            capture_key = capture_key_from_stem(raw_path.stem)
             if capture_key in ori_reference_map:
                 if capture_key not in correction_cache:
                     ori_csv_path, ori_raw_path = ori_reference_map[capture_key]
@@ -535,6 +579,9 @@ def profile_payload(
             "gamma": profile.gamma,
             "linearization_mode": profile.linearization_mode,
             "linearization_toe": profile.linearization_toe,
+            "matched_ori_oecf_reference": profile.matched_ori_oecf_reference,
+            "matched_ori_oecf_strength": profile.matched_ori_oecf_strength,
+            "matched_ori_oecf_quantiles": profile.matched_ori_oecf_quantiles,
             "bayer_pattern": profile.bayer_pattern,
             "bayer_mode": profile.bayer_mode,
             "roi_source": profile.roi_source,

--- a/algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_matched_ori_oecf_proxy_profile.json
+++ b/algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_matched_ori_oecf_proxy_profile.json
@@ -1,0 +1,204 @@
+{
+  "name": "deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_matched_ori_oecf_proxy",
+  "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+  "gamma": 0.5,
+  "linearization_mode": "toe_power",
+  "linearization_toe": 0.12,
+  "matched_ori_oecf_reference": true,
+  "matched_ori_oecf_strength": 0.5,
+  "matched_ori_oecf_quantiles": [
+    0.0,
+    0.05,
+    0.15,
+    0.3,
+    0.5,
+    0.7,
+    0.85,
+    0.95,
+    1.0
+  ],
+  "bayer_pattern": "RGGB",
+  "bayer_mode": "demosaic_red",
+  "roi_source": "reference_refined",
+  "roi_width": 1655,
+  "roi_height": 1673,
+  "roi_refine_percentile": 45.0,
+  "roi_refine_sigma": 5.0,
+  "roi_refine_min_border_margin": 8,
+  "roi_refine_search_radius": 4,
+  "roi_refine_step": 2,
+  "roi_refine_area_tolerance": 0.98,
+  "matched_ori_reference_anchor": true,
+  "matched_ori_correction_clip_lo": 0.5,
+  "matched_ori_correction_clip_hi": 2.0,
+  "matched_ori_anchor_mode": "acutance_only",
+  "matched_ori_strength_curve_frequencies": [
+    0.0,
+    0.12,
+    0.22,
+    0.35,
+    0.5
+  ],
+  "matched_ori_strength_curve_values": [
+    1.0,
+    1.0,
+    0.82,
+    0.95,
+    1.0
+  ],
+  "matched_ori_acutance_reference_anchor": true,
+  "matched_ori_acutance_correction_clip_lo": 0.9,
+  "matched_ori_acutance_correction_clip_hi": 1.1,
+  "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+  "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+    0.0,
+    0.25,
+    0.6,
+    0.8,
+    1.6,
+    2.5
+  ],
+  "matched_ori_acutance_curve_correction_clip_hi_values": [
+    1.02,
+    1.03,
+    0.895,
+    0.895,
+    1.05,
+    1.06
+  ],
+  "matched_ori_acutance_strength_curve_relative_scales": [
+    0.0,
+    0.2,
+    0.8,
+    1.6,
+    2.5
+  ],
+  "matched_ori_acutance_strength_curve_values": [
+    0.7,
+    0.69,
+    0.64,
+    0.62,
+    0.6
+  ],
+  "matched_ori_acutance_correction_delta_power": 1.0,
+  "matched_ori_acutance_curve_correction_delta_power": 0.95,
+  "matched_ori_acutance_preset_correction_delta_power": null,
+  "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+    0.0,
+    4.5,
+    5.8,
+    6.2
+  ],
+  "matched_ori_acutance_preset_correction_delta_power_values": [
+    1.05,
+    1.05,
+    1.85,
+    1.85
+  ],
+  "matched_ori_acutance_preset_strength_curve_relative_scales": [
+    0.0,
+    3.0,
+    4.5,
+    5.8,
+    6.2
+  ],
+  "matched_ori_acutance_preset_strength_curve_values": [
+    1.0,
+    1.0,
+    0.85,
+    0.45,
+    0.45
+  ],
+  "frequency_scale": 1.0,
+  "texture_support_scale": true,
+  "normalization_band_lo": 0.01,
+  "normalization_band_hi": 0.03,
+  "normalization_mode": "max",
+  "acutance_band_lo": 0.017,
+  "acutance_band_hi": 0.035,
+  "acutance_band_mode": "mean",
+  "noise_psd_model": "empirical",
+  "noise_psd_scale": 1.0,
+  "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+  "acutance_noise_share_band_lo": 0.36,
+  "acutance_noise_share_band_hi": 0.5,
+  "acutance_noise_share_scale_coefficients": [
+    521.08180962,
+    -26.62905791,
+    1.59615575
+  ],
+  "high_frequency_guard_start_cpp": 0.36,
+  "high_frequency_guard_stop_cpp": 0.5,
+  "mtf_compensation_mode": "sensor_aperture_sinc",
+  "sensor_fill_factor": 1.5,
+  "compensation_denominator_clip": 0.25,
+  "compensation_max_gain": 3.0,
+  "quality_loss_om_ceiling": 0.8851,
+  "quality_loss_coefficients": [
+    37.240228358776136,
+    26.54550669779819,
+    0.4538662637619741
+  ],
+  "quality_loss_preset_overrides": {
+    "Computer Monitor Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        5677361.198044325,
+        -16715685.9524707,
+        20317567.326582585,
+        -13046703.33912079,
+        4667794.619228022,
+        -882296.9160375095,
+        68863.59709647154
+      ]
+    },
+    "5.5\" Phone Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        -110912321.41149135,
+        50461107.51563171,
+        -9079490.127807735,
+        815148.8697247265,
+        -37712.984407641874,
+        854.6941149036079,
+        -6.261149027919645
+      ]
+    },
+    "UHDTV Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        1783462.6221675149,
+        -3813432.5606394163,
+        3326218.4642961356,
+        -1514886.1959663907,
+        380334.163146246,
+        -49956.87092015135,
+        2692.9566508574017
+      ]
+    },
+    "Small Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        6690980.837239251,
+        -12955277.716404187,
+        10300283.291740375,
+        -4303759.200708971,
+        996904.2653558743,
+        -121409.71509269004,
+        6084.6471373306085
+      ]
+    },
+    "Large Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        2355074.475971866,
+        -5276146.244338096,
+        4846781.143787682,
+        -2336594.295523967,
+        623766.4933095274,
+        -87476.30712136331,
+        5049.882965558553
+      ]
+    }
+  }
+}

--- a/algo/parity_benchmark_common.py
+++ b/algo/parity_benchmark_common.py
@@ -33,6 +33,73 @@ def build_ori_reference_map(dataset_root: Path) -> dict[str, tuple[Path, Path]]:
     return mapping
 
 
+def derive_quantile_transfer_curve(
+    source_image: np.ndarray,
+    target_image: np.ndarray,
+    *,
+    quantiles: Sequence[float],
+) -> tuple[np.ndarray, np.ndarray]:
+    sample_quantiles = np.asarray(quantiles, dtype=np.float64)
+    if sample_quantiles.ndim != 1 or sample_quantiles.size < 2:
+        raise ValueError("quantiles must contain at least two samples")
+    if np.any(sample_quantiles < 0.0) or np.any(sample_quantiles > 1.0):
+        raise ValueError("quantiles must stay within [0, 1]")
+    if np.any(np.diff(sample_quantiles) < 0.0):
+        raise ValueError("quantiles must be sorted ascending")
+
+    source_values = np.quantile(np.asarray(source_image, dtype=np.float64), sample_quantiles)
+    target_values = np.quantile(np.asarray(target_image, dtype=np.float64), sample_quantiles)
+    source_values = np.maximum.accumulate(np.clip(source_values, 0.0, 1.0))
+    target_values = np.maximum.accumulate(np.clip(target_values, 0.0, 1.0))
+
+    collapsed_source = [float(source_values[0])]
+    collapsed_target = [float(target_values[0])]
+    for source_value, target_value in zip(source_values[1:], target_values[1:]):
+        if source_value <= collapsed_source[-1] + 1e-9:
+            collapsed_target[-1] = max(collapsed_target[-1], float(target_value))
+        else:
+            collapsed_source.append(float(source_value))
+            collapsed_target.append(float(target_value))
+
+    if collapsed_source[0] > 0.0:
+        collapsed_source.insert(0, 0.0)
+        collapsed_target.insert(0, 0.0)
+    else:
+        collapsed_source[0] = 0.0
+        collapsed_target[0] = 0.0
+    if collapsed_source[-1] < 1.0:
+        collapsed_source.append(1.0)
+        collapsed_target.append(1.0)
+    else:
+        collapsed_source[-1] = 1.0
+        collapsed_target[-1] = 1.0
+
+    return (
+        np.asarray(collapsed_source, dtype=np.float64),
+        np.asarray(collapsed_target, dtype=np.float64),
+    )
+
+
+def apply_quantile_transfer_curve(
+    image: np.ndarray,
+    source_values: np.ndarray,
+    target_values: np.ndarray,
+    *,
+    strength: float = 1.0,
+) -> np.ndarray:
+    base = np.asarray(image, dtype=np.float64)
+    mapped = np.interp(
+        base,
+        np.asarray(source_values, dtype=np.float64),
+        np.asarray(target_values, dtype=np.float64),
+        left=float(target_values[0]),
+        right=float(target_values[-1]),
+    )
+    if strength != 1.0:
+        mapped = base + (mapped - base) * float(strength)
+    return np.clip(mapped, 0.0, 1.0)
+
+
 def derive_reference_correction_curve(
     reference_frequencies: np.ndarray,
     reference_mtf: np.ndarray,

--- a/artifacts/imatest_parity_matched_ori_oecf_proxy_benchmark.json
+++ b/artifacts/imatest_parity_matched_ori_oecf_proxy_benchmark.json
@@ -1,0 +1,242 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.05,
+          0.15,
+          0.3,
+          0.5,
+          0.7,
+          0.85,
+          0.95,
+          1.0
+        ],
+        "matched_ori_oecf_reference": true,
+        "matched_ori_oecf_strength": 0.5,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.0426419082983667,
+        "0.25": 0.03450723056011866,
+        "0.4": 0.028162391114511045,
+        "0.65": 0.03351676542287892,
+        "0.8": 0.039890883676316505,
+        "ori": 0.044422165524720086
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 1.3421389514230824,
+        "0.25": 1.2825995432153037,
+        "0.4": 1.1337887188584643,
+        "0.65": 0.3646116302822078,
+        "0.8": 1.0109879373437751,
+        "ori": 2.317792173136315
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.04249131400289711,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.013802151888956607,
+          "Computer Monitor Acutance": 0.052691955741307875,
+          "Large Print Acutance": 0.05132126004290283,
+          "Small Print Acutance": 0.04670043959486586,
+          "UHDTV Display Acutance": 0.047940762746452356
+        },
+        "curve_mae_mean": 0.03683437582462248,
+        "overall_quality_loss_mae_mean": 1.2221434105099775,
+        "quality_loss_focus_preset_mae_mean": 1.2221434105099775,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 0.14297762642651196,
+          "Computer Monitor Quality Loss": 2.906111784076103,
+          "Large Print Quality Loss": 0.9547911309308169,
+          "Small Print Quality Loss": 0.6076983310559123,
+          "UHDTV Display Quality Loss": 1.499138180060543
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_matched_ori_oecf_proxy_profile.json"
+    }
+  ]
+}

--- a/docs/imatest_parity_matched_ori_oecf_proxy_followup.md
+++ b/docs/imatest_parity_matched_ori_oecf_proxy_followup.md
@@ -1,0 +1,78 @@
+# Imatest Parity Matched-ORI OECF Proxy Follow-up
+
+Issue: `#31`  
+Refs: `#29`, PR `#30`
+
+## Why this pass
+
+Issue `#31` asked for the next source-backed family to test after the registration and reference-anchor sweep in PR `#30` plateaued short of the README gate.
+
+The black-box research note still lists OECF-driven linearization as a missing family, but the repo had only ruled out:
+
+- literal `analysis_gamma = 0.5`
+- generic inverse `sRGB`
+- generic inverse `Rec.709`
+- a simple `toe_power` proxy
+
+So this pass tested a stronger dataset-constrained OECF proxy instead of continuing local curve or preset retuning:
+
+- keep the current best `#30` branch intact
+- derive a bounded quantile-to-quantile tone curve from each processed capture to its matched `ori` capture
+- apply that tone curve after the existing `toe_power` normalization and before dead-leaves estimation
+
+## What changed
+
+- Added matched-`ori` quantile transfer helpers in `algo/parity_benchmark_common.py`.
+- Added new profile fields in both parity benchmark drivers:
+  - `matched_ori_oecf_reference`
+  - `matched_ori_oecf_strength`
+  - `matched_ori_oecf_quantiles`
+- Added unit coverage for the new transfer-curve helper and profile schema.
+- Added tracked profile:
+  - `algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_matched_ori_oecf_proxy_profile.json`
+- Added tracked benchmark artifact:
+  - `artifacts/imatest_parity_matched_ori_oecf_proxy_benchmark.json`
+
+## Result
+
+The matched-`ori` OECF proxy does not improve the current best `#30` branch.
+
+Current best branch from PR `#30`:
+
+- `curve_mae_mean = 0.03683438`
+- `acutance_focus_preset_mae_mean = 0.04249131`
+- `overall_quality_loss_mae_mean = 1.22214341`
+
+Matched-`ori` OECF proxy benchmark:
+
+- `curve_mae_mean = 0.03683438`
+- `acutance_focus_preset_mae_mean = 0.04249131`
+- `overall_quality_loss_mae_mean = 1.22214341`
+
+That means this formulation is a no-op for the end-to-end benchmark.
+
+## Why it collapsed
+
+A representative matched pair already shows why the benchmark does not move much after the existing `toe_power` normalization:
+
+- processed quantiles:
+  - `[0.327327, 0.493524, 0.696868, 0.756406, 0.803041, 0.852110, 0.898208, 0.938100]`
+- matched `ori` quantiles:
+  - `[0.327327, 0.503318, 0.689098, 0.753038, 0.799396, 0.848527, 0.894965, 0.939409]`
+- deltas stay within about `-0.0078` to `+0.0098`
+
+So once the current branch already applies percentile normalization plus `toe_power`, this quantile-matched proxy does not introduce a materially new tonal family. It mostly reproduces the same normalized ordering with tiny local shifts.
+
+## Working conclusion
+
+This is not the next useful family to keep pushing inside issue `#31`.
+
+- It is more source-backed than a generic `sRGB` / `Rec.709` swap.
+- But in this matched-`ori` quantile formulation it collapses to near-identity and does not move the README gate at all.
+- That makes it a poor use of time compared with the remaining missing family that can still change the model materially: a stronger intrinsic / full-reference method with explicit reference-image warp and phase-retaining correction, rather than another bounded OECF proxy.
+
+## Validation
+
+- `python3 -m pytest tests/test_dead_leaves_mtf_compensation.py tests/test_benchmark_parity_acutance_quality_loss.py`
+- `python3 -m py_compile algo/parity_benchmark_common.py algo/benchmark_parity_psd_mtf.py algo/benchmark_parity_acutance_quality_loss.py`
+- `python3 -m algo.benchmark_parity_acutance_quality_loss 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_matched_ori_oecf_proxy_profile.json --output artifacts/imatest_parity_matched_ori_oecf_proxy_benchmark.json`

--- a/tests/test_benchmark_parity_acutance_quality_loss.py
+++ b/tests/test_benchmark_parity_acutance_quality_loss.py
@@ -15,8 +15,10 @@ from algo.benchmark_parity_acutance_quality_loss import (
 )
 from algo.dead_leaves import AcutancePoint, RoiBounds
 from algo.parity_benchmark_common import (
+    apply_quantile_transfer_curve,
     apply_reference_correction_curve,
     clip_reference_correction_curve,
+    derive_quantile_transfer_curve,
     derive_reference_acutance_correction_curve,
     derive_reference_correction_curve,
 )
@@ -118,6 +120,28 @@ class BenchmarkParityAcutanceQualityLossTest(unittest.TestCase):
             strength_curve_values=[1.0, 0.5, 1.0],
         )
         np.testing.assert_allclose(corrected, [1.875, 1.5, 2.0])
+
+    def test_quantile_transfer_curve_is_monotonic_and_anchored(self) -> None:
+        source_values, target_values = derive_quantile_transfer_curve(
+            np.array([[0.0, 0.2], [0.4, 1.0]], dtype=np.float32),
+            np.array([[0.0, 0.1], [0.3, 1.0]], dtype=np.float32),
+            quantiles=(0.0, 0.25, 0.5, 0.75, 1.0),
+        )
+        self.assertEqual(source_values[0], 0.0)
+        self.assertEqual(target_values[0], 0.0)
+        self.assertEqual(source_values[-1], 1.0)
+        self.assertEqual(target_values[-1], 1.0)
+        self.assertTrue(np.all(np.diff(source_values) > 0.0))
+        self.assertTrue(np.all(np.diff(target_values) >= 0.0))
+
+    def test_quantile_transfer_curve_blends_by_strength(self) -> None:
+        corrected = apply_quantile_transfer_curve(
+            np.array([0.0, 0.25, 0.5, 1.0], dtype=np.float32),
+            np.array([0.0, 0.5, 1.0], dtype=np.float64),
+            np.array([0.0, 0.25, 1.0], dtype=np.float64),
+            strength=0.5,
+        )
+        np.testing.assert_allclose(corrected, [0.0, 0.1875, 0.375, 1.0])
 
     def test_reference_correction_curve_supports_delta_power(self) -> None:
         corrected = apply_reference_correction_curve(
@@ -236,6 +260,18 @@ class BenchmarkParityAcutanceQualityLossTest(unittest.TestCase):
             matched_ori_anchor_mode="acutance_only",
         )
         self.assertEqual(profile.matched_ori_anchor_mode, "acutance_only")
+
+    def test_psd_profile_allows_matched_ori_oecf_fields(self) -> None:
+        profile = PsdProfile(
+            name="test",
+            calibration_file="algo/deadleaf_13b10_psd_calibration.json",
+            matched_ori_oecf_reference=True,
+            matched_ori_oecf_strength=0.4,
+            matched_ori_oecf_quantiles=(0.0, 0.2, 0.5, 0.8, 1.0),
+        )
+        self.assertTrue(profile.matched_ori_oecf_reference)
+        self.assertEqual(profile.matched_ori_oecf_strength, 0.4)
+        self.assertEqual(profile.matched_ori_oecf_quantiles, (0.0, 0.2, 0.5, 0.8, 1.0))
 
     def test_psd_profile_allows_acutance_curve_anchor_fields(self) -> None:
         profile = PsdProfile(


### PR DESCRIPTION
## Summary

- adds a bounded matched-`ori` quantile-transfer OECF proxy in the parity benchmark helpers and drivers
- adds unit coverage plus a tracked issue-31 profile, benchmark artifact, and follow-up note
- records that this OECF formulation does not move the current PR #30 winning branch, so it should not be the next family to keep pushing

## Why This PR

Issue #31 asked for the next concrete model family to test after the registration and reference-anchor sweep in PR #30 plateaued short of the README gate.

The source-backed candidates still included OECF-driven linearization, but the repo had only ruled out generic inverse `sRGB` / `Rec.709` plus the simpler `toe_power` proxy. This PR tests a stronger dataset-constrained OECF proxy before spending more time on another family.

## Result

Benchmarking the tracked profile against the current best PR #30 branch leaves the metrics unchanged:

- `curve_mae_mean = 0.03683438`
- `acutance_focus_preset_mae_mean = 0.04249131`
- `overall_quality_loss_mae_mean = 1.22214341`

The matched-`ori` quantile transfer therefore collapses to a near-identity refinement after the existing percentile normalization plus `toe_power` step. The follow-up note documents this as a bounded negative result and points the next useful work away from more OECF proxies and toward a stronger intrinsic / full-reference method.

## Validation

- `python3 -m pytest tests/test_dead_leaves_mtf_compensation.py tests/test_benchmark_parity_acutance_quality_loss.py`
- `python3 -m py_compile algo/parity_benchmark_common.py algo/benchmark_parity_psd_mtf.py algo/benchmark_parity_acutance_quality_loss.py`
- `python3 -m algo.benchmark_parity_acutance_quality_loss 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_matched_ori_oecf_proxy_profile.json --output artifacts/imatest_parity_matched_ori_oecf_proxy_benchmark.json`

Refs #31
Refs #29
Refs #30