### PR TITLE
Issue #39: Audit chart-plus-sensor MTF compensation family

### DIFF
--- a/algo/benchmark_parity_acutance_quality_loss.py
+++ b/algo/benchmark_parity_acutance_quality_loss.py
@@ -170,6 +170,7 @@ class Profile:
     texture_support_scale: bool = False
     mtf_compensation_mode: str = "none"
     sensor_fill_factor: float = 1.0
+    chart_fill_factor: float = 1.0
     compensation_denominator_clip: float = 0.25
     compensation_max_gain: float = 3.0
 
@@ -420,6 +421,7 @@ def summarize_profile(
             scaled_frequencies,
             mode=profile.mtf_compensation_mode,
             sensor_fill_factor=profile.sensor_fill_factor,
+            chart_fill_factor=profile.chart_fill_factor,
             denominator_clip=profile.compensation_denominator_clip,
             max_gain=profile.compensation_max_gain,
         )
@@ -540,6 +542,7 @@ def summarize_profile(
                         ori_scaled_frequencies,
                         mode=profile.mtf_compensation_mode,
                         sensor_fill_factor=profile.sensor_fill_factor,
+                        chart_fill_factor=profile.chart_fill_factor,
                         denominator_clip=profile.compensation_denominator_clip,
                         max_gain=profile.compensation_max_gain,
                     )
@@ -666,6 +669,7 @@ def summarize_profile(
                         ori_scaled_frequencies,
                         mode=profile.mtf_compensation_mode,
                         sensor_fill_factor=profile.sensor_fill_factor,
+                        chart_fill_factor=profile.chart_fill_factor,
                         denominator_clip=profile.compensation_denominator_clip,
                         max_gain=profile.compensation_max_gain,
                     )
