### PR TITLE
Fix stale matched-ori OECF cache keys after PR #34

### DIFF
--- a/algo/benchmark_parity_acutance_quality_loss.py
+++ b/algo/benchmark_parity_acutance_quality_loss.py
@@ -298,7 +298,7 @@ def summarize_profile(
         )
     )
     ori_reference_map = build_ori_reference_map(dataset_root) if use_ori_reference else {}
-    oecf_curve_cache: dict[str, tuple[np.ndarray, np.ndarray]] = {}
+    oecf_curve_cache: dict[tuple[str, str], tuple[np.ndarray, np.ndarray]] = {}
     correction_cache: dict[str, tuple[np.ndarray, np.ndarray]] = {}
     acutance_correction_cache: dict[str, tuple[np.ndarray, np.ndarray]] = {}
     presets = build_acutance_presets(profile.acutance_preset_overrides)
@@ -330,8 +330,9 @@ def summarize_profile(
         )
         roi = choose_roi(profile, reference, image)
         capture_key = capture_key_from_stem(raw_path.stem)
+        oecf_cache_key = (capture_key, raw_path.stem)
         if profile.matched_ori_oecf_reference and capture_key in ori_reference_map:
-            if capture_key not in oecf_curve_cache:
+            if oecf_cache_key not in oecf_curve_cache:
                 ori_csv_path, ori_raw_path = ori_reference_map[capture_key]
                 ori_reference = parse_imatest_random_csv(ori_csv_path)
                 ori_raw = load_raw_u16(ori_raw_path, width, height)
@@ -355,8 +356,8 @@ def summarize_profile(
                     ],
                     quantiles=profile.matched_ori_oecf_quantiles,
                 )
-                oecf_curve_cache[capture_key] = (source_values, target_values)
-            source_values, target_values = oecf_curve_cache[capture_key]
+                oecf_curve_cache[oecf_cache_key] = (source_values, target_values)
+            source_values, target_values = oecf_curve_cache[oecf_cache_key]
             image = apply_quantile_transfer_curve(
                 image,
                 source_values,

--- a/algo/benchmark_parity_psd_mtf.py
+++ b/algo/benchmark_parity_psd_mtf.py
@@ -268,7 +268,7 @@ def profile_payload(
         )
     )
     ori_reference_map = build_ori_reference_map(dataset_root) if use_ori_reference else {}
-    oecf_curve_cache: dict[str, tuple[np.ndarray, np.ndarray]] = {}
+    oecf_curve_cache: dict[tuple[str, str], tuple[np.ndarray, np.ndarray]] = {}
     correction_cache: dict[str, tuple[np.ndarray, np.ndarray, np.ndarray]] = {}
     csv_paths = sorted(dataset_root.glob("**/Results/*_R_Random.csv"))
     curve_mae: list[float] = []
@@ -299,8 +299,9 @@ def profile_payload(
         )
         roi = choose_roi(profile, reference, image)
         capture_key = capture_key_from_stem(raw_path.stem)
+        oecf_cache_key = (capture_key, raw_path.stem)
         if profile.matched_ori_oecf_reference and capture_key in ori_reference_map:
-            if capture_key not in oecf_curve_cache:
+            if oecf_cache_key not in oecf_curve_cache:
                 ori_csv_path, ori_raw_path = ori_reference_map[capture_key]
                 ori_reference = parse_imatest_random_csv(ori_csv_path)
                 ori_raw = load_raw_u16(ori_raw_path, width, height)
@@ -324,8 +325,8 @@ def profile_payload(
                     ],
                     quantiles=profile.matched_ori_oecf_quantiles,
                 )
