### PR TITLE
Prototype intrinsic/full-reference dead-leaves follow-up after PR #32

### DIFF
--- a/algo/benchmark_parity_acutance_quality_loss.py
+++ b/algo/benchmark_parity_acutance_quality_loss.py
@@ -42,6 +42,7 @@ from .parity_benchmark_common import (
     clip_reference_correction_curve,
     derive_reference_acutance_correction_curve,
     derive_reference_correction_curve,
+    derive_intrinsic_transfer_curve,
 )
 
 FOCUS_ACUTANCE_PRESETS = (
@@ -79,6 +80,10 @@ class Profile:
     roi_refine_search_radius: int = 12
     roi_refine_step: int = 2
     roi_refine_area_tolerance: float = 0.98
+    intrinsic_full_reference_mode: str = "none"
+    intrinsic_full_reference_clip_lo: float = 0.5
+    intrinsic_full_reference_clip_hi: float = 1.5
+    intrinsic_full_reference_registration_mode: str = "phase_correlation"
     matched_ori_reference_anchor: bool = False
     matched_ori_anchor_mode: str = "all"
     matched_ori_correction_clip_lo: float = 0.5
@@ -286,10 +291,17 @@ def summarize_profile(
 ) -> dict[str, object]:
     calibration = load_ideal_psd_calibration(profile.calibration_file)
     ori_reference_map = (
-        build_ori_reference_map(dataset_root) if profile.matched_ori_reference_anchor else {}
+        build_ori_reference_map(dataset_root)
+        if (
+            profile.matched_ori_reference_anchor
+            or profile.matched_ori_acutance_reference_anchor
+            or profile.intrinsic_full_reference_mode != "none"
+        )
+        else {}
     )
     correction_cache: dict[str, tuple[np.ndarray, np.ndarray]] = {}
     acutance_correction_cache: dict[str, tuple[np.ndarray, np.ndarray]] = {}
+    intrinsic_reference_cache: dict[str, tuple[object, np.ndarray, RoiBounds]] = {}
     presets = build_acutance_presets(profile.acutance_preset_overrides)
     csv_paths = sorted(dataset_root.glob("**/Results/*_R_Random.csv"))
     curve_mae: list[float] = []
@@ -370,6 +382,56 @@ def summarize_profile(
             denominator_clip=profile.compensation_denominator_clip,
             max_gain=profile.compensation_max_gain,
         )
+        if profile.intrinsic_full_reference_mode != "none":
+            if profile.intrinsic_full_reference_mode != "paired_ori_transfer":
+                raise ValueError(
+                    f"Unsupported intrinsic full-reference mode: {profile.intrinsic_full_reference_mode}"
+                )
+            capture_key = capture_key_from_stem(raw_path.stem)
+            if capture_key in ori_reference_map:
+                if capture_key not in intrinsic_reference_cache:
+                    ori_csv_path, ori_raw_path = ori_reference_map[capture_key]
+                    ori_reference = parse_imatest_random_csv(ori_csv_path)
+                    ori_raw = load_raw_u16(ori_raw_path, width, height)
+                    ori_plane = extract_analysis_plane(
+                        ori_raw,
+                        bayer_pattern=BayerPattern(profile.bayer_pattern),
+                        mode=BayerMode(profile.bayer_mode),
+                    )
+                    ori_image = normalize_for_analysis(
+                        ori_plane,
+                        gamma=profile.gamma,
+                        mode=profile.linearization_mode,
+                        toe=profile.linearization_toe,
+                    )
+                    ori_roi = choose_roi(profile, ori_reference, ori_image)
+                    intrinsic_reference_cache[capture_key] = (ori_reference, ori_image, ori_roi)
+                ori_reference, ori_image, ori_roi = intrinsic_reference_cache[capture_key]
+                reference_patch = ori_image[
+                    ori_roi.top : ori_roi.bottom + 1,
+                    ori_roi.left : ori_roi.right + 1,
+                ]
+                observed_patch = image[
+                    roi.top : roi.bottom + 1,
+                    roi.left : roi.right + 1,
+                ]
+                transfer_curve = derive_intrinsic_transfer_curve(
+                    reference_patch,
+                    observed_patch,
+                    bin_centers=ori_reference.frequencies_cpp,
+                    normalization_band=(
+                        profile.normalization_band_lo,
+                        profile.normalization_band_hi,
+                    ),
+                    normalization_mode=profile.normalization_mode,
+                    clip_lo=profile.intrinsic_full_reference_clip_lo,
+                    clip_hi=profile.intrinsic_full_reference_clip_hi,
+                    registration_mode=profile.intrinsic_full_reference_registration_mode,
+                )
+                scaled_frequencies = np.asarray(ori_reference.frequencies_cpp, dtype=np.float64)
+                compensated_mtf_for_acutance = (
+                    np.asarray(ori_reference.mtf, dtype=np.float64) * transfer_curve
+                )
         if profile.matched_ori_reference_anchor:
             capture_key = capture_key_from_stem(raw_path.stem)
             if capture_key in ori_reference_map:
@@ -800,6 +862,10 @@ def summarize_profile(
             "bayer_pattern": profile.bayer_pattern,
             "bayer_mode": profile.bayer_mode,
             "roi_source": profile.roi_source,
+            "intrinsic_full_reference_mode": profile.intrinsic_full_reference_mode,
+            "intrinsic_full_reference_clip_lo": profile.intrinsic_full_reference_clip_lo,
+            "intrinsic_full_reference_clip_hi": profile.intrinsic_full_reference_clip_hi,
+            "intrinsic_full_reference_registration_mode": profile.intrinsic_full_reference_registration_mode,
             "matched_ori_reference_anchor": profile.matched_ori_reference_anchor,
             "matched_ori_anchor_mode": profile.matched_ori_anchor_mode,
             "matched_ori_correction_clip_lo": profile.matched_ori_correction_clip_lo,

--- a/algo/benchmark_parity_psd_mtf.py
+++ b/algo/benchmark_parity_psd_mtf.py
@@ -36,6 +36,7 @@ from .parity_benchmark_common import (
     build_ori_reference_map,
     capture_key_from_stem,
     derive_reference_correction_curve,
+    derive_intrinsic_transfer_curve,
 )
 
 BANDS = (
@@ -64,6 +65,10 @@ class Profile:
     roi_refine_search_radius: int = 12
     roi_refine_step: int = 2
     roi_refine_area_tolerance: float = 0.98
+    intrinsic_full_reference_mode: str = "none"
+    intrinsic_full_reference_clip_lo: float = 0.5
+    intrinsic_full_reference_clip_hi: float = 1.5
+    intrinsic_full_reference_registration_mode: str = "phase_correlation"
     matched_ori_reference_anchor: bool = False
     matched_ori_anchor_mode: str = "all"
     matched_ori_correction_clip_lo: float = 0.5
@@ -134,6 +139,10 @@ class Profile:
     sensor_fill_factor: float = 1.0
     compensation_denominator_clip: float = 0.25
     compensation_max_gain: float = 3.0
+    quality_loss_om_ceiling: float = 0.8851
+    quality_loss_coefficients: tuple[float, float, float] = (64.99250542, 9.37974246, 0.72233291)
+    quality_loss_preset_overrides: dict[str, dict[str, object]] | None = None
+    acutance_preset_overrides: dict[str, dict[str, float | str | None]] | None = None
 
 
 def load_profile(path: Path) -> Profile:
@@ -256,9 +265,12 @@ def profile_payload(
 ) -> dict[str, object]:
     calibration = load_ideal_psd_calibration(profile.calibration_file)
     ori_reference_map = (
-        build_ori_reference_map(dataset_root) if profile.matched_ori_reference_anchor else {}
+        build_ori_reference_map(dataset_root)
+        if profile.matched_ori_reference_anchor or profile.intrinsic_full_reference_mode != "none"
+        else {}
     )
     correction_cache: dict[str, tuple[np.ndarray, np.ndarray, np.ndarray]] = {}
+    intrinsic_reference_cache: dict[str, tuple[object, np.ndarray, RoiBounds]] = {}
     csv_paths = sorted(dataset_root.glob("**/Results/*_R_Random.csv"))
     curve_mae: list[float] = []
     preset_errors: dict[str, list[float]] = {}
@@ -347,6 +359,55 @@ def profile_payload(
             denominator_clip=profile.compensation_denominator_clip,
             max_gain=profile.compensation_max_gain,
         )
+        if profile.intrinsic_full_reference_mode != "none":
+            if profile.intrinsic_full_reference_mode != "paired_ori_transfer":
+                raise ValueError(
+                    f"Unsupported intrinsic full-reference mode: {profile.intrinsic_full_reference_mode}"
+                )
+            capture_key = capture_key_from_stem(raw_path.stem)
+            if capture_key in ori_reference_map:
+                if capture_key not in intrinsic_reference_cache:
+                    ori_csv_path, ori_raw_path = ori_reference_map[capture_key]
+                    ori_reference = parse_imatest_random_csv(ori_csv_path)
+                    ori_raw = load_raw_u16(ori_raw_path, width, height)
+                    ori_plane = extract_analysis_plane(
+                        ori_raw,
+                        bayer_pattern=BayerPattern(profile.bayer_pattern),
+                        mode=BayerMode(profile.bayer_mode),
+                    )
+                    ori_image = normalize_for_analysis(
+                        ori_plane,
+                        gamma=profile.gamma,
+                        mode=profile.linearization_mode,
+                        toe=profile.linearization_toe,
+                    )
+                    ori_roi = choose_roi(profile, ori_reference, ori_image)
+                    intrinsic_reference_cache[capture_key] = (ori_reference, ori_image, ori_roi)
+                ori_reference, ori_image, ori_roi = intrinsic_reference_cache[capture_key]
+                reference_patch = ori_image[
+                    ori_roi.top : ori_roi.bottom + 1,
+                    ori_roi.left : ori_roi.right + 1,
+                ]
+                observed_patch = image[
+                    roi.top : roi.bottom + 1,
+                    roi.left : roi.right + 1,
+                ]
+                transfer_curve = derive_intrinsic_transfer_curve(
+                    reference_patch,
+                    observed_patch,
+                    bin_centers=ori_reference.frequencies_cpp,
+                    normalization_band=(
+                        profile.normalization_band_lo,
+                        profile.normalization_band_hi,
+                    ),
+                    normalization_mode=profile.normalization_mode,
+                    clip_lo=profile.intrinsic_full_reference_clip_lo,
+                    clip_hi=profile.intrinsic_full_reference_clip_hi,
+                    registration_mode=profile.intrinsic_full_reference_registration_mode,
+                )
+                scaled_frequencies = np.asarray(ori_reference.frequencies_cpp, dtype=np.float64)
+                compensated_mtf = np.asarray(ori_reference.mtf, dtype=np.float64) * transfer_curve
+                compensated_mtf_for_acutance = compensated_mtf.copy()
         if profile.matched_ori_reference_anchor:
             capture_key = capture_key_from_stem(raw_path.stem)
             if capture_key in ori_reference_map:
@@ -538,6 +599,10 @@ def profile_payload(
             "bayer_pattern": profile.bayer_pattern,
             "bayer_mode": profile.bayer_mode,
             "roi_source": profile.roi_source,
+            "intrinsic_full_reference_mode": profile.intrinsic_full_reference_mode,
+            "intrinsic_full_reference_clip_lo": profile.intrinsic_full_reference_clip_lo,
+            "intrinsic_full_reference_clip_hi": profile.intrinsic_full_reference_clip_hi,
+            "intrinsic_full_reference_registration_mode": profile.intrinsic_full_reference_registration_mode,
             "matched_ori_reference_anchor": profile.matched_ori_reference_anchor,
             "matched_ori_anchor_mode": profile.matched_ori_anchor_mode,
             "matched_ori_correction_clip_lo": profile.matched_ori_correction_clip_lo,

--- a/algo/deadleaf_13b10_imatest_intrinsic_full_reference_profile.json
+++ b/algo/deadleaf_13b10_imatest_intrinsic_full_reference_profile.json
@@ -1,0 +1,99 @@
+{
+  "name": "deadleaf_13b10_imatest_intrinsic_full_reference",
+  "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+  "gamma": 0.5,
+  "linearization_mode": "toe_power",
+  "linearization_toe": 0.12,
+  "bayer_pattern": "RGGB",
+  "bayer_mode": "demosaic_red",
+  "roi_source": "reference_refined",
+  "roi_width": 1655,
+  "roi_height": 1673,
+  "roi_refine_percentile": 45.0,
+  "roi_refine_sigma": 5.0,
+  "roi_refine_min_border_margin": 8,
+  "roi_refine_search_radius": 4,
+  "roi_refine_step": 2,
+  "roi_refine_area_tolerance": 0.98,
+  "intrinsic_full_reference_mode": "paired_ori_transfer",
+  "intrinsic_full_reference_clip_lo": 0.5,
+  "intrinsic_full_reference_clip_hi": 1.5,
+  "intrinsic_full_reference_registration_mode": "phase_correlation",
+  "frequency_scale": 1.0,
+  "normalization_band_lo": 0.01,
+  "normalization_band_hi": 0.03,
+  "normalization_mode": "max",
+  "acutance_band_lo": 0.017,
+  "acutance_band_hi": 0.035,
+  "acutance_band_mode": "mean",
+  "noise_psd_model": "empirical",
+  "noise_psd_scale": 1.0,
+  "quality_loss_om_ceiling": 0.8851,
+  "quality_loss_coefficients": [
+    37.240228358776136,
+    26.54550669779819,
+    0.4538662637619741
+  ],
+  "quality_loss_preset_overrides": {
+    "Computer Monitor Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        5677361.198044325,
+        -16715685.9524707,
+        20317567.326582585,
+        -13046703.33912079,
+        4667794.619228022,
+        -882296.9160375095,
+        68863.59709647154
+      ]
+    },
+    "5.5\" Phone Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        -110912321.41149135,
+        50461107.51563171,
+        -9079490.127807735,
+        815148.8697247265,
+        -37712.984407641874,
+        854.6941149036079,
+        -6.261149027919645
+      ]
+    },
+    "UHDTV Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        1783462.6221675149,
+        -3813432.5606394163,
+        3326218.4642961356,
+        -1514886.1959663907,
+        380334.163146246,
+        -49956.87092015135,
+        2692.9566508574017
+      ]
+    },
+    "Small Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        6690980.837239251,
+        -12955277.716404187,
+        10300283.291740375,
+        -4303759.200708971,
+        996904.2653558743,
+        -121409.71509269004,
+        6084.6471373306085
+      ]
+    },
+    "Large Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        2355074.475971866,
+        -5276146.244338096,
+        4846781.143787682,
+        -2336594.295523967,
+        623766.4933095274,
+        -87476.30712136331,
+        5049.882965558553
+      ]
+    }
+  }
+}

