### PR TITLE
Issue #41: audit bounded chart-prior slope family after PR #42

### DIFF
--- a/algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_chart_prior_slope_m006_profile.json
+++ b/algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_chart_prior_slope_m006_profile.json
@@ -1,0 +1,135 @@
+{
+  "name": "deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_chart_prior_slope_m006",
+  "calibration_file": "algo/deadleaf_13b10_psd_calibration_chart_prior_slope_m006.json",
+  "gamma": 0.5,
+  "linearization_mode": "toe_power",
+  "linearization_toe": 0.12,
+  "bayer_pattern": "RGGB",
+  "bayer_mode": "demosaic_red",
+  "roi_source": "reference_refined",
+  "roi_width": 1655,
+  "roi_height": 1673,
+  "roi_refine_percentile": 45.0,
+  "roi_refine_sigma": 5.0,
+  "roi_refine_min_border_margin": 8,
+  "roi_refine_search_radius": 12,
+  "roi_refine_step": 2,
+  "roi_refine_area_tolerance": 0.98,
+  "matched_ori_reference_anchor": true,
+  "matched_ori_anchor_mode": "acutance_only",
+  "matched_ori_correction_clip_lo": 0.5,
+  "matched_ori_correction_clip_hi": 2.0,
+  "matched_ori_correction_strength": 1.0,
+  "matched_ori_strength_curve_frequencies": [
+    0.0,
+    0.12,
+    0.22,
+    0.35,
+    0.5
+  ],
+  "matched_ori_strength_curve_values": [
+    1.0,
+    1.0,
+    0.82,
+    0.95,
+    1.0
+  ],
+  "matched_ori_acutance_reference_anchor": true,
+  "matched_ori_acutance_correction_clip_lo": 0.9,
+  "matched_ori_acutance_correction_clip_hi": 1.1,
+  "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+  "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+    0.0,
+    0.25,
+    0.6,
+    0.8,
+    1.6,
+    2.5
+  ],
+  "matched_ori_acutance_curve_correction_clip_hi_values": [
+    1.02,
+    1.03,
+    0.895,
+    0.895,
+    1.05,
+    1.06
+  ],
+  "matched_ori_acutance_curve_correction_delta_power": 0.95,
+  "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+    0.0,
+    4.5,
+    5.8,
+    6.2
+  ],
+  "matched_ori_acutance_preset_correction_delta_power_values": [
+    1.05,
+    1.05,
+    1.85,
+    1.85
+  ],
+  "matched_ori_acutance_preset_strength_curve_relative_scales": [
+    0.0,
+    3.0,
+    4.5,
+    5.8,
+    6.2
+  ],
+  "matched_ori_acutance_preset_strength_curve_values": [
+    1.0,
+    1.0,
+    0.85,
+    0.45,
+    0.45
+  ],
+  "matched_ori_acutance_correction_strength": 1.0,
+  "matched_ori_acutance_strength_curve_relative_scales": [
+    0.0,
+    0.2,
+    0.8,
+    1.6,
+    2.5
+  ],
+  "matched_ori_acutance_strength_curve_values": [
+    0.7,
+    0.69,
+    0.64,
+    0.62,
+    0.6
+  ],
+  "frequency_scale": 1.0,
+  "normalization_band_lo": 0.01,
+  "normalization_band_hi": 0.03,
+  "normalization_mode": "max",
+  "acutance_band_lo": 0.017,
+  "acutance_band_hi": 0.035,
+  "acutance_band_mode": "mean",
+  "signal_psd_correction_gain": 0.0,
+  "signal_psd_correction_start_cpp": 0.08,
+  "signal_psd_correction_peak_cpp": 0.15,
+  "signal_psd_correction_stop_cpp": 0.22,
+  "noise_psd_model": "empirical",
+  "noise_psd_log_polynomial_degree": 2,
+  "noise_psd_scale": 1.0,
+  "acutance_noise_scale_mode": "fixed",
+  "acutance_noise_share_band_lo": 0.36,
+  "acutance_noise_share_band_hi": 0.5,
+  "acutance_noise_share_scale_coefficients": [
+    521.08180962,
+    -26.62905791,
+    1.59615575
+  ],
+  "high_frequency_guard_start_cpp": 0.36,
+  "high_frequency_guard_stop_cpp": 0.5,
+  "texture_support_scale": false,
+  "mtf_compensation_mode": "sensor_aperture_sinc",
+  "sensor_fill_factor": 0.7,
+  "chart_fill_factor": 1.0,
+  "compensation_denominator_clip": 0.25,
+  "compensation_max_gain": 3.0,
+  "quality_loss_om_ceiling": 0.8851,
+  "quality_loss_coefficients": [
+    64.99250542,
+    9.37974246,
+    0.72233291
+  ]
+}