-                oecf_curve_cache[capture_key] = (source_values, target_values)
-            source_values, target_values = oecf_curve_cache[capture_key]
+                oecf_curve_cache[oecf_cache_key] = (source_values, target_values)
+            source_values, target_values = oecf_curve_cache[oecf_cache_key]
             image = apply_quantile_transfer_curve(
                 image,
                 source_values,

--- a/tests/test_benchmark_parity_acutance_quality_loss.py
+++ b/tests/test_benchmark_parity_acutance_quality_loss.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import tempfile
 import unittest
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -12,6 +14,7 @@ from algo.benchmark_parity_acutance_quality_loss import (
     build_parser,
     choose_roi,
     mean_named_metrics,
+    summarize_profile,
 )
 from algo.dead_leaves import AcutancePoint, RoiBounds
 from algo.parity_benchmark_common import (
@@ -360,6 +363,142 @@ class BenchmarkParityAcutanceQualityLossTest(unittest.TestCase):
             profile.matched_ori_acutance_preset_strength_curve_values,
             (1.0, 0.85, 0.45),
         )
+
+    def test_summarize_profile_recomputes_oecf_curve_for_variants_sharing_capture_key(self) -> None:
+        capture_key = "OV13b10_AG8_ET5500_deadleaf_12M_40"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dataset_root = Path(tmpdir)
+            variant_root = dataset_root / "OV13B10_AI_NR_OV13B10_ppqpkl_0.10"
+            results_dir = variant_root / "Results"
+            results_dir.mkdir(parents=True)
+            for suffix in ("variantA", "variantB"):
+                stem = f"{capture_key}_{suffix}"
+                (results_dir / f"{stem}_R_Random.csv").write_text("", encoding="utf-8")
+                (variant_root / f"{stem}.raw").write_bytes(b"")
+
+            acutance_table = [
+                AcutancePoint(print_height_cm=40.0, viewing_distance_cm=10.0, acutance=1.0)
+            ]
+            reported_acutance = {
+                '5.5" Phone Display Acutance': 1.0,
+                "Computer Monitor Acutance": 1.0,
+                "UHDTV Display Acutance": 1.0,
+                "Small Print Acutance": 1.0,
+                "Large Print Acutance": 1.0,
+            }
+            reported_quality_loss = {
+                '5.5" Phone Display Quality Loss': 0.0,
+                "Computer Monitor Quality Loss": 0.0,
+                "UHDTV Display Quality Loss": 0.0,
+                "Small Print Quality Loss": 0.0,
+                "Large Print Quality Loss": 0.0,
+            }
+            reference = SimpleNamespace(
+                lrtb=RoiBounds(left=0, right=1, top=0, bottom=1),
+                acutance_table=acutance_table,
+                reported_acutance=reported_acutance,
+                reported_quality_loss=reported_quality_loss,
+            )
+            estimate = SimpleNamespace(
+                roi=RoiBounds(left=0, right=1, top=0, bottom=1),
+                frequencies_cpp=np.array([0.1, 0.2], dtype=np.float64),
+                mtf_for_acutance=np.array([1.0, 0.8], dtype=np.float64),
+                acutance_high_frequency_noise_share=0.0,
+            )
+            profile = Profile(
+                name="test",
+                calibration_file="calibration.json",
+                roi_source="reference",
+                matched_ori_oecf_reference=True,
+            )
+
+            with (
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.load_ideal_psd_calibration",
+                    return_value=None,
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.build_ori_reference_map",
+                    return_value={capture_key: (dataset_root / "ori.csv", dataset_root / "ori.raw")},
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.parse_imatest_random_csv",
+                    return_value=reference,
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.load_raw_u16",
+                    side_effect=lambda path, width, height: np.zeros((height, width), dtype=np.uint16),
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.extract_analysis_plane",
+                    side_effect=lambda raw, **_: raw,
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.normalize_for_analysis",
+                    side_effect=lambda plane, **_: plane,
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.derive_quantile_transfer_curve",
+                    side_effect=[
+                        (np.array([0.0, 1.0]), np.array([0.0, 0.8])),
+                        (np.array([0.0, 1.0]), np.array([0.0, 0.6])),
+                    ],
+                ) as derive_curve,
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.apply_quantile_transfer_curve",
+                    side_effect=lambda image, *_args, **_kwargs: image,
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.estimate_dead_leaves_mtf",
+                    return_value=estimate,
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.apply_mtf_compensation",
+                    side_effect=lambda mtf, freqs, **_: (
+                        np.asarray(mtf, dtype=np.float64),
+                        np.asarray(freqs, dtype=np.float64),
+                    ),
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.apply_mtf_shape_correction",
+                    side_effect=lambda mtf, freqs, **_: (
+                        np.asarray(mtf, dtype=np.float64),
+                        np.asarray(freqs, dtype=np.float64),
+                    ),
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.acutance_curve_from_mtf",
+                    return_value=acutance_table,
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.acutance_presets_from_mtf",
+                    return_value=reported_acutance,
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.compare_acutance_curves",
+                    return_value={"count": 1, "mae": 0.0},
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.compare_acutance_presets",
+                    side_effect=lambda _estimate, _reference: {
+                        name: {"abs_error": 0.0, "estimate": value, "reference": value}
+                        for name, value in reported_acutance.items()
+                    },
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.quality_loss_presets_from_acutance",
+                    return_value=reported_quality_loss,
+                ),
+            ):
+                summarize_profile(
+                    dataset_root=dataset_root,
+                    profile_path=dataset_root / "profile.json",
+                    profile=profile,
+                    width=2,
+                    height=2,
+                )
+
+            self.assertEqual(derive_curve.call_count, 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_benchmark_parity_psd_mtf.py
+++ b/tests/test_benchmark_parity_psd_mtf.py
@@ -1,13 +1,21 @@
 from __future__ import annotations
 
+import tempfile
 import unittest
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
 import numpy as np
 
-from algo.benchmark_parity_psd_mtf import Profile, band_error_summary, choose_roi, resample_curve
-from algo.dead_leaves import RoiBounds
+from algo.benchmark_parity_psd_mtf import (
+    Profile,
+    band_error_summary,
+    choose_roi,
+    profile_payload,
+    resample_curve,
+)
+from algo.dead_leaves import AcutancePoint, RoiBounds
 from algo.parity_benchmark_common import capture_key_from_stem
 
 
@@ -43,6 +51,95 @@ class BenchmarkParityPsdMtfTest(unittest.TestCase):
             capture_key_from_stem("OV13b10_AG8_ET5500_deadleaf_12M_40_denoised_A_model_mixup04"),
             "OV13b10_AG8_ET5500_deadleaf_12M_40",
         )