--- a/algo/parity_benchmark_common.py
+++ b/algo/parity_benchmark_common.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import re
 from typing import Sequence
 
+import cv2
 import numpy as np
 
 from .dead_leaves import AcutancePoint
@@ -31,6 +32,153 @@ def build_ori_reference_map(dataset_root: Path) -> dict[str, tuple[Path, Path]]:
         if raw_path.exists():
             mapping[key] = (csv_path, raw_path)
     return mapping
+
+
+def center_crop_to_common_shape(
+    reference_patch: np.ndarray,
+    observed_patch: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    reference = np.asarray(reference_patch, dtype=np.float64)
+    observed = np.asarray(observed_patch, dtype=np.float64)
+    target_height = min(reference.shape[0], observed.shape[0])
+    target_width = min(reference.shape[1], observed.shape[1])
+    if target_height <= 0 or target_width <= 0:
+        raise ValueError("reference and observed patches must both be non-empty")
+
+    def crop_center(patch: np.ndarray) -> np.ndarray:
+        top = max((patch.shape[0] - target_height) // 2, 0)
+        left = max((patch.shape[1] - target_width) // 2, 0)
+        return patch[top : top + target_height, left : left + target_width]
+
+    return crop_center(reference), crop_center(observed)
+
+
+def align_patch_phase_correlation(
+    reference_patch: np.ndarray,
+    observed_patch: np.ndarray,
+) -> tuple[np.ndarray, tuple[float, float], float]:
+    reference, observed = center_crop_to_common_shape(reference_patch, observed_patch)
+    window = np.outer(
+        np.hanning(reference.shape[0]),
+        np.hanning(reference.shape[1]),
+    ).astype(np.float32)
+    shift, response = cv2.phaseCorrelate(
+        reference.astype(np.float32),
+        observed.astype(np.float32),
+        window,
+    )
+    transform = np.array(
+        [
+            [1.0, 0.0, -float(shift[0])],
+            [0.0, 1.0, -float(shift[1])],
+        ],
+        dtype=np.float32,
+    )
+    aligned = cv2.warpAffine(
+        observed.astype(np.float32),
+        transform,
+        (reference.shape[1], reference.shape[0]),
+        flags=cv2.INTER_LINEAR,
+        borderMode=cv2.BORDER_REFLECT,
+    )
+    return aligned.astype(np.float64), (float(shift[0]), float(shift[1])), float(response)
+
+
+def _radial_bin_average(
+    values2d: np.ndarray,
+    *,
+    bin_centers: np.ndarray,
+    valid_mask: np.ndarray | None = None,
+) -> np.ndarray:
+    centers = np.asarray(bin_centers, dtype=np.float64)
+    values = np.asarray(values2d, dtype=np.float64)
+    fy = np.fft.fftshift(np.fft.fftfreq(values.shape[0], d=1.0))
+    fx = np.fft.fftshift(np.fft.fftfreq(values.shape[1], d=1.0))
+    yy, xx = np.meshgrid(fy, fx, indexing="ij")
+    radius = np.sqrt(xx * xx + yy * yy)
+
+    edges = np.empty(centers.size + 1, dtype=np.float64)
+    edges[0] = 0.0
+    edges[-1] = 0.5
+    if centers.size > 1:
+        edges[1:-1] = 0.5 * (centers[:-1] + centers[1:])
+    else:
+        edges[1:-1] = centers[0]
+
+    mask = radius <= 0.5
+    if valid_mask is not None:
+        mask &= np.asarray(valid_mask, dtype=bool)
+    radius = radius[mask]
+    sample_values = values[mask]
+
+    averaged = np.ones(centers.size, dtype=np.float64)
+    counts = np.zeros(centers.size, dtype=np.int64)
+    if radius.size == 0:
+        return averaged
+
+    sums = np.zeros(centers.size, dtype=np.float64)
+    bin_ids = np.digitize(radius, edges) - 1
+    valid = (bin_ids >= 0) & (bin_ids < centers.size)
+    for idx, value in zip(bin_ids[valid], sample_values[valid]):
+        sums[idx] += float(value)
+        counts[idx] += 1
+    nonzero = counts > 0
+    averaged[nonzero] = sums[nonzero] / counts[nonzero]
+    return averaged
+
+
+def derive_intrinsic_transfer_curve(
+    reference_patch: np.ndarray,
+    observed_patch: np.ndarray,
+    *,
+    bin_centers: np.ndarray,
+    normalization_band: tuple[float, float],
+    normalization_mode: str,
+    clip_lo: float,
+    clip_hi: float,
+    registration_mode: str = "phase_correlation",
+) -> np.ndarray:
+    reference, observed = center_crop_to_common_shape(reference_patch, observed_patch)
+    if registration_mode == "phase_correlation":
+        observed_aligned, _, _ = align_patch_phase_correlation(reference, observed)
+    elif registration_mode == "none":
+        observed_aligned = observed
+    else:
+        raise ValueError(f"Unsupported intrinsic registration mode: {registration_mode}")
+
+    reference = reference - float(np.mean(reference))
+    observed_aligned = observed_aligned - float(np.mean(observed_aligned))
+    window = np.outer(
+        np.hanning(reference.shape[0]),
+        np.hanning(reference.shape[1]),
+    )
+    reference_spectrum = np.fft.fftshift(np.fft.fft2(reference * window))
+    observed_spectrum = np.fft.fftshift(np.fft.fft2(observed_aligned * window))
+    reference_power = np.abs(reference_spectrum) ** 2
+    transfer_2d = np.abs(observed_spectrum * np.conj(reference_spectrum)) / np.maximum(
+        reference_power,
+        EPS,
+    )
+    support = reference_power[reference_power > EPS]
+    power_floor = max(float(np.percentile(support, 10)) * 0.1, EPS) if support.size else EPS
+    transfer_curve = _radial_bin_average(
+        np.clip(transfer_2d, clip_lo, clip_hi),
+        bin_centers=np.asarray(bin_centers, dtype=np.float64),
+        valid_mask=reference_power >= power_floor,
+    )
+    lo, hi = normalization_band
+    band = (
+        (np.asarray(bin_centers, dtype=np.float64) >= float(lo))
+        & (np.asarray(bin_centers, dtype=np.float64) <= float(hi))
+    )
+    if np.any(band):
+        if normalization_mode == "mean":
+            anchor = float(np.mean(transfer_curve[band]))
+        else:
+            anchor = float(np.max(transfer_curve[band]))
+        if anchor > EPS:
+            transfer_curve = transfer_curve / anchor
+    return np.clip(transfer_curve, clip_lo, clip_hi)
 
 
 def derive_reference_correction_curve(

--- a/artifacts/imatest_parity_intrinsic_full_reference_benchmark.json
+++ b/artifacts/imatest_parity_intrinsic_full_reference_benchmark.json
@@ -1,0 +1,407 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.0426419082983667,
+        "0.25": 0.03450723056011866,
+        "0.4": 0.028162391114511045,
+        "0.65": 0.03351676542287892,
+        "0.8": 0.039890883676316505,
+        "ori": 0.044422165524720086
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 1.3421389514230824,
+        "0.25": 1.2825995432153037,
+        "0.4": 1.1337887188584643,
+        "0.65": 0.3646116302822078,
+        "0.8": 1.0109879373437751,
+        "ori": 2.317792173136315
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.04249131400289711,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.013802151888956607,
+          "Computer Monitor Acutance": 0.052691955741307875,
+          "Large Print Acutance": 0.05132126004290283,
+          "Small Print Acutance": 0.04670043959486586,
+          "UHDTV Display Acutance": 0.047940762746452356
+        },
+        "curve_mae_mean": 0.03683437582462248,
+        "overall_quality_loss_mae_mean": 1.2221434105099775,
+        "quality_loss_focus_preset_mae_mean": 1.2221434105099775,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 0.14297762642651196,
+          "Computer Monitor Quality Loss": 2.906111784076103,
+          "Large Print Quality Loss": 0.9547911309308169,
+          "Small Print Quality Loss": 0.6076983310559123,
+          "UHDTV Display Quality Loss": 1.499138180060543
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json"
+    },
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": null,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": null,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_hi_values": null,
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": null,
+        "matched_ori_acutance_preset_correction_delta_power_values": null,
+        "matched_ori_acutance_preset_strength_curve_relative_scales": null,
+        "matched_ori_acutance_preset_strength_curve_values": null,
+        "matched_ori_acutance_reference_anchor": false,
+        "matched_ori_acutance_strength_curve_relative_scales": null,
+        "matched_ori_acutance_strength_curve_values": null,
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_reference_anchor": false,
+        "matched_ori_strength_curve_frequencies": null,
+        "matched_ori_strength_curve_values": null,
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "none",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.0,
+        "texture_support_scale": false
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.035196683613694144,
+        "0.25": 0.026063595116536987,
+        "0.4": 0.01753747396802398,
+        "0.65": 0.02312474254644139,
+        "0.8": 0.049338085629964015,
+        "ori": 0.07933816634336006
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 9.228172826352582,
+        "0.25": 5.167259124080752,
+        "0.4": 1.9657004646755276,
+        "0.65": 0.4897094076381619,
+        "0.8": 0.995854510684369,
+        "ori": 10.476408297514947
+      },
+      "delta_vs_first_profile": {
+        "acutance_focus_preset_mae_mean": -0.010839086413757582,
+        "curve_mae_mean": -0.0009609172699985083,
+        "overall_quality_loss_mae_mean": 3.3458657451639797,
+        "quality_loss_focus_preset_mae_mean": 3.3458657451639797
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.03165222758913953,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.019550144806142,
+          "Computer Monitor Acutance": 0.03459963699573056,
+          "Large Print Acutance": 0.035489754869580475,
+          "Small Print Acutance": 0.03236185429681691,
+          "UHDTV Display Acutance": 0.03625974697742769
+        },
+        "curve_mae_mean": 0.03587345855462397,
+        "overall_quality_loss_mae_mean": 4.568009155673957,
+        "quality_loss_focus_preset_mae_mean": 4.568009155673957,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 10.625076452435083,
+          "Computer Monitor Quality Loss": 8.429551248810423,
+          "Large Print Quality Loss": 0.8041006693709367,
+          "Small Print Quality Loss": 0.8460359016507393,
+          "UHDTV Display Quality Loss": 2.1352815061026047
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_profile.json"
+    }
+  ]
+}