@@ -959,6 +963,7 @@ def summarize_profile(
             "mtf_shape_correction_mode": profile.mtf_shape_correction_mode,
             "mtf_compensation_mode": profile.mtf_compensation_mode,
             "sensor_fill_factor": profile.sensor_fill_factor,
+            "chart_fill_factor": profile.chart_fill_factor,
             "acutance_preset_overrides": profile.acutance_preset_overrides,
         },
         "overall": {

--- a/algo/benchmark_parity_psd_mtf.py
+++ b/algo/benchmark_parity_psd_mtf.py
@@ -142,6 +142,7 @@ class Profile:
     texture_support_scale: bool = False
     mtf_compensation_mode: str = "none"
     sensor_fill_factor: float = 1.0
+    chart_fill_factor: float = 1.0
     compensation_denominator_clip: float = 0.25
     compensation_max_gain: float = 3.0
     quality_loss_om_ceiling: float = 0.8851
@@ -393,6 +394,7 @@ def profile_payload(
             scaled_frequencies,
             mode=profile.mtf_compensation_mode,
             sensor_fill_factor=profile.sensor_fill_factor,
+            chart_fill_factor=profile.chart_fill_factor,
             denominator_clip=profile.compensation_denominator_clip,
             max_gain=profile.compensation_max_gain,
         )
@@ -401,6 +403,7 @@ def profile_payload(
             scaled_frequencies,
             mode=profile.mtf_compensation_mode,
             sensor_fill_factor=profile.sensor_fill_factor,
+            chart_fill_factor=profile.chart_fill_factor,
             denominator_clip=profile.compensation_denominator_clip,
             max_gain=profile.compensation_max_gain,
         )
@@ -520,6 +523,7 @@ def profile_payload(
                         ori_scaled_frequencies,
                         mode=profile.mtf_compensation_mode,
                         sensor_fill_factor=profile.sensor_fill_factor,
+                        chart_fill_factor=profile.chart_fill_factor,
                         denominator_clip=profile.compensation_denominator_clip,
                         max_gain=profile.compensation_max_gain,
                     )
@@ -528,6 +532,7 @@ def profile_payload(
                         ori_scaled_frequencies,
                         mode=profile.mtf_compensation_mode,
                         sensor_fill_factor=profile.sensor_fill_factor,
+                        chart_fill_factor=profile.chart_fill_factor,
                         denominator_clip=profile.compensation_denominator_clip,
                         max_gain=profile.compensation_max_gain,
                     )
@@ -696,6 +701,7 @@ def profile_payload(
             "calibration_file": profile.calibration_file,
             "mtf_compensation_mode": profile.mtf_compensation_mode,
             "sensor_fill_factor": profile.sensor_fill_factor,
+            "chart_fill_factor": profile.chart_fill_factor,
         },
         "overall": {
             "curve_mae_mean": float(np.mean(curve_mae)),

--- a/algo/dead_leaves.py
+++ b/algo/dead_leaves.py
@@ -1324,23 +1324,29 @@ def estimate_mtf_compensation_curve(
     *,
     mode: str = "none",
     sensor_fill_factor: float = 1.0,
+    chart_fill_factor: float = 1.0,
     denominator_clip: float = 0.25,
     max_gain: float = 3.0,
 ) -> np.ndarray:
     frequencies = np.asarray(frequencies_cpp, dtype=np.float64)
     if mode == "none":
         return np.ones_like(frequencies)
-    if mode != "sensor_aperture_sinc":
+    if mode not in {"sensor_aperture_sinc", "chart_sensor_aperture_sinc"}:
         raise ValueError(f"Unknown MTF compensation mode: {mode}")
     if sensor_fill_factor <= 0.0:
         raise ValueError("sensor_fill_factor must be positive")
+    if chart_fill_factor <= 0.0:
+        raise ValueError("chart_fill_factor must be positive")
     if denominator_clip <= 0.0:
         raise ValueError("denominator_clip must be positive")
     if max_gain < 1.0:
         raise ValueError("max_gain must be at least 1.0")
 
     sensor_mtf = _sinc_pi(sensor_fill_factor * frequencies)
-    compensation = 1.0 / np.clip(sensor_mtf, denominator_clip, None)
+    total_mtf = sensor_mtf
+    if mode == "chart_sensor_aperture_sinc":
+        total_mtf = total_mtf * _sinc_pi(chart_fill_factor * frequencies)
+    compensation = 1.0 / np.clip(total_mtf, denominator_clip, None)
     return np.clip(compensation, 1.0, max_gain)
 
 
@@ -1350,6 +1356,7 @@ def apply_mtf_compensation(
     *,
     mode: str = "none",
     sensor_fill_factor: float = 1.0,
+    chart_fill_factor: float = 1.0,
     denominator_clip: float = 0.25,
     max_gain: float = 3.0,
 ) -> tuple[np.ndarray, np.ndarray]:
@@ -1357,6 +1364,7 @@ def apply_mtf_compensation(
         frequencies_cpp,
         mode=mode,
         sensor_fill_factor=sensor_fill_factor,
+        chart_fill_factor=chart_fill_factor,
         denominator_clip=denominator_clip,
         max_gain=max_gain,
     )

--- a/algo/deadleaf_13b10_imatest_chart_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json
+++ b/algo/deadleaf_13b10_imatest_chart_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json
@@ -1,0 +1,192 @@
+{
+  "name": "deadleaf_13b10_imatest_chart_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895",
+  "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+  "gamma": 0.5,
+  "linearization_mode": "toe_power",
+  "linearization_toe": 0.12,
+  "bayer_pattern": "RGGB",
+  "bayer_mode": "demosaic_red",
+  "roi_source": "reference_refined",
+  "roi_width": 1655,
+  "roi_height": 1673,
+  "roi_refine_percentile": 45.0,
+  "roi_refine_sigma": 5.0,
+  "roi_refine_min_border_margin": 8,
+  "roi_refine_search_radius": 4,
+  "roi_refine_step": 2,
+  "roi_refine_area_tolerance": 0.98,
+  "matched_ori_reference_anchor": true,
+  "matched_ori_correction_clip_lo": 0.5,
+  "matched_ori_correction_clip_hi": 2.0,
+  "matched_ori_anchor_mode": "acutance_only",
+  "matched_ori_strength_curve_frequencies": [
+    0.0,
+    0.12,
+    0.22,
+    0.35,
+    0.5
+  ],
+  "matched_ori_strength_curve_values": [
+    1.0,
+    1.0,
+    0.82,
+    0.95,
+    1.0
+  ],
+  "matched_ori_acutance_reference_anchor": true,
+  "matched_ori_acutance_correction_clip_lo": 0.9,
+  "matched_ori_acutance_correction_clip_hi": 1.1,
+  "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+  "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+    0.0,
+    0.25,
+    0.6,
+    0.8,
+    1.6,
+    2.5
+  ],
+  "matched_ori_acutance_curve_correction_clip_hi_values": [
+    1.02,
+    1.03,
+    0.895,
+    0.895,
+    1.05,
+    1.06
+  ],
+  "matched_ori_acutance_strength_curve_relative_scales": [
+    0.0,
+    0.2,
+    0.8,
+    1.6,
+    2.5
+  ],
+  "matched_ori_acutance_strength_curve_values": [
+    0.7,
+    0.69,
+    0.64,
+    0.62,
+    0.6
+  ],
+  "matched_ori_acutance_correction_delta_power": 1.0,
+  "matched_ori_acutance_curve_correction_delta_power": 0.95,
+  "matched_ori_acutance_preset_correction_delta_power": null,
+  "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+    0.0,
+    4.5,
+    5.8,
+    6.2
+  ],
+  "matched_ori_acutance_preset_correction_delta_power_values": [
+    1.05,
+    1.05,
+    1.85,
+    1.85
+  ],
+  "matched_ori_acutance_preset_strength_curve_relative_scales": [
+    0.0,
+    3.0,
+    4.5,
+    5.8,
+    6.2
+  ],
+  "matched_ori_acutance_preset_strength_curve_values": [
+    1.0,
+    1.0,
+    0.85,
+    0.45,
+    0.45
+  ],
+  "frequency_scale": 1.0,
+  "texture_support_scale": true,
+  "normalization_band_lo": 0.01,
+  "normalization_band_hi": 0.03,
+  "normalization_mode": "max",
+  "acutance_band_lo": 0.017,
+  "acutance_band_hi": 0.035,
+  "acutance_band_mode": "mean",
+  "noise_psd_model": "empirical",
+  "noise_psd_scale": 1.0,
+  "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+  "acutance_noise_share_band_lo": 0.36,
+  "acutance_noise_share_band_hi": 0.5,
+  "acutance_noise_share_scale_coefficients": [
+    521.08180962,
+    -26.62905791,
+    1.59615575
+  ],
+  "high_frequency_guard_start_cpp": 0.36,
+  "high_frequency_guard_stop_cpp": 0.5,
+  "mtf_compensation_mode": "chart_sensor_aperture_sinc",
+  "sensor_fill_factor": 1.5,
+  "chart_fill_factor": 0.15,
+  "compensation_denominator_clip": 0.25,
+  "compensation_max_gain": 3.0,
+  "quality_loss_om_ceiling": 0.8851,
+  "quality_loss_coefficients": [
+    37.240228358776136,
+    26.54550669779819,
+    0.4538662637619741
+  ],
+  "quality_loss_preset_overrides": {
+    "Computer Monitor Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        5677361.198044325,
+        -16715685.9524707,
+        20317567.326582585,
+        -13046703.33912079,
+        4667794.619228022,
+        -882296.9160375095,
+        68863.59709647154
+      ]
+    },
+    "5.5\" Phone Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        -110912321.41149135,
+        50461107.51563171,
+        -9079490.127807735,
+        815148.8697247265,
+        -37712.984407641874,
+        854.6941149036079,
+        -6.261149027919645
+      ]
+    },
+    "UHDTV Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        1783462.6221675149,
+        -3813432.5606394163,
+        3326218.4642961356,
+        -1514886.1959663907,
+        380334.163146246,
+        -49956.87092015135,
+        2692.9566508574017
+      ]
+    },
+    "Small Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        6690980.837239251,
+        -12955277.716404187,
+        10300283.291740375,
+        -4303759.200708971,
+        996904.2653558743,
+        -121409.71509269004,
+        6084.6471373306085
+      ]
+    },
+    "Large Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        2355074.475971866,
+        -5276146.244338096,
+        4846781.143787682,
+        -2336594.295523967,
+        623766.4933095274,
+        -87476.30712136331,
+        5049.882965558553
+      ]
+    }
+  }
+}