+
+    def test_profile_payload_recomputes_oecf_curve_for_variants_sharing_capture_key(self) -> None:
+        capture_key = "OV13b10_AG8_ET5500_deadleaf_12M_40"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dataset_root = Path(tmpdir)
+            variant_root = dataset_root / "OV13B10_AI_NR_OV13B10_ppqpkl_0.10"
+            results_dir = variant_root / "Results"
+            results_dir.mkdir(parents=True)
+            for suffix in ("variantA", "variantB"):
+                stem = f"{capture_key}_{suffix}"
+                (results_dir / f"{stem}_R_Random.csv").write_text("", encoding="utf-8")
+                (variant_root / f"{stem}.raw").write_bytes(b"")
+
+            reference = SimpleNamespace(
+                lrtb=RoiBounds(left=0, right=1, top=0, bottom=1),
+                frequencies_cpp=np.array([0.02, 0.1, 0.25, 0.4], dtype=np.float64),
+                mtf=np.array([1.0, 0.9, 0.8, 0.7], dtype=np.float64),
+                acutance_table=[
+                    AcutancePoint(print_height_cm=40.0, viewing_distance_cm=10.0, acutance=1.0)
+                ],
+                reported_acutance={'5.5" Phone Display Acutance': 1.0},
+            )
+            estimate = SimpleNamespace(
+                roi=RoiBounds(left=0, right=1, top=0, bottom=1),
+                frequencies_cpp=np.array([0.02, 0.1, 0.25, 0.4], dtype=np.float64),
+                mtf=np.array([1.0, 0.9, 0.8, 0.7], dtype=np.float64),
+                mtf_for_acutance=np.array([1.0, 0.9, 0.8, 0.7], dtype=np.float64),
+            )
+            profile = Profile(
+                name="test",
+                calibration_file="calibration.json",
+                roi_source="reference",
+                matched_ori_oecf_reference=True,
+            )
+
+            with (
+                patch("algo.benchmark_parity_psd_mtf.load_ideal_psd_calibration", return_value=None),
+                patch(
+                    "algo.benchmark_parity_psd_mtf.build_ori_reference_map",
+                    return_value={capture_key: (dataset_root / "ori.csv", dataset_root / "ori.raw")},
+                ),
+                patch("algo.benchmark_parity_psd_mtf.parse_imatest_random_csv", return_value=reference),
+                patch(
+                    "algo.benchmark_parity_psd_mtf.load_raw_u16",
+                    side_effect=lambda path, width, height: np.zeros((height, width), dtype=np.uint16),
+                ),
+                patch("algo.benchmark_parity_psd_mtf.extract_analysis_plane", side_effect=lambda raw, **_: raw),
+                patch("algo.benchmark_parity_psd_mtf.normalize_for_analysis", side_effect=lambda plane, **_: plane),
+                patch(
+                    "algo.benchmark_parity_psd_mtf.derive_quantile_transfer_curve",
+                    side_effect=[
+                        (np.array([0.0, 1.0]), np.array([0.0, 0.8])),
+                        (np.array([0.0, 1.0]), np.array([0.0, 0.6])),
+                    ],
+                ) as derive_curve,
+                patch(
+                    "algo.benchmark_parity_psd_mtf.apply_quantile_transfer_curve",
+                    side_effect=lambda image, *_args, **_kwargs: image,
+                ),
+                patch("algo.benchmark_parity_psd_mtf.estimate_dead_leaves_mtf", return_value=estimate),
+                patch(
+                    "algo.benchmark_parity_psd_mtf.apply_mtf_compensation",
+                    side_effect=lambda mtf, freqs, **_: (
+                        np.asarray(mtf, dtype=np.float64),
+                        np.asarray(freqs, dtype=np.float64),
+                    ),
+                ),
+                patch(
+                    "algo.benchmark_parity_psd_mtf.compute_mtf_metrics",
+                    return_value=SimpleNamespace(mtf50=0.1, mtf30=0.1, mtf20=0.1),
+                ),
+                patch("algo.benchmark_parity_psd_mtf.interpolate_threshold", return_value=0.1),
+                patch("algo.benchmark_parity_psd_mtf.acutance_curve_from_mtf", return_value=reference.acutance_table),
+                patch("algo.benchmark_parity_psd_mtf.compare_acutance_curves", return_value={"count": 1, "mae": 0.0}),
+                patch("algo.benchmark_parity_psd_mtf.acutance_presets_from_mtf", return_value=reference.reported_acutance),
+                patch(
+                    "algo.benchmark_parity_psd_mtf.compare_acutance_presets",
+                    return_value={'5.5" Phone Display Acutance': {"abs_error": 0.0}},
+                ),
+            ):
+                profile_payload(
+                    dataset_root=dataset_root,
+                    profile_path=dataset_root / "profile.json",
+                    profile=profile,
+                    width=2,
+                    height=2,
+                )
+
+            self.assertEqual(derive_curve.call_count, 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- fixes the stale matched-`ori` OECF cache bug in both parity benchmark entrypoints by keying the transfer-curve cache per processed variant instead of only per scene capture key
- adds regression coverage for both PSD and acutance/quality-loss benchmark paths using two non-`ori` variants that share the same capture key
- keeps the intrinsic/full-reference issue-33 branch conclusions intact while making the carried matched-`ori` path safe for re-use

## Why This PR

PR #34 carried forward the matched-`ori` OECF helper path from PR #32. An owner follow-up comment on PR #34 pointed out that the OECF transfer cache was keyed only by `capture_key`, even though `derive_quantile_transfer_curve(...)` depends on the current processed ROI as well as the paired `ori` ROI. On this dataset the same capture key is reused across multiple processed variants, so later variants could reuse the wrong source-side transfer curve.

This PR fixes that carried bug on top of the merged issue-33 baseline.

## Validation

- `python3 -m pytest tests/test_benchmark_parity_acutance_quality_loss.py tests/test_benchmark_parity_psd_mtf.py tests/test_dead_leaves_mtf_compensation.py`
- `python3 -m py_compile algo/parity_benchmark_common.py algo/benchmark_parity_psd_mtf.py algo/benchmark_parity_acutance_quality_loss.py`

## Notes

- I rechecked the intrinsic full-reference artifact files after the fix; the checked-in issue-33 metrics remain aligned with `docs/imatest_parity_intrinsic_full_reference_followup.md`, so this PR only changes code and regression tests.

Refs #33
Refs #29
Refs #30
Refs #32