--- a/algo/deadleaf_13b10_psd_calibration_chart_prior_slope_m006.json
+++ b/algo/deadleaf_13b10_psd_calibration_chart_prior_slope_m006.json
@@ -1,0 +1,33 @@
+{
+  "name": "deadleaf_13b10_empirical_chart_prior_slope_m006",
+  "source_count": 40,
+  "blend_width_cpp": 0.06,
+  "piecewise_segments": [
+    {
+      "start_cpp": 0.0,
+      "stop_cpp": 0.24,
+      "log_frequency_polynomial_coefficients": [
+        -0.08560034693213156,
+        -2.304373899007511,
+        -10.427709574750658
+      ],
+      "polynomial_degree": 2
+    },
+    {
+      "start_cpp": 0.18,
+      "stop_cpp": 0.5,
+      "log_frequency_polynomial_coefficients": [
+        -0.08560034693213156,
+        -2.244373899007511,
+        -10.530599990239481
+      ],
+      "polynomial_degree": 2
+    }
+  ],
+  "polynomial_degree": 2,
+  "log_frequency_quadratic_coefficients": [
+    -0.08560034693213156,
+    -2.304373899007511,
+    -10.427709574750658
+  ]
+}

--- a/artifacts/issue41_chart_prior_slope_acutance_benchmark.json
+++ b/artifacts/issue41_chart_prior_slope_acutance_benchmark.json
@@ -1,0 +1,679 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.0426419082983667,
+        "0.25": 0.03450723056011866,
+        "0.4": 0.028162391114511045,
+        "0.65": 0.03351676542287892,
+        "0.8": 0.039890883676316505,
+        "ori": 0.044422165524720086
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 1.3421389514230824,
+        "0.25": 1.2825995432153037,
+        "0.4": 1.1337887188584643,
+        "0.65": 0.3646116302822078,
+        "0.8": 1.0109879373437751,
+        "ori": 2.317792173136315
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.04249131400289711,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.013802151888956607,
+          "Computer Monitor Acutance": 0.052691955741307875,
+          "Large Print Acutance": 0.05132126004290283,
+          "Small Print Acutance": 0.04670043959486586,
+          "UHDTV Display Acutance": 0.047940762746452356
+        },
+        "curve_mae_mean": 0.03683437582462248,
+        "overall_quality_loss_mae_mean": 1.2221434105099775,
+        "quality_loss_focus_preset_mae_mean": 1.2221434105099775,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 0.14297762642651196,
+          "Computer Monitor Quality Loss": 2.906111784076103,
+          "Large Print Quality Loss": 0.9547911309308169,
+          "Small Print Quality Loss": 0.6076983310559123,
+          "UHDTV Display Quality Loss": 1.499138180060543
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json"
+    },
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.042590946803836086,
+        "0.25": 0.03445388601391976,
+        "0.4": 0.02812300087573406,
+        "0.65": 0.03348094496771122,
+        "0.8": 0.03985097286768009,
+        "ori": 0.04437175852000011
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 1.340078092044587,
+        "0.25": 1.2821447346117552,
+        "0.4": 1.1338375203719742,
+        "0.65": 0.3638397334773291,
+        "0.8": 1.0108222634621686,
+        "ori": 2.317384589918815
+      },
+      "delta_vs_first_profile": {
+        "acutance_focus_preset_mae_mean": -4.48278419531295e-06,
+        "curve_mae_mean": -4.534416361734461e-05,
+        "overall_quality_loss_mae_mean": -0.000644456072266264,
+        "quality_loss_focus_preset_mae_mean": -0.000644456072266264
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.042486831218701795,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.013802247905288301,
+          "Computer Monitor Acutance": 0.052665183748573804,
+          "Large Print Acutance": 0.05132586418527154,
+          "Small Print Acutance": 0.046702107662187464,
+          "UHDTV Display Acutance": 0.04793875259218785
+        },
+        "curve_mae_mean": 0.03678903166100513,
+        "overall_quality_loss_mae_mean": 1.2214989544377113,
+        "quality_loss_focus_preset_mae_mean": 1.2214989544377113,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 0.14297991495607307,
+          "Computer Monitor Quality Loss": 2.902905846061304,
+          "Large Print Quality Loss": 0.9548172583377941,
+          "Small Print Quality Loss": 0.6076935256225349,
+          "UHDTV Display Quality Loss": 1.4990982272108502
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_profile.json"
+    },
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_chart_prior_slope_m006.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          64.99250542,
+          9.37974246,
+          0.72233291
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": null,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 0.7,
+        "texture_support_scale": false
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.03215413652506652,
+        "0.25": 0.025371584343638894,
+        "0.4": 0.012399886374698006,
+        "0.65": 0.017085450252590745,
+        "0.8": 0.03107496671278288,
+        "ori": 0.04903293084081115
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 1.2640017342729237,
+        "0.25": 1.1345788464210735,
+        "0.4": 1.213966033922506,
+        "0.65": 1.622334700541301,
+        "0.8": 1.9188641973494125,
+        "ori": 2.0503984565491775
+      },
+      "delta_vs_first_profile": {
+        "acutance_focus_preset_mae_mean": -0.013664826559807736,
+        "curve_mae_mean": -0.010022422924045024,
+        "overall_quality_loss_mae_mean": 0.2514120675922533,
+        "quality_loss_focus_preset_mae_mean": 0.2514120675922533
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.028826487443089372,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.012469769922903527,
+          "Computer Monitor Acutance": 0.018445765302918915,
+          "Large Print Acutance": 0.04088482627143688,
+          "Small Print Acutance": 0.042660347986504435,
+          "UHDTV Display Acutance": 0.02967172773168309
+        },
+        "curve_mae_mean": 0.026811952900577453,
+        "overall_quality_loss_mae_mean": 1.4735554781022309,
+        "quality_loss_focus_preset_mae_mean": 1.4735554781022309,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 0.2247358126146569,
+          "Computer Monitor Quality Loss": 1.3537044829861922,
+          "Large Print Quality Loss": 2.1809817899151143,
+          "Small Print Quality Loss": 2.047258068175407,
+          "UHDTV Display Quality Loss": 1.5610972368197849
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_chart_prior_slope_m006_profile.json"
+    }
+  ]
+}

