### PR TITLE
Issue #37: Prototype acutance-side-only intrinsic/full-reference follow-up

### DIFF
--- a/algo/benchmark_parity_acutance_quality_loss.py
+++ b/algo/benchmark_parity_acutance_quality_loss.py
@@ -86,6 +86,7 @@ class Profile:
     roi_refine_step: int = 2
     roi_refine_area_tolerance: float = 0.98
     intrinsic_full_reference_mode: str = "none"
+    intrinsic_full_reference_scope: str = "replace_all"
     intrinsic_full_reference_clip_lo: float = 0.5
     intrinsic_full_reference_clip_hi: float = 1.5
     intrinsic_full_reference_registration_mode: str = "phase_correlation"
@@ -318,6 +319,219 @@ def summarize_profile(
     acutance_records: list[dict[str, object]] = []
     quality_loss_records: list[dict[str, object]] = []
 
+    def maybe_anchor_acutance_results(
+        *,
+        capture_key: str,
+        curve: list[AcutancePoint],
+        acutance: dict[str, float],
+        roi_height: int,
+    ) -> tuple[list[AcutancePoint], dict[str, float]]:
+        if not profile.matched_ori_acutance_reference_anchor:
+            return curve, acutance
+        if capture_key not in ori_reference_map:
+            return curve, acutance
+        if capture_key not in acutance_correction_cache:
+            ori_csv_path, ori_raw_path = ori_reference_map[capture_key]
+            ori_reference = parse_imatest_random_csv(ori_csv_path)
+            ori_raw = load_raw_u16(ori_raw_path, width, height)
+            ori_plane = extract_analysis_plane(
+                ori_raw,
+                bayer_pattern=BayerPattern(profile.bayer_pattern),
+                mode=BayerMode(profile.bayer_mode),
+            )
+            ori_image = normalize_for_analysis(
+                ori_plane,
+                gamma=profile.gamma,
+                mode=profile.linearization_mode,
+                toe=profile.linearization_toe,
+            )
+            ori_roi = choose_roi(profile, ori_reference, ori_image)
+            ori_estimate = estimate_dead_leaves_mtf(
+                ori_image,
+                num_bins=len(IMATEST_REFERENCE_BINS),
+                ideal_psd_mode="calibrated_log",
+                ideal_psd_calibration=calibration,
+                bin_centers=IMATEST_REFERENCE_BINS,
+                roi_override=ori_roi,
+                normalization_band=(profile.normalization_band_lo, profile.normalization_band_hi),
+                normalization_mode=profile.normalization_mode,
+                acutance_reference_band=(profile.acutance_band_lo, profile.acutance_band_hi),
+                acutance_reference_mode=profile.acutance_band_mode,
+                signal_psd_correction_gain=profile.signal_psd_correction_gain,
+                signal_psd_correction_start_cpp=profile.signal_psd_correction_start_cpp,
+                signal_psd_correction_peak_cpp=profile.signal_psd_correction_peak_cpp,
+                signal_psd_correction_stop_cpp=profile.signal_psd_correction_stop_cpp,
+                noise_psd_model=profile.noise_psd_model,
+                noise_psd_log_polynomial_degree=profile.noise_psd_log_polynomial_degree,
+                noise_psd_scale=profile.noise_psd_scale,
+                noise_psd_scale_for_acutance=profile.noise_psd_scale_for_acutance,
+                acutance_noise_scale_model=profile.acutance_noise_scale_mode,
+                acutance_noise_share_band=(
+                    profile.acutance_noise_share_band_lo,
+                    profile.acutance_noise_share_band_hi,
+                ),
+                acutance_noise_share_scale_coefficients=tuple(
+                    profile.acutance_noise_share_scale_coefficients
+                ),
+                high_frequency_guard_start_cpp=profile.high_frequency_guard_start_cpp,
+                high_frequency_guard_stop_cpp=profile.high_frequency_guard_stop_cpp,
+            )
+            ori_frequency_scale = profile.frequency_scale
+            if profile.texture_support_scale:
+                ori_crop = ori_image[
+                    ori_estimate.roi.top : ori_estimate.roi.bottom + 1,
+                    ori_estimate.roi.left : ori_estimate.roi.right + 1,
+                ]
+                ori_frequency_scale *= estimate_texture_support_scale(
+                    ori_crop,
+                    percentile=45.0,
+                ).frequency_scale
+            ori_scaled_frequencies = apply_frequency_scale(
+                ori_estimate.frequencies_cpp,
+                scale=ori_frequency_scale,
+            )
+            ori_compensated_mtf_for_acutance, _ = apply_mtf_compensation(
+                ori_estimate.mtf_for_acutance,
+                ori_scaled_frequencies,
+                mode=profile.mtf_compensation_mode,
+                sensor_fill_factor=profile.sensor_fill_factor,
+                denominator_clip=profile.compensation_denominator_clip,
+                max_gain=profile.compensation_max_gain,
+            )
+            ori_corrected_mtf_for_acutance, _ = apply_mtf_shape_correction(
+                ori_compensated_mtf_for_acutance,
+                ori_scaled_frequencies,
+                mode=profile.mtf_shape_correction_mode,
+                high_frequency_noise_share=ori_estimate.acutance_high_frequency_noise_share,
+                gain=profile.mtf_shape_correction_gain,
+                share_gate_lo=profile.mtf_shape_correction_share_gate_lo,
+                share_gate_hi=profile.mtf_shape_correction_share_gate_hi,
+                mid_start_cpp=profile.mtf_shape_correction_mid_start_cpp,
+                mid_peak_cpp=profile.mtf_shape_correction_mid_peak_cpp,
+                mid_stop_cpp=profile.mtf_shape_correction_mid_stop_cpp,
+                high_start_cpp=profile.mtf_shape_correction_high_start_cpp,
+                high_peak_cpp=profile.mtf_shape_correction_high_peak_cpp,
+                high_stop_cpp=profile.mtf_shape_correction_high_stop_cpp,
+                high_weight=profile.mtf_shape_correction_high_weight,
+            )
+            ori_curve = acutance_curve_from_mtf(
+                ori_scaled_frequencies,
+                ori_corrected_mtf_for_acutance,
+                picture_height_cm=40.0,
+                viewing_distances_cm=np.arange(1.0, 101.0, 1.0),
+                pixels_along_picture_height=roi_height,
+            )
+            acutance_correction_cache[capture_key] = derive_reference_acutance_correction_curve(
+                ori_reference.acutance_table,
+                ori_curve,
+                clip_lo=None,
+                clip_hi=None,
+            )
+        correction_positions, correction_curve = acutance_correction_cache[capture_key]
+        curve_positions = np.asarray(
+            [
+                point.viewing_distance_cm / max(point.print_height_cm, 1e-12)
+                for point in curve
+            ],
+            dtype=np.float64,
+        )
+        curve_correction_curve = clip_reference_correction_curve(
+            curve_positions,
+            correction_curve,
+            clip_lo=(
+                profile.matched_ori_acutance_curve_correction_clip_lo
+                if profile.matched_ori_acutance_curve_correction_clip_lo is not None
+                else profile.matched_ori_acutance_correction_clip_lo
+            ),
+            clip_hi=(
+                profile.matched_ori_acutance_curve_correction_clip_hi
+                if profile.matched_ori_acutance_curve_correction_clip_hi is not None
+                else profile.matched_ori_acutance_correction_clip_hi
+            ),
+            clip_lo_positions=profile.matched_ori_acutance_curve_correction_clip_lo_relative_scales,
+            clip_lo_values=profile.matched_ori_acutance_curve_correction_clip_lo_values,
+            clip_hi_positions=profile.matched_ori_acutance_curve_correction_clip_hi_relative_scales,
+            clip_hi_values=profile.matched_ori_acutance_curve_correction_clip_hi_values,
+        )
+        corrected_curve_values = apply_reference_correction_curve(
+            curve_positions,
+            np.asarray([point.acutance for point in curve], dtype=np.float64),
+            correction_positions,
+            curve_correction_curve,
+            strength=profile.matched_ori_acutance_correction_strength,
+            blend_start_cpp=profile.matched_ori_acutance_blend_start_relative_scale,
+            blend_stop_cpp=profile.matched_ori_acutance_blend_stop_relative_scale,
+            strength_curve_frequencies=profile.matched_ori_acutance_strength_curve_relative_scales,
+            strength_curve_values=profile.matched_ori_acutance_strength_curve_values,
+            correction_delta_power=(
+                profile.matched_ori_acutance_curve_correction_delta_power
+                if profile.matched_ori_acutance_curve_correction_delta_power is not None
+                else profile.matched_ori_acutance_correction_delta_power
+            ),
+        )
+        anchored_curve = [
+            point.__class__(
+                print_height_cm=point.print_height_cm,
+                viewing_distance_cm=point.viewing_distance_cm,
+                acutance=float(value),
+            )
+            for point, value in zip(curve, corrected_curve_values)
+        ]
+        preset_positions = np.asarray(
+            [preset.viewing_distance_cm / preset.picture_height_cm for preset in presets],
+            dtype=np.float64,
+        )
+        corrected_preset_values = apply_reference_correction_curve(
+            preset_positions,
+            np.asarray([acutance[preset.name] for preset in presets], dtype=np.float64),
+            correction_positions,
+            clip_reference_correction_curve(
+                correction_positions,
+                correction_curve,
+                clip_lo=(
+                    profile.matched_ori_acutance_preset_correction_clip_lo
+                    if profile.matched_ori_acutance_preset_correction_clip_lo is not None
+                    else profile.matched_ori_acutance_correction_clip_lo
+                ),
+                clip_hi=(
+                    profile.matched_ori_acutance_preset_correction_clip_hi
+                    if profile.matched_ori_acutance_preset_correction_clip_hi is not None
+                    else profile.matched_ori_acutance_correction_clip_hi
+                ),
+                clip_lo_positions=profile.matched_ori_acutance_preset_correction_clip_lo_relative_scales,
+                clip_lo_values=profile.matched_ori_acutance_preset_correction_clip_lo_values,
+                clip_hi_positions=profile.matched_ori_acutance_preset_correction_clip_hi_relative_scales,
+                clip_hi_values=profile.matched_ori_acutance_preset_correction_clip_hi_values,
+            ),
+            strength=profile.matched_ori_acutance_correction_strength,
+            blend_start_cpp=profile.matched_ori_acutance_blend_start_relative_scale,
+            blend_stop_cpp=profile.matched_ori_acutance_blend_stop_relative_scale,
+            strength_curve_frequencies=(
+                profile.matched_ori_acutance_preset_strength_curve_relative_scales
+                or profile.matched_ori_acutance_strength_curve_relative_scales
+            ),
+            strength_curve_values=(
+                profile.matched_ori_acutance_preset_strength_curve_values
+                or profile.matched_ori_acutance_strength_curve_values
+            ),
+            correction_delta_power=(
+                profile.matched_ori_acutance_preset_correction_delta_power
+                if profile.matched_ori_acutance_preset_correction_delta_power is not None
+                else profile.matched_ori_acutance_correction_delta_power
+            ),
+            correction_delta_power_positions=(
+                profile.matched_ori_acutance_preset_correction_delta_power_relative_scales
+            ),
+            correction_delta_power_values=(
+                profile.matched_ori_acutance_preset_correction_delta_power_values
+            ),
+        )
+        anchored_acutance = {
+            preset.name: float(value)
+            for preset, value in zip(presets, corrected_preset_values)
+        }
+        return anchored_curve, anchored_acutance
+
     for csv_path in csv_paths:
         raw_path = csv_path.parent.parent / csv_path.name.replace("_R_Random.csv", ".raw")
         if not raw_path.exists():
@@ -423,10 +637,19 @@ def summarize_profile(
             denominator_clip=profile.compensation_denominator_clip,
             max_gain=profile.compensation_max_gain,
         )
+        quality_loss_scaled_frequencies = np.asarray(scaled_frequencies, dtype=np.float64).copy()
+        quality_loss_compensated_mtf_for_acutance = np.asarray(
+            compensated_mtf_for_acutance,
+            dtype=np.float64,
+        ).copy()
         if profile.intrinsic_full_reference_mode != "none":
             if profile.intrinsic_full_reference_mode != "paired_ori_transfer":
                 raise ValueError(
                     f"Unsupported intrinsic full-reference mode: {profile.intrinsic_full_reference_mode}"
+                )
+            if profile.intrinsic_full_reference_scope not in {"replace_all", "acutance_only"}:
+                raise ValueError(
+                    f"Unsupported intrinsic full-reference scope: {profile.intrinsic_full_reference_scope}"
                 )
             capture_key = capture_key_from_stem(raw_path.stem)
             if capture_key in ori_reference_map:
@@ -473,6 +696,9 @@ def summarize_profile(
                 compensated_mtf_for_acutance = (
                     np.asarray(ori_reference.mtf, dtype=np.float64) * transfer_curve
                 )
+                if profile.intrinsic_full_reference_scope == "replace_all":
+                    quality_loss_scaled_frequencies = scaled_frequencies.copy()
+                    quality_loss_compensated_mtf_for_acutance = compensated_mtf_for_acutance.copy()
         if profile.matched_ori_reference_anchor:
             if capture_key in ori_reference_map:
                 if capture_key not in correction_cache:
@@ -570,9 +796,40 @@ def summarize_profile(
                     strength_curve_frequencies=profile.matched_ori_strength_curve_frequencies,
                     strength_curve_values=profile.matched_ori_strength_curve_values,
                 )
+                quality_loss_compensated_mtf_for_acutance = apply_reference_correction_curve(
+                    quality_loss_scaled_frequencies,
+                    quality_loss_compensated_mtf_for_acutance,
+                    correction_frequencies,
+                    correction_curve,
+                    strength=profile.matched_ori_correction_strength,
+                    blend_start_cpp=profile.matched_ori_blend_start_cpp,
+                    blend_stop_cpp=profile.matched_ori_blend_stop_cpp,
+                    strength_low=profile.matched_ori_strength_low,
+                    strength_high=profile.matched_ori_strength_high,
+                    strength_ramp_start_cpp=profile.matched_ori_strength_ramp_start_cpp,
+                    strength_ramp_stop_cpp=profile.matched_ori_strength_ramp_stop_cpp,
+                    strength_curve_frequencies=profile.matched_ori_strength_curve_frequencies,
+                    strength_curve_values=profile.matched_ori_strength_curve_values,
+                )
         corrected_mtf_for_acutance, _ = apply_mtf_shape_correction(
             compensated_mtf_for_acutance,
             scaled_frequencies,
+            mode=profile.mtf_shape_correction_mode,
+            high_frequency_noise_share=estimate.acutance_high_frequency_noise_share,
+            gain=profile.mtf_shape_correction_gain,
+            share_gate_lo=profile.mtf_shape_correction_share_gate_lo,
+            share_gate_hi=profile.mtf_shape_correction_share_gate_hi,
+            mid_start_cpp=profile.mtf_shape_correction_mid_start_cpp,
+            mid_peak_cpp=profile.mtf_shape_correction_mid_peak_cpp,
+            mid_stop_cpp=profile.mtf_shape_correction_mid_stop_cpp,
+            high_start_cpp=profile.mtf_shape_correction_high_start_cpp,
+            high_peak_cpp=profile.mtf_shape_correction_high_peak_cpp,
+            high_stop_cpp=profile.mtf_shape_correction_high_stop_cpp,
+            high_weight=profile.mtf_shape_correction_high_weight,
+        )
+        quality_loss_corrected_mtf_for_acutance, _ = apply_mtf_shape_correction(
+            quality_loss_compensated_mtf_for_acutance,
+            quality_loss_scaled_frequencies,
             mode=profile.mtf_shape_correction_mode,
             high_frequency_noise_share=estimate.acutance_high_frequency_noise_share,
             gain=profile.mtf_shape_correction_gain,
@@ -599,218 +856,37 @@ def summarize_profile(
             pixels_along_picture_height=estimate.roi.height,
             presets=presets,
         )
-        if profile.matched_ori_acutance_reference_anchor:
-            if capture_key in ori_reference_map:
-                if capture_key not in acutance_correction_cache:
-                    ori_csv_path, ori_raw_path = ori_reference_map[capture_key]
-                    ori_reference = parse_imatest_random_csv(ori_csv_path)
-                    ori_raw = load_raw_u16(ori_raw_path, width, height)
-                    ori_plane = extract_analysis_plane(
-                        ori_raw,
-                        bayer_pattern=BayerPattern(profile.bayer_pattern),
-                        mode=BayerMode(profile.bayer_mode),
-                    )
-                    ori_image = normalize_for_analysis(
-                        ori_plane,
-                        gamma=profile.gamma,
-                        mode=profile.linearization_mode,
-                        toe=profile.linearization_toe,
-                    )
-                    ori_roi = choose_roi(profile, ori_reference, ori_image)
-                    ori_estimate = estimate_dead_leaves_mtf(
-                        ori_image,
-                        num_bins=len(IMATEST_REFERENCE_BINS),
-                        ideal_psd_mode="calibrated_log",
-                        ideal_psd_calibration=calibration,
-                        bin_centers=IMATEST_REFERENCE_BINS,
-                        roi_override=ori_roi,
-                        normalization_band=(profile.normalization_band_lo, profile.normalization_band_hi),
-                        normalization_mode=profile.normalization_mode,
-                        acutance_reference_band=(profile.acutance_band_lo, profile.acutance_band_hi),
-                        acutance_reference_mode=profile.acutance_band_mode,
-                        signal_psd_correction_gain=profile.signal_psd_correction_gain,
-                        signal_psd_correction_start_cpp=profile.signal_psd_correction_start_cpp,
-                        signal_psd_correction_peak_cpp=profile.signal_psd_correction_peak_cpp,
-                        signal_psd_correction_stop_cpp=profile.signal_psd_correction_stop_cpp,
-                        noise_psd_model=profile.noise_psd_model,
-                        noise_psd_log_polynomial_degree=profile.noise_psd_log_polynomial_degree,
-                        noise_psd_scale=profile.noise_psd_scale,
-                        noise_psd_scale_for_acutance=profile.noise_psd_scale_for_acutance,
-                        acutance_noise_scale_model=profile.acutance_noise_scale_mode,
-                        acutance_noise_share_band=(
-                            profile.acutance_noise_share_band_lo,
-                            profile.acutance_noise_share_band_hi,
-                        ),
-                        acutance_noise_share_scale_coefficients=tuple(
-                            profile.acutance_noise_share_scale_coefficients
-                        ),
-                        high_frequency_guard_start_cpp=profile.high_frequency_guard_start_cpp,
-                        high_frequency_guard_stop_cpp=profile.high_frequency_guard_stop_cpp,
-                    )
-                    ori_frequency_scale = profile.frequency_scale
-                    if profile.texture_support_scale:
-                        ori_crop = ori_image[
-                            ori_estimate.roi.top : ori_estimate.roi.bottom + 1,
-                            ori_estimate.roi.left : ori_estimate.roi.right + 1,
-                        ]
-                        ori_frequency_scale *= estimate_texture_support_scale(
-                            ori_crop,
-                            percentile=45.0,
-                        ).frequency_scale
-                    ori_scaled_frequencies = apply_frequency_scale(
-                        ori_estimate.frequencies_cpp,
-                        scale=ori_frequency_scale,
-                    )
-                    ori_compensated_mtf_for_acutance, _ = apply_mtf_compensation(
-                        ori_estimate.mtf_for_acutance,
-                        ori_scaled_frequencies,
-                        mode=profile.mtf_compensation_mode,
-                        sensor_fill_factor=profile.sensor_fill_factor,
-                        denominator_clip=profile.compensation_denominator_clip,
-                        max_gain=profile.compensation_max_gain,
-                    )
-                    ori_corrected_mtf_for_acutance, _ = apply_mtf_shape_correction(
-                        ori_compensated_mtf_for_acutance,
-                        ori_scaled_frequencies,
-                        mode=profile.mtf_shape_correction_mode,
-                        high_frequency_noise_share=ori_estimate.acutance_high_frequency_noise_share,
-                        gain=profile.mtf_shape_correction_gain,
-                        share_gate_lo=profile.mtf_shape_correction_share_gate_lo,
-                        share_gate_hi=profile.mtf_shape_correction_share_gate_hi,
-                        mid_start_cpp=profile.mtf_shape_correction_mid_start_cpp,
-                        mid_peak_cpp=profile.mtf_shape_correction_mid_peak_cpp,
-                        mid_stop_cpp=profile.mtf_shape_correction_mid_stop_cpp,
-                        high_start_cpp=profile.mtf_shape_correction_high_start_cpp,
-                        high_peak_cpp=profile.mtf_shape_correction_high_peak_cpp,
-                        high_stop_cpp=profile.mtf_shape_correction_high_stop_cpp,
-                        high_weight=profile.mtf_shape_correction_high_weight,
-                    )
-                    ori_curve = acutance_curve_from_mtf(
-                        ori_scaled_frequencies,
-                        ori_corrected_mtf_for_acutance,
-                        picture_height_cm=40.0,
-                        viewing_distances_cm=np.arange(1.0, 101.0, 1.0),
-                        pixels_along_picture_height=ori_estimate.roi.height,
-                    )
-                    acutance_correction_cache[capture_key] = (
-                        derive_reference_acutance_correction_curve(
-                            ori_reference.acutance_table,
-                            ori_curve,
-                            clip_lo=None,
-                            clip_hi=None,
-                        )
-                    )
-                correction_positions, correction_curve = acutance_correction_cache[capture_key]
-                curve_positions = np.asarray(
-                    [
-                        point.viewing_distance_cm / max(point.print_height_cm, 1e-12)
-                        for point in curve
-                    ],
-                    dtype=np.float64,
-                )
-                curve_correction_curve = clip_reference_correction_curve(
-                    curve_positions,
-                    correction_curve,
-                    clip_lo=(
-                        profile.matched_ori_acutance_curve_correction_clip_lo
-                        if profile.matched_ori_acutance_curve_correction_clip_lo is not None
-                        else profile.matched_ori_acutance_correction_clip_lo
-                    ),
-                    clip_hi=(
-                        profile.matched_ori_acutance_curve_correction_clip_hi
-                        if profile.matched_ori_acutance_curve_correction_clip_hi is not None
-                        else profile.matched_ori_acutance_correction_clip_hi
-                    ),
-                    clip_lo_positions=(
-                        profile.matched_ori_acutance_curve_correction_clip_lo_relative_scales
-                    ),
-                    clip_lo_values=profile.matched_ori_acutance_curve_correction_clip_lo_values,
-                    clip_hi_positions=profile.matched_ori_acutance_curve_correction_clip_hi_relative_scales,
-                    clip_hi_values=profile.matched_ori_acutance_curve_correction_clip_hi_values,
-                )
-                corrected_curve_values = apply_reference_correction_curve(
-                    curve_positions,
-                    np.asarray([point.acutance for point in curve], dtype=np.float64),
-                    correction_positions,
-                    curve_correction_curve,
-                    strength=profile.matched_ori_acutance_correction_strength,
-                    blend_start_cpp=profile.matched_ori_acutance_blend_start_relative_scale,
-                    blend_stop_cpp=profile.matched_ori_acutance_blend_stop_relative_scale,
-                    strength_curve_frequencies=profile.matched_ori_acutance_strength_curve_relative_scales,
-                    strength_curve_values=profile.matched_ori_acutance_strength_curve_values,
-                    correction_delta_power=(
-                        profile.matched_ori_acutance_curve_correction_delta_power
-                        if profile.matched_ori_acutance_curve_correction_delta_power is not None
-                        else profile.matched_ori_acutance_correction_delta_power
-                    ),
-                )
-                curve = [
-                    point.__class__(
-                        print_height_cm=point.print_height_cm,
-                        viewing_distance_cm=point.viewing_distance_cm,
-                        acutance=float(value),
-                    )
-                    for point, value in zip(curve, corrected_curve_values)
-                ]
-                preset_positions = np.asarray(
-                    [preset.viewing_distance_cm / preset.picture_height_cm for preset in presets],
-                    dtype=np.float64,
-                )
-                corrected_preset_values = apply_reference_correction_curve(
-                    preset_positions,
-                    np.asarray([acutance[preset.name] for preset in presets], dtype=np.float64),
-                    correction_positions,
-                    clip_reference_correction_curve(
-                        correction_positions,
-                        correction_curve,
-                        clip_lo=(
-                            profile.matched_ori_acutance_preset_correction_clip_lo
-                            if profile.matched_ori_acutance_preset_correction_clip_lo is not None
-                            else profile.matched_ori_acutance_correction_clip_lo
-                        ),
-                        clip_hi=(
-                            profile.matched_ori_acutance_preset_correction_clip_hi
-                            if profile.matched_ori_acutance_preset_correction_clip_hi is not None
-                            else profile.matched_ori_acutance_correction_clip_hi
-                        ),
-                        clip_lo_positions=(
-                            profile.matched_ori_acutance_preset_correction_clip_lo_relative_scales
-                        ),
-                        clip_lo_values=(
-                            profile.matched_ori_acutance_preset_correction_clip_lo_values
-                        ),
-                        clip_hi_positions=(
-                            profile.matched_ori_acutance_preset_correction_clip_hi_relative_scales
-                        ),
-                        clip_hi_values=profile.matched_ori_acutance_preset_correction_clip_hi_values,
-                    ),
-                    strength=profile.matched_ori_acutance_correction_strength,
-                    blend_start_cpp=profile.matched_ori_acutance_blend_start_relative_scale,
-                    blend_stop_cpp=profile.matched_ori_acutance_blend_stop_relative_scale,
-                    strength_curve_frequencies=(
-                        profile.matched_ori_acutance_preset_strength_curve_relative_scales
-                        or profile.matched_ori_acutance_strength_curve_relative_scales
-                    ),
-                    strength_curve_values=(
-                        profile.matched_ori_acutance_preset_strength_curve_values
-                        or profile.matched_ori_acutance_strength_curve_values
-                    ),
-                    correction_delta_power=(
-                        profile.matched_ori_acutance_preset_correction_delta_power
-                        if profile.matched_ori_acutance_preset_correction_delta_power is not None
-                        else profile.matched_ori_acutance_correction_delta_power
-                    ),
-                    correction_delta_power_positions=(
-                        profile.matched_ori_acutance_preset_correction_delta_power_relative_scales
-                    ),
-                    correction_delta_power_values=(
-                        profile.matched_ori_acutance_preset_correction_delta_power_values
-                    ),
-                )
-                acutance = {
-                    preset.name: float(value)
-                    for preset, value in zip(presets, corrected_preset_values)
-                }
+        curve, acutance = maybe_anchor_acutance_results(
+            capture_key=capture_key,
+            curve=curve,
+            acutance=acutance,
+            roi_height=estimate.roi.height,
+        )
+        if (
+            profile.intrinsic_full_reference_mode != "none"
+            and profile.intrinsic_full_reference_scope == "acutance_only"
+        ):
+            quality_loss_curve = acutance_curve_from_mtf(
+                quality_loss_scaled_frequencies,
+                quality_loss_corrected_mtf_for_acutance,
+                picture_height_cm=40.0,
+                viewing_distances_cm=np.arange(1.0, 101.0, 1.0),
+                pixels_along_picture_height=estimate.roi.height,
+            )
+            quality_loss_acutance = acutance_presets_from_mtf(
+                quality_loss_scaled_frequencies,
+                quality_loss_corrected_mtf_for_acutance,
+                pixels_along_picture_height=estimate.roi.height,
+                presets=presets,
+            )
+            _, quality_loss_acutance = maybe_anchor_acutance_results(
+                capture_key=capture_key,
+                curve=quality_loss_curve,
+                acutance=quality_loss_acutance,
+                roi_height=estimate.roi.height,
+            )
+        else:
+            quality_loss_acutance = acutance
         curve_cmp = compare_acutance_curves(curve, reference.acutance_table)
         if curve_cmp.get("count", 0):
             curve_mae.append(float(curve_cmp["mae"]))
@@ -864,7 +940,7 @@ def summarize_profile(
                 )
 
         quality_loss = quality_loss_presets_from_acutance(
-            acutance,
+            quality_loss_acutance,
             om_ceiling=profile.quality_loss_om_ceiling,
             coefficients=tuple(profile.quality_loss_coefficients),
             preset_overrides=profile.quality_loss_preset_overrides,
@@ -884,7 +960,7 @@ def summarize_profile(
                         "reported_quality_loss": float(reference.reported_quality_loss[name]),
                         "predicted_quality_loss": float(value),
                         "predicted_acutance": float(
-                            acutance[name.replace("Quality Loss", "Acutance")]
+                            quality_loss_acutance[name.replace("Quality Loss", "Acutance")]
                         ),
                     }
                 )
@@ -905,6 +981,7 @@ def summarize_profile(
             "bayer_mode": profile.bayer_mode,
             "roi_source": profile.roi_source,
             "intrinsic_full_reference_mode": profile.intrinsic_full_reference_mode,
+            "intrinsic_full_reference_scope": profile.intrinsic_full_reference_scope,
             "intrinsic_full_reference_clip_lo": profile.intrinsic_full_reference_clip_lo,
             "intrinsic_full_reference_clip_hi": profile.intrinsic_full_reference_clip_hi,
             "intrinsic_full_reference_registration_mode": profile.intrinsic_full_reference_registration_mode,

--- a/algo/benchmark_parity_psd_mtf.py
+++ b/algo/benchmark_parity_psd_mtf.py
@@ -71,6 +71,7 @@ class Profile:
     roi_refine_step: int = 2
     roi_refine_area_tolerance: float = 0.98
     intrinsic_full_reference_mode: str = "none"
+    intrinsic_full_reference_scope: str = "replace_all"
     intrinsic_full_reference_clip_lo: float = 0.5
     intrinsic_full_reference_clip_hi: float = 1.5
     intrinsic_full_reference_registration_mode: str = "phase_correlation"
@@ -409,6 +410,10 @@ def profile_payload(
                 raise ValueError(
                     f"Unsupported intrinsic full-reference mode: {profile.intrinsic_full_reference_mode}"
                 )
+            if profile.intrinsic_full_reference_scope not in {"replace_all", "acutance_only"}:
+                raise ValueError(
+                    f"Unsupported intrinsic full-reference scope: {profile.intrinsic_full_reference_scope}"
+                )
             capture_key = capture_key_from_stem(raw_path.stem)
             if capture_key in ori_reference_map:
                 if capture_key not in intrinsic_reference_cache:
@@ -451,8 +456,10 @@ def profile_payload(
                     registration_mode=profile.intrinsic_full_reference_registration_mode,
                 )
                 scaled_frequencies = np.asarray(ori_reference.frequencies_cpp, dtype=np.float64)
-                compensated_mtf = np.asarray(ori_reference.mtf, dtype=np.float64) * transfer_curve
-                compensated_mtf_for_acutance = compensated_mtf.copy()
+                intrinsic_mtf = np.asarray(ori_reference.mtf, dtype=np.float64) * transfer_curve
+                compensated_mtf_for_acutance = intrinsic_mtf.copy()
+                if profile.intrinsic_full_reference_scope == "replace_all":
+                    compensated_mtf = intrinsic_mtf
         if profile.matched_ori_reference_anchor:
             if capture_key in ori_reference_map:
                 if capture_key not in correction_cache:
@@ -647,6 +654,7 @@ def profile_payload(
             "bayer_mode": profile.bayer_mode,
             "roi_source": profile.roi_source,
             "intrinsic_full_reference_mode": profile.intrinsic_full_reference_mode,
+            "intrinsic_full_reference_scope": profile.intrinsic_full_reference_scope,
             "intrinsic_full_reference_clip_lo": profile.intrinsic_full_reference_clip_lo,
             "intrinsic_full_reference_clip_hi": profile.intrinsic_full_reference_clip_hi,
             "intrinsic_full_reference_registration_mode": profile.intrinsic_full_reference_registration_mode,

--- a/algo/deadleaf_13b10_imatest_intrinsic_full_reference_acutance_side_only_profile.json
+++ b/algo/deadleaf_13b10_imatest_intrinsic_full_reference_acutance_side_only_profile.json
@@ -1,0 +1,196 @@
+{
+  "name": "deadleaf_13b10_imatest_intrinsic_full_reference_acutance_side_only",
+  "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+  "gamma": 0.5,
+  "linearization_mode": "toe_power",
+  "linearization_toe": 0.12,
+  "bayer_pattern": "RGGB",
+  "bayer_mode": "demosaic_red",
+  "roi_source": "reference_refined",
+  "roi_width": 1655,
+  "roi_height": 1673,
+  "roi_refine_percentile": 45.0,
+  "roi_refine_sigma": 5.0,
+  "roi_refine_min_border_margin": 8,
+  "roi_refine_search_radius": 4,
+  "roi_refine_step": 2,
+  "roi_refine_area_tolerance": 0.98,
+  "matched_ori_reference_anchor": true,
+  "matched_ori_correction_clip_lo": 0.5,
+  "matched_ori_correction_clip_hi": 2.0,
+  "matched_ori_anchor_mode": "acutance_only",
+  "matched_ori_strength_curve_frequencies": [
+    0.0,
+    0.12,
+    0.22,
+    0.35,
+    0.5
+  ],
+  "matched_ori_strength_curve_values": [
+    1.0,
+    1.0,
+    0.82,
+    0.95,
+    1.0
+  ],
+  "matched_ori_acutance_reference_anchor": true,
+  "matched_ori_acutance_correction_clip_lo": 0.9,
+  "matched_ori_acutance_correction_clip_hi": 1.1,
+  "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+  "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+    0.0,
+    0.25,
+    0.6,
+    0.8,
+    1.6,
+    2.5
+  ],
+  "matched_ori_acutance_curve_correction_clip_hi_values": [
+    1.02,
+    1.03,
+    0.895,
+    0.895,
+    1.05,
+    1.06
+  ],
+  "matched_ori_acutance_strength_curve_relative_scales": [
+    0.0,
+    0.2,
+    0.8,
+    1.6,
+    2.5
+  ],
+  "matched_ori_acutance_strength_curve_values": [
+    0.7,
+    0.69,
+    0.64,
+    0.62,
+    0.6
+  ],
+  "matched_ori_acutance_correction_delta_power": 1.0,
+  "matched_ori_acutance_curve_correction_delta_power": 0.95,
+  "matched_ori_acutance_preset_correction_delta_power": null,
+  "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+    0.0,
+    4.5,
+    5.8,
+    6.2
+  ],
+  "matched_ori_acutance_preset_correction_delta_power_values": [
+    1.05,
+    1.05,
+    1.85,
+    1.85
+  ],
+  "matched_ori_acutance_preset_strength_curve_relative_scales": [
+    0.0,
+    3.0,
+    4.5,
+    5.8,
+    6.2
+  ],
+  "matched_ori_acutance_preset_strength_curve_values": [
+    1.0,
+    1.0,
+    0.85,
+    0.45,
+    0.45
+  ],
+  "intrinsic_full_reference_mode": "paired_ori_transfer",
+  "intrinsic_full_reference_scope": "acutance_only",
+  "intrinsic_full_reference_clip_lo": 0.5,
+  "intrinsic_full_reference_clip_hi": 1.5,
+  "intrinsic_full_reference_registration_mode": "phase_correlation",
+  "frequency_scale": 1.0,
+  "texture_support_scale": true,
+  "normalization_band_lo": 0.01,
+  "normalization_band_hi": 0.03,
+  "normalization_mode": "max",
+  "acutance_band_lo": 0.017,
+  "acutance_band_hi": 0.035,
+  "acutance_band_mode": "mean",
+  "noise_psd_model": "empirical",
+  "noise_psd_scale": 1.0,
+  "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+  "acutance_noise_share_band_lo": 0.36,
+  "acutance_noise_share_band_hi": 0.5,
+  "acutance_noise_share_scale_coefficients": [
+    521.08180962,
+    -26.62905791,
+    1.59615575
+  ],
+  "high_frequency_guard_start_cpp": 0.36,
+  "high_frequency_guard_stop_cpp": 0.5,
+  "mtf_compensation_mode": "sensor_aperture_sinc",
+  "sensor_fill_factor": 1.5,
+  "compensation_denominator_clip": 0.25,
+  "compensation_max_gain": 3.0,
+  "quality_loss_om_ceiling": 0.8851,
+  "quality_loss_coefficients": [
+    37.240228358776136,
+    26.54550669779819,
+    0.4538662637619741
+  ],
+  "quality_loss_preset_overrides": {
+    "Computer Monitor Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        5677361.198044325,
+        -16715685.9524707,
+        20317567.326582585,
+        -13046703.33912079,
+        4667794.619228022,
+        -882296.9160375095,
+        68863.59709647154
+      ]
+    },
+    "5.5\" Phone Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        -110912321.41149135,
+        50461107.51563171,
+        -9079490.127807735,
+        815148.8697247265,
+        -37712.984407641874,
+        854.6941149036079,
+        -6.261149027919645
+      ]
+    },
+    "UHDTV Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        1783462.6221675149,
+        -3813432.5606394163,
+        3326218.4642961356,
+        -1514886.1959663907,
+        380334.163146246,
+        -49956.87092015135,
+        2692.9566508574017
+      ]
+    },
+    "Small Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        6690980.837239251,
+        -12955277.716404187,
+        10300283.291740375,
+        -4303759.200708971,
+        996904.2653558743,
+        -121409.71509269004,
+        6084.6471373306085
+      ]
+    },
+    "Large Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        2355074.475971866,
+        -5276146.244338096,
+        4846781.143787682,
+        -2336594.295523967,
+        623766.4933095274,
+        -87476.30712136331,
+        5049.882965558553
+      ]
+    }
+  }
+}