--- a/artifacts/issue39_chart_sensor_compensation_psd_benchmark.json
+++ b/artifacts/issue39_chart_sensor_compensation_psd_benchmark.json
@@ -1,0 +1,363 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.045132331541343135,
+        "0.25": 0.03837972282290488,
+        "0.4": 0.03424583283108843,
+        "0.65": 0.04020915188141205,
+        "0.8": 0.049664991465143526,
+        "ori": 0.055589288189657284
+      },
+      "overall": {
+        "curve_mae_mean": 0.04306441973920293,
+        "mtf_abs_signed_rel_mean": 0.08692955889841379,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.017639268013990343,
+            "mre_mean": 0.08883603386012136,
+            "signed_rel_mean": 0.04964177427444007
+          },
+          "low": {
+            "mae_mean": 0.03704553941403868,
+            "mre_mean": 0.046572470331734825,
+            "signed_rel_mean": 0.0237949421475065
+          },
+          "mid": {
+            "mae_mean": 0.03898616152003224,
+            "mre_mean": 0.12397538768693758,
+            "signed_rel_mean": 0.10965436746685472
+          },
+          "top": {
+            "mae_mean": 0.0738124428343438,
+            "mre_mean": 0.20207246214765648,
+            "signed_rel_mean": -0.16462715170485387
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.033009025007104606,
+          "mtf30": 0.03693523768742383,
+          "mtf50": 0.009332615436071163
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.014469243052711292,
+          "Computer Monitor Acutance": 0.06145640899956405,
+          "Large Print Acutance": 0.05374582109239643,
+          "Small Print Acutance": 0.061691355516267324,
+          "UHDTV Display Acutance": 0.056009600718383366
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json"
+    },
+    {
+      "analysis_pipeline": {
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 0.15,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "chart_sensor_aperture_sinc",
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.04525229503354099,
+        "0.25": 0.038461215547988356,
+        "0.4": 0.03430068018615759,
+        "0.65": 0.040261957177632854,
+        "0.8": 0.049701202162008185,
+        "ori": 0.05562585158999771
+      },
+      "overall": {
+        "curve_mae_mean": 0.04313185946270208,
+        "mtf_abs_signed_rel_mean": 0.086722504707274,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.017970390485496625,
+            "mre_mean": 0.09013778007601495,
+            "signed_rel_mean": 0.052667948551990494
+          },
+          "low": {
+            "mae_mean": 0.03704173356898847,
+            "mre_mean": 0.046576553027837454,
+            "signed_rel_mean": 0.02388487251187907
+          },
+          "mid": {
+            "mae_mean": 0.039119361297531255,
+            "mre_mean": 0.12452523737462444,
+            "signed_rel_mean": 0.11051854047385516
+          },
+          "top": {
+            "mae_mean": 0.07309575037982753,
+            "mre_mean": 0.19987217677600805,
+            "signed_rel_mean": -0.15981865729137126
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.03317034207682017,
+          "mtf30": 0.0370544739927258,
+          "mtf50": 0.009380744679678721
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.014470107265073676,
+          "Computer Monitor Acutance": 0.06152705760305268,
+          "Large Print Acutance": 0.053777104775235826,
+          "Small Print Acutance": 0.06170977375933333,
+          "UHDTV Display Acutance": 0.05604615282700389
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_chart_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json"
+    }
+  ]
+}