--- a/artifacts/issue41_chart_prior_slope_psd_benchmark.json
+++ b/artifacts/issue41_chart_prior_slope_psd_benchmark.json
@@ -1,0 +1,545 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.045132331541343135,
+        "0.25": 0.03837972282290488,
+        "0.4": 0.03424583283108843,
+        "0.65": 0.04020915188141205,
+        "0.8": 0.049664991465143526,
+        "ori": 0.055589288189657284
+      },
+      "overall": {
+        "curve_mae_mean": 0.04306441973920293,
+        "mtf_abs_signed_rel_mean": 0.08692955889841379,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.017639268013990343,
+            "mre_mean": 0.08883603386012136,
+            "signed_rel_mean": 0.04964177427444007
+          },
+          "low": {
+            "mae_mean": 0.03704553941403868,
+            "mre_mean": 0.046572470331734825,
+            "signed_rel_mean": 0.0237949421475065
+          },
+          "mid": {
+            "mae_mean": 0.03898616152003224,
+            "mre_mean": 0.12397538768693758,
+            "signed_rel_mean": 0.10965436746685472
+          },
+          "top": {
+            "mae_mean": 0.0738124428343438,
+            "mre_mean": 0.20207246214765648,
+            "signed_rel_mean": -0.16462715170485387
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.033009025007104606,
+          "mtf30": 0.03693523768742383,
+          "mtf50": 0.009332615436071163
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.014469243052711292,
+          "Computer Monitor Acutance": 0.06145640899956405,
+          "Large Print Acutance": 0.05374582109239643,
+          "Small Print Acutance": 0.061691355516267324,
+          "UHDTV Display Acutance": 0.056009600718383366
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json"
+    },
+    {
+      "analysis_pipeline": {
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.04505838676895136,
+        "0.25": 0.03830294990572591,
+        "0.4": 0.03417346101446392,
+        "0.65": 0.04016098674153959,
+        "0.8": 0.04962195025048853,
+        "ori": 0.055534435160880836
+      },
+      "overall": {
+        "curve_mae_mean": 0.04300089177816799,
+        "mtf_abs_signed_rel_mean": 0.08671416893394165,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.01764835359892083,
+            "mre_mean": 0.088865357734797,
+            "signed_rel_mean": 0.04982888092128941
+          },
+          "low": {
+            "mae_mean": 0.03704553941403868,
+            "mre_mean": 0.046572470331734825,
+            "signed_rel_mean": 0.0237949421475065
+          },
+          "mid": {
+            "mae_mean": 0.03898616152003224,
+            "mre_mean": 0.12397538768693758,
+            "signed_rel_mean": 0.10965436746685472
+          },
+          "top": {
+            "mae_mean": 0.07374065223652229,
+            "mre_mean": 0.20171750026037474,
+            "signed_rel_mean": -0.16357848520011598
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.03301077142967389,
+          "mtf30": 0.03693639342667963,
+          "mtf50": 0.009332615436071163
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.014469251255210305,
+          "Computer Monitor Acutance": 0.06140362409578977,
+          "Large Print Acutance": 0.05374588217426117,
+          "Small Print Acutance": 0.06169135551342499,
+          "UHDTV Display Acutance": 0.05600207521610212
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_profile.json"
+    },
+    {
+      "analysis_pipeline": {
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_chart_prior_slope_m006.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 0.7,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": false
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.03230929416937095,
+        "0.25": 0.025334667391512064,
+        "0.4": 0.01109954045805001,
+        "0.65": 0.014974616964351227,
+        "0.8": 0.03168529427753006,
+        "ori": 0.050243636962276676
+      },
+      "overall": {
+        "curve_mae_mean": 0.026607584651955406,
+        "mtf_abs_signed_rel_mean": 0.332739677626147,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.07440168246714296,
+            "mre_mean": 0.32701823948294273,
+            "signed_rel_mean": -0.32701823948294273
+          },
+          "low": {
+            "mae_mean": 0.07688041832069795,
+            "mre_mean": 0.09579131947287828,
+            "signed_rel_mean": -0.0953403940985911
+          },
+          "mid": {
+            "mae_mean": 0.10901615822457673,
+            "mre_mean": 0.2714274685379013,
+            "signed_rel_mean": -0.2714274685379013
+          },
+          "top": {
+            "mae_mean": 0.2404239182589249,
+            "mre_mean": 0.6371726083851528,
+            "signed_rel_mean": -0.6371726083851528
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.03801027433950881,
+          "mtf30": 0.05639193743384798,
+          "mtf50": 0.033666939703106656
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.012279761909372074,
+          "Computer Monitor Acutance": 0.013215783912474128,
+          "Large Print Acutance": 0.0295648820969033,
+          "Small Print Acutance": 0.033212600565072734,
+          "UHDTV Display Acutance": 0.014515724202707164
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_chart_prior_slope_m006_profile.json"
+    }
+  ]
+}