--- a/artifacts/imatest_parity_intrinsic_full_reference_acutance_side_only_benchmark.json
+++ b/artifacts/imatest_parity_intrinsic_full_reference_acutance_side_only_benchmark.json
@@ -1,0 +1,245 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "acutance_only",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.08545849763734528,
+        "0.25": 0.07823066068923268,
+        "0.4": 0.07206389327002002,
+        "0.65": 0.09083195357199653,
+        "0.8": 0.12461080527278755,
+        "ori": 0.16848650475453283
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 1.3421389514230824,
+        "0.25": 1.2825995432153037,
+        "0.4": 1.1337887188584643,
+        "0.65": 0.3646116302822078,
+        "0.8": 1.0109879373437751,
+        "ori": 2.317792173136315
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.0866340728595097,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.07161152857712626,
+          "Computer Monitor Acutance": 0.1527729351132822,
+          "Large Print Acutance": 0.07458544484598892,
+          "Small Print Acutance": 0.04489532746407428,
+          "UHDTV Display Acutance": 0.08930512829707686
+        },
+        "curve_mae_mean": 0.09800461720653005,
+        "overall_quality_loss_mae_mean": 1.2221434105099775,
+        "quality_loss_focus_preset_mae_mean": 1.2221434105099775,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 0.14297762642651196,
+          "Computer Monitor Quality Loss": 2.906111784076103,
+          "Large Print Quality Loss": 0.9547911309308169,
+          "Small Print Quality Loss": 0.6076983310559123,
+          "UHDTV Display Quality Loss": 1.499138180060543
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_acutance_side_only_profile.json"
+    }
+  ]
+}