--- a/docs/issue39_chart_sensor_compensation_followup.md
+++ b/docs/issue39_chart_sensor_compensation_followup.md
@@ -1,0 +1,82 @@
+# Issue 39 Chart And Sensor Compensation Follow-up
+
+This note records the first bounded prototype for issue `#39`.
+
+It follows the direction set in issue `#39` after PR `#38`:
+
+- move the search back down to the MTF layer
+- test one source-backed chart / reference-model family
+- judge the result on PSD / MTF metrics first against the current PR `#30` best branch
+
+## Source Basis
+
+The source-backed family used here is the chart / sensor compensation path already called out in
+[dead_leaves_black_box_research.md](./dead_leaves_black_box_research.md):
+
+- Imatest documentation models measured MTF as the product of chart, lens, sensor, and processing terms
+- the repo already had a one-term `sensor_aperture_sinc` approximation
+- this prototype extends that same family with a second aperture term for the chart medium instead of opening a new unrelated search axis
+
+## Profiles Compared
+
+Baseline, representing the current PR `#30` best branch:
+
+- [../algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json](../algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json)
+
+Candidate prototype from this issue:
+
+- [../algo/deadleaf_13b10_imatest_chart_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json](../algo/deadleaf_13b10_imatest_chart_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json)
+
+Artifact:
+
+- [../artifacts/issue39_chart_sensor_compensation_psd_benchmark.json](../artifacts/issue39_chart_sensor_compensation_psd_benchmark.json)
+
+The candidate keeps the PR `#30` profile intact except for the MTF-layer family change:
+
+- `mtf_compensation_mode: sensor_aperture_sinc -> chart_sensor_aperture_sinc`
+- `chart_fill_factor: 0.15`
+
+## PSD / MTF Result
+
+Compared with the current PR `#30` best branch:
+
+| Profile | `curve_mae_mean` | mean abs signed-rel | `MTF20` MAE | `MTF30` MAE | `MTF50` MAE |
+| --- | --- | --- | --- | --- | --- |
+| PR `#30` best branch | `0.04306442` | `0.08692956` | `0.03300903` | `0.03693524` | `0.00933262` |
+| issue `#39` chart+sensor candidate | `0.04313186` | `0.08672250` | `0.03317034` | `0.03705447` | `0.00938074` |
+
+Metric deltas from the PR `#30` best branch:
+
+- `curve_mae_mean`: `+0.00006744` worse
+- mean absolute signed-relative MTF residual: `-0.00020705` better
+- `MTF20` MAE: `+0.00016132` worse
+- `MTF30` MAE: `+0.00011924` worse
+- `MTF50` MAE: `+0.00004813` worse
+
+Band-wise signed-relative movement is also mixed rather than clearly better:
+
+- `top`: `-0.16462715 -> -0.15981866` improves slightly
+- `high`: `0.04964177 -> 0.05266795` worsens
+- `mid`: `0.10965437 -> 0.11051854` worsens
+- `low`: `0.02379494 -> 0.02388487` worsens slightly
+
+## Working Conclusion
+
+This prototype does **not** meet issue `#39`'s stricter lower-layer win condition.
+
+Why:
+
+- it does not improve `curve_mae_mean`
+- it does not improve the threshold readouts at `MTF20`, `MTF30`, or `MTF50`
+- the small win in mean absolute signed-relative residual is too weak and too mixed across bands to outweigh the curve and threshold losses
+
+Because the candidate fails at the primary PSD / MTF gate, this pass stops here and does not claim any downstream Acutance or Quality-Loss success from this family.
+
+## Outcome For Issue 39
+
+The bounded chart-plus-sensor aperture prototype is another negative result, not a new main-line family.
+
+That still narrows the search space usefully:
+
+- the existing one-term sensor compensation path remains the better approximation in the current reduced model
+- issue `#39` should not continue searching this exact chart-aperture variant unless a stronger source-backed chart-medium model justifies reopening the family