--- a/docs/issue41_chart_prior_slope_followup.md
+++ b/docs/issue41_chart_prior_slope_followup.md
@@ -1,0 +1,109 @@
+# Issue 41 Chart-Prior Slope Follow-up
+
+This note records the re-scoped issue `#41` follow-up after PR `#42`.
+
+The bounded family tested here stays inside the existing chart-prior / ideal-PSD path instead of reopening issue `#39`'s chart-plus-sensor compensation family or the unavailable measured chart-patch OECF scope that issue `#41` originally carried.
+
+## Family Tested
+
+The candidate uses one constrained high-frequency prior-slope change inside the ideal-PSD calibration:
+
+- low-frequency segment stays on the current empirical quadratic calibration
+- high-frequency segment keeps the same quadratic curvature but reduces the log-slope by `0.06`
+- the two segments are joined with a narrow blend so the change stays bounded to the upper-frequency chart-prior region
+
+Tracked files:
+
+- [../algo/deadleaf_13b10_psd_calibration_chart_prior_slope_m006.json](../algo/deadleaf_13b10_psd_calibration_chart_prior_slope_m006.json)
+- [../algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_chart_prior_slope_m006_profile.json](../algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_chart_prior_slope_m006_profile.json)
+
+Benchmark artifacts:
+
+- [../artifacts/issue41_chart_prior_slope_psd_benchmark.json](../artifacts/issue41_chart_prior_slope_psd_benchmark.json)
+- [../artifacts/issue41_chart_prior_slope_acutance_benchmark.json](../artifacts/issue41_chart_prior_slope_acutance_benchmark.json)
+
+Comparison references:
+
+- PR `#30` current best branch
+- PR `#42` anchored-high-frequency chart-prior candidate
+
+## Why This Is Source-Backed
+
+This follows the same repo evidence that justified re-scoping issue `#41`:
+
+- [dead_leaves_black_box_research.md](./dead_leaves_black_box_research.md) lists `chart ideal PSD / chart-MTF prior` as modeled but still partial
+- the same note also lists `chart MTF exponent` as only partially modeled rather than explicitly exposed
+- PR `#42` already showed that bounded chart-prior changes can move the lower-layer metrics without reopening unrelated families
+
+That makes this pass a constrained prior-slope / chart-exponent-style audit inside the current data-supported ideal-PSD family.
+
+## PSD / MTF Result
+
+| Profile | `curve_mae_mean` | mean abs signed-rel | `MTF20` MAE | `MTF30` MAE | `MTF50` MAE |
+| --- | --- | --- | --- | --- | --- |
+| PR `#30` best branch | `0.04306442` | `0.08692956` | `0.03300903` | `0.03693524` | `0.00933262` |
+| PR `#42` anchored HF PSD | `0.04300089` | `0.08671417` | `0.03301077` | `0.03693639` | `0.00933262` |
+| issue `#41` chart-prior slope candidate | `0.02660758` | `0.33273968` | `0.03801027` | `0.05639194` | `0.03366694` |
+
+Band movement for the new candidate:
+
+- `low`: `0.02379494 -> -0.09534039`
+- `mid`: `0.10965437 -> -0.27142747`
+- `high`: `0.04964177 -> -0.32701824`
+- `top`: `-0.16462715 -> -0.63717261`
+
+Interpretation:
+
+- aggregate curve MAE improves sharply
+- the issue's primary lower-layer readouts get much worse
+- the candidate no longer preserves the threshold behavior that PR `#30` and PR `#42` keep roughly stable
+
+So this is not a viable next main-line chart-prior direction on the issue `#41` decision surface.
+
+## Acutance / Quality-Loss Guardrails
+
+| Profile | `curve_mae_mean` | focus-preset Acutance MAE mean | `overall_quality_loss_mae_mean` |
+| --- | --- | --- | --- |
+| PR `#30` best branch | `0.03683438` | `0.04249131` | `1.22214341` |
+| PR `#42` anchored HF PSD | `0.03678903` | `0.04248683` | `1.22149895` |
+| issue `#41` chart-prior slope candidate | `0.02681195` | `0.02882649` | `1.47355548` |
+
+Additional preset movement for the new candidate:
+
+- `5.5" Phone Display Acutance`: `0.01380215 -> 0.01246977` better
+- `5.5" Phone Display Quality Loss`: `0.14297763 -> 0.22473581` worse
+
+Interpretation:
+
+- the same slope variant improves aggregate curve and Acutance fit materially
+- but it regresses overall Quality Loss beyond the current branch and beyond the README quality-loss gate
+- this confirms the family is another mixed result, not a safe upgrade over PR `#30` or PR `#42`
+
+## Difference From PR 40
+
+This issue does **not** reopen PR `#40`'s chart-plus-sensor aperture compensation family.
+
+PR `#40` changed the compensation denominator with an explicit chart-medium aperture term.
+This issue instead keeps the compensation path unchanged and only changes the chart-prior slope inside the ideal-PSD calibration.
+
+That separation matters because the current result shows the failure mode is different:
+
+- PR `#40` was a bounded lower-layer negative result with only small movement
+- this slope variant moves the curve strongly, but it does so by destabilizing the threshold and quality-loss readouts
+
+## Conclusion
+
+The bounded chart-prior slope family is another mixed negative result.
+
+What it proved:
+
+- the chart-prior slope is a real signal-bearing lever inside the current reduced model
+- that lever can improve aggregate curve and Acutance fit much more strongly than PR `#42`'s anchored residual
+
+Why it still closes as a negative result:
+
+- issue `#41` prioritizes PSD/MTF readouts first
+- `MTF20`, `MTF30`, `MTF50`, and mean absolute signed-relative residual all regress badly
+- overall Quality Loss also regresses from `1.22214341` to `1.47355548`
+
+That means the family should be recorded, but not promoted as the next main-line chart-prior path.