--- a/artifacts/imatest_parity_intrinsic_full_reference_acutance_side_only_psd_benchmark.json
+++ b/artifacts/imatest_parity_intrinsic_full_reference_acutance_side_only_psd_benchmark.json
@@ -1,0 +1,184 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "acutance_only",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.08798816977845184,
+        "0.25": 0.07933534365253607,
+        "0.4": 0.0714643216080878,
+        "0.65": 0.09003315838830904,
+        "0.8": 0.13191758379069268,
+        "ori": 0.1819146233765151
+      },
+      "overall": {
+        "curve_mae_mean": 0.10133586194243609,
+        "mtf_abs_signed_rel_mean": 0.11528892106675531,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.03158105207331191,
+            "mre_mean": 0.1447569817901349,
+            "signed_rel_mean": 0.060932730830363616
+          },
+          "low": {
+            "mae_mean": 0.06882712306637258,
+            "mre_mean": 0.08543706347416531,
+            "signed_rel_mean": -0.08492015654298801
+          },
+          "mid": {
+            "mae_mean": 0.0747917611591199,
+            "mre_mean": 0.18177205226001394,
+            "signed_rel_mean": -0.18177205226001394
+          },
+          "top": {
+            "mae_mean": 0.17270812630821766,
+            "mre_mean": 0.44953500617374154,
+            "signed_rel_mean": -0.1335307446336557
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.028310603916373085,
+          "mtf30": 0.034878982980577775,
+          "mtf50": 0.024062848856597114
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.07021633509174197,
+          "Computer Monitor Acutance": 0.1237616574394167,
+          "Large Print Acutance": 0.06292909545542294,
+          "Small Print Acutance": 0.042778635513213446,
+          "UHDTV Display Acutance": 0.0774702661250479
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_acutance_side_only_profile.json"
+    }
+  ]
+}