--- a/artifacts/imatest_parity_intrinsic_full_reference_psd_benchmark.json
+++ b/artifacts/imatest_parity_intrinsic_full_reference_psd_benchmark.json
@@ -1,0 +1,279 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.045132331541343135,
+        "0.25": 0.03837972282290488,
+        "0.4": 0.03424583283108843,
+        "0.65": 0.04020915188141205,
+        "0.8": 0.049664991465143526,
+        "ori": 0.055589288189657284
+      },
+      "overall": {
+        "curve_mae_mean": 0.04306441973920293,
+        "mtf_abs_signed_rel_mean": 0.08692955889841379,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.017639268013990343,
+            "mre_mean": 0.08883603386012136,
+            "signed_rel_mean": 0.04964177427444007
+          },
+          "low": {
+            "mae_mean": 0.03704553941403868,
+            "mre_mean": 0.046572470331734825,
+            "signed_rel_mean": 0.0237949421475065
+          },
+          "mid": {
+            "mae_mean": 0.03898616152003224,
+            "mre_mean": 0.12397538768693758,
+            "signed_rel_mean": 0.10965436746685472
+          },
+          "top": {
+            "mae_mean": 0.0738124428343438,
+            "mre_mean": 0.20207246214765648,
+            "signed_rel_mean": -0.16462715170485387
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.033009025007104606,
+          "mtf30": 0.03693523768742383,
+          "mtf50": 0.009332615436071163
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.014469243052711292,
+          "Computer Monitor Acutance": 0.06145640899956405,
+          "Large Print Acutance": 0.05374582109239643,
+          "Small Print Acutance": 0.061691355516267324,
+          "UHDTV Display Acutance": 0.056009600718383366
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json"
+    },
+    {
+      "analysis_pipeline": {
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": null,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_hi_values": null,
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": null,
+        "matched_ori_acutance_preset_correction_delta_power_values": null,
+        "matched_ori_acutance_preset_strength_curve_relative_scales": null,
+        "matched_ori_acutance_preset_strength_curve_values": null,
+        "matched_ori_acutance_reference_anchor": false,
+        "matched_ori_acutance_strength_curve_relative_scales": null,
+        "matched_ori_acutance_strength_curve_values": null,
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_reference_anchor": false,
+        "matched_ori_strength_curve_frequencies": null,
+        "matched_ori_strength_curve_values": null,
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "none",
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.0,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": false
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.035196683613694144,
+        "0.25": 0.026063595116536987,
+        "0.4": 0.01753747396802398,
+        "0.65": 0.02312474254644139,
+        "0.8": 0.049338085629964015,
+        "ori": 0.07933816634336006
+      },
+      "overall": {
+        "curve_mae_mean": 0.03587345855462397,
+        "mtf_abs_signed_rel_mean": 0.20631328511090832,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.05364693984972888,
+            "mre_mean": 0.4393614969865764,
+            "signed_rel_mean": 0.42543616835229364
+          },
+          "low": {
+            "mae_mean": 0.01376897213542222,
+            "mre_mean": 0.019784103888456157,
+            "signed_rel_mean": 0.01835499188457983
+          },
+          "mid": {
+            "mae_mean": 0.043064434659796536,
+            "mre_mean": 0.21014153510561587,
+            "signed_rel_mean": 0.19180123688322911
+          },
+          "top": {
+            "mae_mean": 0.044614178371310126,
+            "mre_mean": 0.23687141210944618,
+            "signed_rel_mean": 0.18966074332353067
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.08283943347415898,
+          "mtf30": 0.037939058443613165,
+          "mtf50": 0.005028927723658681
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.019550144806142,
+          "Computer Monitor Acutance": 0.03459963699573056,
+          "Large Print Acutance": 0.035489754869580475,
+          "Small Print Acutance": 0.03236185429681691,
+          "UHDTV Display Acutance": 0.03625974697742769
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_profile.json"
+    }
+  ]
+}