--- a/tests/test_benchmark_parity_psd_mtf.py
+++ b/tests/test_benchmark_parity_psd_mtf.py
@@ -149,6 +149,16 @@ class BenchmarkParityPsdMtfTest(unittest.TestCase):
         )
         self.assertEqual(profile.intrinsic_full_reference_mode, "paired_ori_transfer")
 
+    def test_profile_allows_chart_fill_factor_for_compensation_family(self) -> None:
+        profile = Profile(
+            name="test",
+            calibration_file="algo/deadleaf_13b10_psd_calibration.json",
+            mtf_compensation_mode="chart_sensor_aperture_sinc",
+            chart_fill_factor=0.5,
+        )
+        self.assertEqual(profile.mtf_compensation_mode, "chart_sensor_aperture_sinc")
+        self.assertEqual(profile.chart_fill_factor, 0.5)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_dead_leaves_mtf_compensation.py
+++ b/tests/test_dead_leaves_mtf_compensation.py
@@ -80,6 +80,33 @@ class DeadLeavesMtfCompensationTest(unittest.TestCase):
         )
         np.testing.assert_allclose(compensation, [2.0, 2.0])
 
+    def test_chart_sensor_aperture_compensation_adds_more_gain_than_sensor_only(self) -> None:
+        frequencies = np.array([0.0, 0.1, 0.25, 0.5], dtype=np.float64)
+        sensor_only = estimate_mtf_compensation_curve(
+            frequencies,
+            mode="sensor_aperture_sinc",
+            sensor_fill_factor=1.5,
+            max_gain=8.0,
+        )
+        chart_sensor = estimate_mtf_compensation_curve(
+            frequencies,
+            mode="chart_sensor_aperture_sinc",
+            sensor_fill_factor=1.5,
+            chart_fill_factor=0.5,
+            max_gain=8.0,
+        )
+        self.assertAlmostEqual(chart_sensor[0], 1.0)
+        self.assertGreater(chart_sensor[-1], sensor_only[-1])
+
+    def test_chart_sensor_aperture_compensation_validates_chart_fill_factor(self) -> None:
+        frequencies = np.array([0.1, 0.25], dtype=np.float64)
+        with self.assertRaisesRegex(ValueError, "chart_fill_factor must be positive"):
+            estimate_mtf_compensation_curve(
+                frequencies,
+                mode="chart_sensor_aperture_sinc",
+                chart_fill_factor=0.0,
+            )
+
     def test_apply_mtf_compensation_multiplies_curve(self) -> None:
         frequencies = np.array([0.0, 0.25, 0.5], dtype=np.float64)
         mtf = np.array([1.0, 0.8, 0.4], dtype=np.float64)