--- a/docs/imatest_parity_intrinsic_full_reference_acutance_side_only_followup.md
+++ b/docs/imatest_parity_intrinsic_full_reference_acutance_side_only_followup.md
@@ -1,0 +1,84 @@
+# Imatest Parity Intrinsic Full-Reference Acutance-Side-Only Follow-up
+
+Issue: `#37`  
+Parent: `#29`  
+Follow-up from: `#33`  
+Context: `#30`, `#34`, `#36`
+
+## What changed
+
+- Added `intrinsic_full_reference_scope` to the parity benchmark entrypoints.
+- Kept the existing intrinsic behavior as `replace_all`.
+- Added `acutance_only` so the intrinsic/full-reference transfer can be applied only to the acutance-side path while leaving the baseline reported-MTF and quality-loss path intact.
+- Added `algo/deadleaf_13b10_imatest_intrinsic_full_reference_acutance_side_only_profile.json`.
+- Checked in:
+  - `artifacts/imatest_parity_intrinsic_full_reference_acutance_side_only_benchmark.json`
+  - `artifacts/imatest_parity_intrinsic_full_reference_acutance_side_only_psd_benchmark.json`
+
+## Why this follow-up existed
+
+PR `#34` showed that the intrinsic/full-reference family was useful for the remaining curve and focus-preset acutance gap, but it also broke the quality-loss objective badly enough that it could not replace the whole parity path.
+
+Issue `#37` tested the narrow next question: whether that intrinsic signal should be limited to the acutance side while keeping the PR `#30` baseline branch for reported-MTF and quality loss.
+
+## Result
+
+PR `#30` merged baseline:
+
+- `curve_mae_mean = 0.03683438`
+- `acutance_focus_preset_mae_mean = 0.04249131`
+- `overall_quality_loss_mae_mean = 1.22214341`
+
+PR `#34` intrinsic/full-reference replacement:
+
+- `curve_mae_mean = 0.03587346`
+- `acutance_focus_preset_mae_mean = 0.03165223`
+- `overall_quality_loss_mae_mean = 4.56800916`
+
+Issue `#37` acutance-side-only split:
+
+- `curve_mae_mean = 0.09800462`
+- `acutance_focus_preset_mae_mean = 0.08663407`
+- `overall_quality_loss_mae_mean = 1.22214341`
+
+Relative to PR `#30`, the issue `#37` split:
+
+- preserves `overall_quality_loss_mae_mean` exactly
+- regresses `curve_mae_mean` sharply
+- regresses `acutance_focus_preset_mae_mean` sharply
+- loses the PR `#34` non-Phone acutance gains instead of preserving them
+
+Preset-level acutance comparison against PR `#30`:
+
+- `5.5" Phone Display Acutance`: `0.01380 -> 0.07161`
+- `Computer Monitor Acutance`: `0.05269 -> 0.15277`
+- `UHDTV Display Acutance`: `0.04794 -> 0.08931`
+- `Small Print Acutance`: `0.04670 -> 0.04490`
+- `Large Print Acutance`: `0.05132 -> 0.07459`
+
+The PSD benchmark shows the same direction:
+
+PR `#30` baseline:
+
+- `curve_mae_mean = 0.04306442`
+- `mtf_abs_signed_rel_mean = 0.08692956`
+
+PR `#34` intrinsic/full-reference replacement:
+
+- `curve_mae_mean = 0.03587346`
+- `mtf_abs_signed_rel_mean = 0.20631329`
+
+Issue `#37` acutance-side-only split:
+
+- `curve_mae_mean = 0.10133586`
+- `mtf_abs_signed_rel_mean = 0.11528892`
+
+That means the split lands in the worst available curve regime while only partially recovering the MTF regression from PR `#34`.
+
+## Conclusion
+
+This follow-up is a bounded negative result.
+
+Constraining the intrinsic/full-reference signal to the acutance side does preserve the PR `#30` quality-loss branch, but it does not preserve the PR `#34` curve or focus-preset acutance gains. Instead, it produces a much worse curve fit than both PR `#30` and PR `#34`.
+
+So the issue `#37` answer is no: the intrinsic/full-reference family does not become a viable next main-line family when it is limited to the acutance side only in this form.