--- a/docs/imatest_parity_intrinsic_full_reference_followup.md
+++ b/docs/imatest_parity_intrinsic_full_reference_followup.md
@@ -1,0 +1,70 @@
+# Imatest Parity Intrinsic Full-Reference Follow-up
+
+Issue: `#33`  
+Parent: `#29`  
+Context: `#30`, `#32`
+
+## What changed
+
+- Added a bounded intrinsic / full-reference dead-leaves path that uses the paired `ori` capture as the reference image for the same scene.
+- Added translation-only registration via phase correlation so the intrinsic slice can align the observed patch against the paired `ori` patch without reopening the broader crop-tuning family.
+- Derived a radial transfer curve from the paired `ori` and observed patches, then used that transfer to anchor the predicted dead-leaves MTF against the paired `ori` reference MTF.
+- Checked in:
+  - `algo/deadleaf_13b10_imatest_intrinsic_full_reference_profile.json`
+  - `artifacts/imatest_parity_intrinsic_full_reference_psd_benchmark.json`
+  - `artifacts/imatest_parity_intrinsic_full_reference_benchmark.json`
+
+## Why this family
+
+Issue `#31` asked for the next source-backed model family after the registration / reference-anchor sweep in PR `#30` plateaued.
+
+PR `#32` then tested a stronger matched-`ori` OECF proxy and left the top-line metrics unchanged, which ruled out spending more time on that family. The black-box research notes still identified intrinsic / full-reference dead-leaves behavior as a plausible missing family, so this issue implements one bounded slice of that path.
+
+## Result
+
+Current best PR `#30` branch:
+
+- `curve_mae_mean = 0.03683438`
+- `acutance_focus_preset_mae_mean = 0.04249131`
+- `overall_quality_loss_mae_mean = 1.22214341`
+
+PR `#32` matched-`ori` OECF proxy result:
+
+- `curve_mae_mean = 0.03683438`
+- `acutance_focus_preset_mae_mean = 0.04249131`
+- `overall_quality_loss_mae_mean = 1.22214341`
+
+Intrinsic / full-reference prototype:
+
+- `curve_mae_mean = 0.03587346`
+- `acutance_focus_preset_mae_mean = 0.03165223`
+- `overall_quality_loss_mae_mean = 4.56800916`
+
+Relative to both PR `#30` and PR `#32`, this intrinsic slice:
+
+- improves `curve_mae_mean`
+- improves the focus-preset Acutance mean
+- improves every non-Phone Acutance preset MAE
+- slightly worsens the Phone preset
+- regresses `overall_quality_loss_mae_mean` sharply
+
+Preset-level Acutance comparison against the PR `#30` / PR `#32` control:
+
+- `5.5" Phone Display Acutance`: `0.01380 -> 0.01955`
+- `Computer Monitor Acutance`: `0.05269 -> 0.03460`
+- `UHDTV Display Acutance`: `0.04794 -> 0.03626`
+- `Small Print Acutance`: `0.04670 -> 0.03236`
+- `Large Print Acutance`: `0.05132 -> 0.03549`
+
+The PSD benchmark shows the same mixed shape:
+
+- the intrinsic slice improves `curve_mae_mean` from `0.04306442` to `0.03587346`
+- but `mtf_abs_signed_rel_mean` rises from `0.08692956` to `0.20631329`
+
+## Conclusion
+
+This is a bounded mixed result, not a new winning replacement for the current PR `#30` branch.
+
+The intrinsic / full-reference family does appear to help the remaining curve and non-Phone Acutance gap, which means the family is more promising than the matched-`ori` OECF proxy tested in PR `#32`. But the current transfer-only formulation breaks the README-facing quality-loss objective badly enough that it should remain experiment-only for now.
+
+The most likely next narrower follow-up, if issue `#29` needs another descendant, is not more local curve tuning. It is a source-backed check on why the intrinsic transfer improves curve / Acutance while destabilizing the quality-loss mapping, for example by isolating whether the remaining miss is the transfer formulation itself or the downstream quality-loss calibration under that new MTF shape.