### PR DESCRIPTION
## Summary

Issue #41 was re-scoped away from unavailable measured chart-patch OECF work and back into one current-data-supported chart-prior family under umbrella issue #29.

This PR records one bounded chart-prior slope / chart-exponent-style follow-up inside the existing ideal-PSD calibration path:

- adds a tracked piecewise chart-prior slope calibration that keeps the low-frequency quadratic branch intact and applies a mild `-0.06` high-frequency slope delta
- adds the matching profile and benchmark artifacts
- documents the result as a bounded mixed negative outcome, not a new main-line direction

## Why This Family

This stays within the repo evidence cited by issue #41:

- chart ideal PSD / chart-MTF prior is still only partially modeled
- chart MTF exponent is still only partially modeled
- PR #42 already showed that a tightly bounded chart-prior change can move the lower-layer metrics

Unlike PR #40, this does not change chart/sensor aperture compensation. It changes only the chart-prior slope inside the ideal-PSD calibration.

## PSD / MTF Comparison

Compared against PR #30 and PR #42:

| Profile | curve_mae_mean | mean abs signed-rel | MTF20 | MTF30 | MTF50 |
| --- | --- | --- | --- | --- | --- |
| PR #30 best branch | 0.04306442 | 0.08692956 | 0.03300903 | 0.03693524 | 0.00933262 |
| PR #42 anchored HF PSD | 0.04300089 | 0.08671417 | 0.03301077 | 0.03693639 | 0.00933262 |
| issue #41 chart-prior slope candidate | 0.02660758 | 0.33273968 | 0.03801027 | 0.05639194 | 0.03366694 |