--- a/tests/test_benchmark_parity_acutance_quality_loss.py
+++ b/tests/test_benchmark_parity_acutance_quality_loss.py
@@ -560,6 +560,159 @@ class BenchmarkParityAcutanceQualityLossTest(unittest.TestCase):
 
             self.assertEqual(derive_curve.call_count, 2)
 
+    def test_intrinsic_scope_can_limit_full_reference_to_acutance_only(self) -> None:
+        capture_key = "OV13b10_AG8_ET5500_deadleaf_12M_40"
+        preset_names = (
+            '5.5" Phone Display Acutance',
+            "Computer Monitor Acutance",
+            "UHDTV Display Acutance",
+            "Small Print Acutance",
+            "Large Print Acutance",
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dataset_root = Path(tmpdir)
+            variant_root = dataset_root / "OV13B10_AI_NR_OV13B10_ppqpkl_0.10"
+            results_dir = variant_root / "Results"
+            results_dir.mkdir(parents=True)
+            stem = f"{capture_key}_variantA"
+            (results_dir / f"{stem}_R_Random.csv").write_text("", encoding="utf-8")
+            (variant_root / f"{stem}.raw").write_bytes(b"")
+
+            reference = SimpleNamespace(
+                lrtb=RoiBounds(left=0, right=1, top=0, bottom=1),
+                acutance_table=[
+                    AcutancePoint(print_height_cm=40.0, viewing_distance_cm=10.0, acutance=1.0)
+                ],
+                reported_acutance={name: 1.0 for name in preset_names},
+                reported_quality_loss={
+                    name.replace("Acutance", "Quality Loss"): 0.0 for name in preset_names
+                },
+            )
+            ori_reference = SimpleNamespace(
+                lrtb=RoiBounds(left=0, right=1, top=0, bottom=1),
+                frequencies_cpp=np.array([0.1, 0.2], dtype=np.float64),
+                mtf=np.array([1.0, 1.0], dtype=np.float64),
+                acutance_table=reference.acutance_table,
+            )
+            estimate = SimpleNamespace(
+                roi=RoiBounds(left=0, right=1, top=0, bottom=1),
+                frequencies_cpp=np.array([0.1, 0.2], dtype=np.float64),
+                mtf_for_acutance=np.array([1.0, 1.0], dtype=np.float64),
+                acutance_high_frequency_noise_share=0.0,
+            )
+            profile = Profile(
+                name="test",
+                calibration_file="calibration.json",
+                roi_source="reference",
+                intrinsic_full_reference_mode="paired_ori_transfer",
+                intrinsic_full_reference_scope="acutance_only",
+            )
+
+            def parse_csv(path: Path):
+                return ori_reference if path.name == "ori.csv" else reference
+
+            def acutance_from_mtf(_freqs, mtf, **_kwargs):
+                value = float(np.asarray(mtf, dtype=np.float64)[0])
+                return {name: value for name in preset_names}
+
+            with (
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.load_ideal_psd_calibration",
+                    return_value=None,
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.build_ori_reference_map",
+                    return_value={capture_key: (dataset_root / "ori.csv", dataset_root / "ori.raw")},
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.parse_imatest_random_csv",
+                    side_effect=parse_csv,
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.load_raw_u16",
+                    side_effect=lambda path, width, height: np.zeros((height, width), dtype=np.uint16),
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.extract_analysis_plane",
+                    side_effect=lambda raw, **_: raw,
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.normalize_for_analysis",
+                    side_effect=lambda plane, **_: plane,
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.estimate_dead_leaves_mtf",
+                    return_value=estimate,
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.apply_mtf_compensation",
+                    side_effect=lambda mtf, freqs, **_: (
+                        np.asarray(mtf, dtype=np.float64),
+                        np.asarray(freqs, dtype=np.float64),
+                    ),
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.derive_intrinsic_transfer_curve",
+                    return_value=np.array([2.0, 2.0], dtype=np.float64),
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.apply_mtf_shape_correction",
+                    side_effect=lambda mtf, freqs, **_: (
+                        np.asarray(mtf, dtype=np.float64),
+                        np.asarray(freqs, dtype=np.float64),
+                    ),
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.acutance_curve_from_mtf",
+                    side_effect=lambda _freqs, mtf, **_kwargs: [
+                        AcutancePoint(
+                            print_height_cm=40.0,
+                            viewing_distance_cm=10.0,
+                            acutance=float(np.asarray(mtf, dtype=np.float64)[0]),
+                        )
+                    ],
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.acutance_presets_from_mtf",
+                    side_effect=acutance_from_mtf,
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.compare_acutance_curves",
+                    return_value={"count": 1, "mae": 0.0},
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.compare_acutance_presets",
+                    side_effect=lambda estimate_map, reference_map: {
+                        name: {
+                            "abs_error": abs(float(estimate_map[name]) - float(reference_map[name])),
+                            "estimate": float(estimate_map[name]),
+                            "reference": float(reference_map[name]),
+                        }
+                        for name in estimate_map
+                    },
+                ) as compare_presets,
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.quality_loss_presets_from_acutance",
+                    return_value=reference.reported_quality_loss,
+                ) as quality_loss_from_acutance,
+            ):
+                summarize_profile(
+                    dataset_root=dataset_root,
+                    profile_path=dataset_root / "profile.json",
+                    profile=profile,
+                    width=2,
+                    height=2,
+                )
+
+            self.assertEqual(
+                compare_presets.call_args.args[0]['5.5" Phone Display Acutance'],
+                2.0,
+            )
+            self.assertEqual(
+                quality_loss_from_acutance.call_args.args[0]['5.5" Phone Display Acutance'],
+                1.0,
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_benchmark_parity_psd_mtf.py
+++ b/tests/test_benchmark_parity_psd_mtf.py
@@ -149,6 +149,111 @@ class BenchmarkParityPsdMtfTest(unittest.TestCase):
         )
         self.assertEqual(profile.intrinsic_full_reference_mode, "paired_ori_transfer")
 