--- a/tests/test_benchmark_parity_acutance_quality_loss.py
+++ b/tests/test_benchmark_parity_acutance_quality_loss.py
@@ -4,6 +4,7 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import cv2
 import numpy as np
 
 from algo.benchmark_parity_acutance_quality_loss import (
@@ -15,10 +16,12 @@ from algo.benchmark_parity_acutance_quality_loss import (
 )
 from algo.dead_leaves import AcutancePoint, RoiBounds
 from algo.parity_benchmark_common import (
+    align_patch_phase_correlation,
     apply_reference_correction_curve,
     clip_reference_correction_curve,
     derive_reference_acutance_correction_curve,
     derive_reference_correction_curve,
+    derive_intrinsic_transfer_curve,
 )
 from algo.benchmark_parity_psd_mtf import Profile as PsdProfile
 
@@ -227,6 +230,63 @@ class BenchmarkParityAcutanceQualityLossTest(unittest.TestCase):
         )
         np.testing.assert_allclose(positions, [0.25, 0.5])
         np.testing.assert_allclose(correction, [2.0, 0.25])
+
+    def test_phase_correlation_alignment_recovers_simple_translation(self) -> None:
+        rng = np.random.default_rng(123)
+        reference = rng.normal(size=(96, 96)).astype(np.float32)
+        transform = np.array([[1.0, 0.0, 5.0], [0.0, 1.0, -3.0]], dtype=np.float32)
+        observed = cv2.warpAffine(
+            reference,
+            transform,
+            (reference.shape[1], reference.shape[0]),
+            flags=cv2.INTER_LINEAR,
+            borderMode=cv2.BORDER_REFLECT,
+        )
+        aligned, shift, response = align_patch_phase_correlation(reference, observed)
+        self.assertGreater(response, 0.5)
+        self.assertAlmostEqual(shift[0], 5.0, delta=0.5)
+        self.assertAlmostEqual(shift[1], -3.0, delta=0.5)
+        self.assertLess(float(np.mean(np.abs(aligned - reference))), 0.2)
+
+    def test_intrinsic_transfer_curve_is_near_identity_for_registered_translation(self) -> None:
+        rng = np.random.default_rng(123)
+        reference = rng.normal(size=(96, 96)).astype(np.float32)
+        transform = np.array([[1.0, 0.0, 4.0], [0.0, 1.0, 2.0]], dtype=np.float32)
+        observed = cv2.warpAffine(
+            reference,
+            transform,
+            (reference.shape[1], reference.shape[0]),
+            flags=cv2.INTER_LINEAR,
+            borderMode=cv2.BORDER_REFLECT,
+        )
+        transfer = derive_intrinsic_transfer_curve(
+            reference,
+            observed,
+            bin_centers=np.linspace(0.01, 0.49, 32, dtype=np.float64),
+            normalization_band=(0.01, 0.03),
+            normalization_mode="mean",
+            clip_lo=0.5,
+            clip_hi=1.5,
+            registration_mode="phase_correlation",
+        )
+        self.assertLess(float(np.mean(np.abs(transfer - 1.0))), 0.12)
+
+    def test_intrinsic_transfer_curve_captures_high_frequency_rolloff(self) -> None:
+        rng = np.random.default_rng(123)
+        reference = rng.normal(size=(96, 96)).astype(np.float32)
+        observed = cv2.GaussianBlur(reference, (0, 0), 1.4)
+        transfer = derive_intrinsic_transfer_curve(
+            reference,
+            observed,
+            bin_centers=np.linspace(0.01, 0.49, 32, dtype=np.float64),
+            normalization_band=(0.01, 0.03),
+            normalization_mode="mean",
+            clip_lo=0.5,
+            clip_hi=1.5,
+            registration_mode="phase_correlation",
+        )
+        self.assertGreater(float(np.mean(transfer[:4])), float(np.mean(transfer[-4:])))
+        self.assertLess(float(np.mean(transfer[-4:])), 0.85)
 
     def test_psd_profile_allows_acutance_only_anchor_mode(self) -> None:
         profile = PsdProfile(

--- a/tests/test_benchmark_parity_psd_mtf.py
+++ b/tests/test_benchmark_parity_psd_mtf.py
@@ -44,6 +44,14 @@ class BenchmarkParityPsdMtfTest(unittest.TestCase):
             "OV13b10_AG8_ET5500_deadleaf_12M_40",
         )
 