Interpretation:

- the bounded slope change dramatically improves aggregate curve MAE
- but it catastrophically regresses the primary lower-layer readouts that issue #41 prioritizes first
- this is therefore not a viable main-line replacement for either PR #30 or PR #42

## Acutance / Quality-Loss Guardrails

| Profile | curve_mae_mean | focus-preset Acutance MAE mean | overall_quality_loss_mae_mean |
| --- | --- | --- | --- |
| PR #30 best branch | 0.03683438 | 0.04249131 | 1.22214341 |
| PR #42 anchored HF PSD | 0.03678903 | 0.04248683 | 1.22149895 |
| issue #41 chart-prior slope candidate | 0.02681195 | 0.02882649 | 1.47355548 |

Interpretation:

- the same slope change improves aggregate curve and Acutance fit materially
- but it pushes overall Quality Loss far past the current branch and past the README quality-loss gate
- that makes the family another bounded mixed negative result rather than the next main-line direction

## Validation

- `python3 -m algo.benchmark_parity_psd_mtf 20260318_deadleaf_13b10 ... --output artifacts/issue41_chart_prior_slope_psd_benchmark.json`
- `python3 -m algo.benchmark_parity_acutance_quality_loss 20260318_deadleaf_13b10 ... --output artifacts/issue41_chart_prior_slope_acutance_benchmark.json`

Refs #41
Refs #29
Context from #30
Context from #40
Context from #42