+    def test_intrinsic_scope_can_limit_full_reference_to_acutance_side_only(self) -> None:
+        capture_key = "OV13b10_AG8_ET5500_deadleaf_12M_40"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dataset_root = Path(tmpdir)
+            variant_root = dataset_root / "OV13B10_AI_NR_OV13B10_ppqpkl_0.10"
+            results_dir = variant_root / "Results"
+            results_dir.mkdir(parents=True)
+            stem = f"{capture_key}_variantA"
+            (results_dir / f"{stem}_R_Random.csv").write_text("", encoding="utf-8")
+            (variant_root / f"{stem}.raw").write_bytes(b"")
+
+            reference = SimpleNamespace(
+                lrtb=RoiBounds(left=0, right=1, top=0, bottom=1),
+                frequencies_cpp=np.array([0.02, 0.1, 0.25, 0.4], dtype=np.float64),
+                mtf=np.array([1.0, 1.0, 1.0, 1.0], dtype=np.float64),
+                acutance_table=[
+                    AcutancePoint(print_height_cm=40.0, viewing_distance_cm=10.0, acutance=1.0)
+                ],
+                reported_acutance={'5.5" Phone Display Acutance': 1.0},
+            )
+            ori_reference = SimpleNamespace(
+                lrtb=RoiBounds(left=0, right=1, top=0, bottom=1),
+                frequencies_cpp=np.array([0.02, 0.1, 0.25, 0.4], dtype=np.float64),
+                mtf=np.array([1.0, 1.0, 1.0, 1.0], dtype=np.float64),
+                acutance_table=reference.acutance_table,
+                reported_acutance=reference.reported_acutance,
+            )
+            estimate = SimpleNamespace(
+                roi=RoiBounds(left=0, right=1, top=0, bottom=1),
+                frequencies_cpp=np.array([0.02, 0.1, 0.25, 0.4], dtype=np.float64),
+                mtf=np.array([1.0, 1.0, 1.0, 1.0], dtype=np.float64),
+                mtf_for_acutance=np.array([1.0, 1.0, 1.0, 1.0], dtype=np.float64),
+            )
+            profile = Profile(
+                name="test",
+                calibration_file="calibration.json",
+                roi_source="reference",
+                intrinsic_full_reference_mode="paired_ori_transfer",
+                intrinsic_full_reference_scope="acutance_only",
+            )
+
+            def parse_csv(path: Path):
+                return ori_reference if path.name == "ori.csv" else reference
+
+            with (
+                patch("algo.benchmark_parity_psd_mtf.load_ideal_psd_calibration", return_value=None),
+                patch(
+                    "algo.benchmark_parity_psd_mtf.build_ori_reference_map",
+                    return_value={capture_key: (dataset_root / "ori.csv", dataset_root / "ori.raw")},
+                ),
+                patch(
+                    "algo.benchmark_parity_psd_mtf.parse_imatest_random_csv",
+                    side_effect=parse_csv,
+                ),
+                patch(
+                    "algo.benchmark_parity_psd_mtf.load_raw_u16",
+                    side_effect=lambda path, width, height: np.zeros((height, width), dtype=np.uint16),
+                ),
+                patch("algo.benchmark_parity_psd_mtf.extract_analysis_plane", side_effect=lambda raw, **_: raw),
+                patch("algo.benchmark_parity_psd_mtf.normalize_for_analysis", side_effect=lambda plane, **_: plane),
+                patch("algo.benchmark_parity_psd_mtf.estimate_dead_leaves_mtf", return_value=estimate),
+                patch(
+                    "algo.benchmark_parity_psd_mtf.apply_mtf_compensation",
+                    side_effect=lambda mtf, freqs, **_: (
+                        np.asarray(mtf, dtype=np.float64),
+                        np.asarray(freqs, dtype=np.float64),
+                    ),
+                ),
+                patch(
+                    "algo.benchmark_parity_psd_mtf.derive_intrinsic_transfer_curve",
+                    return_value=np.array([2.0, 2.0, 2.0, 2.0], dtype=np.float64),
+                ),
+                patch(
+                    "algo.benchmark_parity_psd_mtf.compute_mtf_metrics",
+                    return_value=SimpleNamespace(mtf50=0.1, mtf30=0.1, mtf20=0.1),
+                ) as compute_metrics,
+                patch("algo.benchmark_parity_psd_mtf.interpolate_threshold", return_value=0.1),
+                patch(
+                    "algo.benchmark_parity_psd_mtf.acutance_curve_from_mtf",
+                    return_value=reference.acutance_table,
+                ),
+                patch(
+                    "algo.benchmark_parity_psd_mtf.compare_acutance_curves",
+                    return_value={"count": 1, "mae": 0.0},
+                ),
+                patch(
+                    "algo.benchmark_parity_psd_mtf.acutance_presets_from_mtf",
+                    return_value=reference.reported_acutance,
+                ) as acutance_from_mtf,
+                patch(
+                    "algo.benchmark_parity_psd_mtf.compare_acutance_presets",
+                    return_value={'5.5" Phone Display Acutance': {"abs_error": 0.0}},
+                ),
+            ):
+                profile_payload(
+                    dataset_root=dataset_root,
+                    profile_path=dataset_root / "profile.json",
+                    profile=profile,
+                    width=2,
+                    height=2,
+                )
+
+            np.testing.assert_allclose(compute_metrics.call_args.args[1], [1.0, 1.0, 1.0, 1.0])
+            np.testing.assert_allclose(acutance_from_mtf.call_args.args[1], [2.0, 2.0, 2.0, 2.0])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