+    def test_profile_allows_intrinsic_full_reference_mode(self) -> None:
+        profile = Profile(
+            name="test",
+            calibration_file="algo/deadleaf_13b10_psd_calibration.json",
+            intrinsic_full_reference_mode="paired_ori_transfer",
+        )
+        self.assertEqual(profile.intrinsic_full_reference_mode, "paired_ori_transfer")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- adds a bounded intrinsic / full-reference dead-leaves path using paired `ori` captures, phase-correlation registration, and a radial transfer estimate
- adds unit coverage plus a tracked issue-33 profile, benchmark artifacts, and a follow-up note
- records that this family improves curve and non-Phone Acutance gaps relative to PR #30 / PR #32, but is still not a winning replacement because quality-loss error regresses sharply

## Why This PR

Issue #33 is the concrete follow-up chosen after issue #31 and PR #32 ruled out spending more time on matched-`ori` OECF proxies. The black-box research still identified intrinsic / full-reference dead-leaves behavior as a plausible missing model family, so this PR implements one bounded slice of that path instead of reopening the old PR #30 tuning chain.

## Result

Current PR #30 winning branch and PR #32 negative-result control:

- `curve_mae_mean = 0.03683438`
- `acutance_focus_preset_mae_mean = 0.04249131`
- `overall_quality_loss_mae_mean = 1.22214341`