### PR DESCRIPTION
## Summary

- extend the existing source-backed compensation family with a bounded `chart_sensor_aperture_sinc` prototype
- thread `chart_fill_factor` through the PSD/MTF and Acutance/Quality-Loss profile schemas
- add narrow compensation-family tests, a candidate profile, a PSD benchmark artifact, and a benchmark note for issue `#39`

## Result

This is a bounded negative result, not a new main-line family.

Compared with the current PR `#30` best branch on the PSD/MTF benchmark:

- `curve_mae_mean`: `0.04306442 -> 0.04313186` worse
- mean absolute signed-relative MTF residual: `0.08692956 -> 0.08672250` better
- `MTF20` MAE: `0.03300903 -> 0.03317034` worse
- `MTF30` MAE: `0.03693524 -> 0.03705447` worse
- `MTF50` MAE: `0.00933262 -> 0.00938074` worse

The family improves the mean absolute signed-relative residual slightly, but it fails issue `#39`'s primary lower-layer gate because `curve_mae_mean` and all three threshold readouts regress.

## Validation

- `python3 -m pytest -q tests/test_dead_leaves_mtf_compensation.py tests/test_benchmark_parity_psd_mtf.py`
- `python3 -m pytest -q tests/test_benchmark_parity_acutance_quality_loss.py`
- `python3 -m py_compile algo/dead_leaves.py algo/benchmark_parity_psd_mtf.py algo/benchmark_parity_acutance_quality_loss.py`
- `python3 -m algo.benchmark_parity_psd_mtf 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json algo/deadleaf_13b10_imatest_chart_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json --output artifacts/issue39_chart_sensor_compensation_psd_benchmark.json`

Refs #39
Refs #29
Context from #10
Context from #11
Context from #30
Context from #38