This PR implements the bounded issue #37 follow-up after PR #34 and PR #36.

Changes in this branch:

- add `intrinsic_full_reference_scope` to the parity benchmark entrypoints
- keep the existing PR #34 behavior as `replace_all`
- add `acutance_only` so the intrinsic/full-reference transfer can be applied only to the acutance-side path
- add focused regression coverage for the scoped behavior
- add `algo/deadleaf_13b10_imatest_intrinsic_full_reference_acutance_side_only_profile.json`
- add benchmark outputs for the new scoped profile
- add a benchmark note documenting the result

## Benchmark Result

Acutance / quality-loss benchmark

- PR #30 baseline:
  - `curve_mae_mean = 0.03683438`
  - `acutance_focus_preset_mae_mean = 0.04249131`
  - `overall_quality_loss_mae_mean = 1.22214341`
- PR #34 intrinsic replacement:
  - `curve_mae_mean = 0.03587346`
  - `acutance_focus_preset_mae_mean = 0.03165223`
  - `overall_quality_loss_mae_mean = 4.56800916`
- issue #37 acutance-side-only split:
  - `curve_mae_mean = 0.09800462`
  - `acutance_focus_preset_mae_mean = 0.08663407`
  - `overall_quality_loss_mae_mean = 1.22214341`