Intrinsic / full-reference prototype:

- `curve_mae_mean = 0.03587346`
- `acutance_focus_preset_mae_mean = 0.03165223`
- `overall_quality_loss_mae_mean = 4.56800916`

So this family is more promising than the matched-`ori` OECF proxy for the remaining curve and non-Phone Acutance gap, but the current transfer-only formulation destabilizes the quality-loss mapping enough that it should remain experiment-only for now.

## Validation

- `python3 -m pytest tests/test_benchmark_parity_acutance_quality_loss.py tests/test_benchmark_parity_psd_mtf.py tests/test_dead_leaves_mtf_compensation.py`
- `python3 -m py_compile algo/parity_benchmark_common.py algo/benchmark_parity_psd_mtf.py algo/benchmark_parity_acutance_quality_loss.py`
- `python3 -m algo.benchmark_parity_psd_mtf 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json algo/deadleaf_13b10_imatest_intrinsic_full_reference_profile.json --output artifacts/imatest_parity_intrinsic_full_reference_psd_benchmark.json`
- `python3 -m algo.benchmark_parity_acutance_quality_loss 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json algo/deadleaf_13b10_imatest_intrinsic_full_reference_profile.json --output artifacts/imatest_parity_intrinsic_full_reference_benchmark.json`

Refs #33
Refs #29
Refs #31
Refs #30
Refs #32