PSD / MTF benchmark

- PR #30 baseline:
  - `curve_mae_mean = 0.04306442`
  - `mtf_abs_signed_rel_mean = 0.08692956`
- PR #34 intrinsic replacement:
  - `curve_mae_mean = 0.03587346`
  - `mtf_abs_signed_rel_mean = 0.20631329`
- issue #37 acutance-side-only split:
  - `curve_mae_mean = 0.10133586`
  - `mtf_abs_signed_rel_mean = 0.11528892`

Conclusion:

- the split preserves the PR #30 quality-loss branch exactly
- it does not preserve the PR #34 curve or focus-preset acutance gains
- this is a bounded negative result, not a viable next main-line family

## Validation

- `python3 -m pytest -q tests/test_benchmark_parity_acutance_quality_loss.py tests/test_benchmark_parity_psd_mtf.py`
- `python3 -m py_compile algo/benchmark_parity_acutance_quality_loss.py algo/benchmark_parity_psd_mtf.py`
- `python3 -m algo.benchmark_parity_acutance_quality_loss 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_intrinsic_full_reference_acutance_side_only_profile.json --output artifacts/imatest_parity_intrinsic_full_reference_acutance_side_only_benchmark.json`
- `python3 -m algo.benchmark_parity_psd_mtf 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_intrinsic_full_reference_acutance_side_only_profile.json --output artifacts/imatest_parity_intrinsic_full_reference_acutance_side_only_psd_benchmark.json`

Refs #37
Refs #29
Follow-up from #33
Context from #30
Context from #34
Context from #36
