### PR TITLE
Issue #44: audit intrinsic phase-ECC affine alignment

### DIFF
--- a/algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_ecc_affine_profile.json
+++ b/algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_ecc_affine_profile.json
@@ -1,0 +1,99 @@
+{
+  "name": "deadleaf_13b10_imatest_intrinsic_full_reference_phase_ecc_affine",
+  "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+  "gamma": 0.5,
+  "linearization_mode": "toe_power",
+  "linearization_toe": 0.12,
+  "bayer_pattern": "RGGB",
+  "bayer_mode": "demosaic_red",
+  "roi_source": "reference_refined",
+  "roi_width": 1655,
+  "roi_height": 1673,
+  "roi_refine_percentile": 45.0,
+  "roi_refine_sigma": 5.0,
+  "roi_refine_min_border_margin": 8,
+  "roi_refine_search_radius": 4,
+  "roi_refine_step": 2,
+  "roi_refine_area_tolerance": 0.98,
+  "intrinsic_full_reference_mode": "paired_ori_transfer",
+  "intrinsic_full_reference_clip_lo": 0.5,
+  "intrinsic_full_reference_clip_hi": 1.5,
+  "intrinsic_full_reference_registration_mode": "phase_ecc_affine",
+  "frequency_scale": 1.0,
+  "normalization_band_lo": 0.01,
+  "normalization_band_hi": 0.03,
+  "normalization_mode": "max",
+  "acutance_band_lo": 0.017,
+  "acutance_band_hi": 0.035,
+  "acutance_band_mode": "mean",
+  "noise_psd_model": "empirical",
+  "noise_psd_scale": 1.0,
+  "quality_loss_om_ceiling": 0.8851,
+  "quality_loss_coefficients": [
+    37.240228358776136,
+    26.54550669779819,
+    0.4538662637619741
+  ],
+  "quality_loss_preset_overrides": {
+    "Computer Monitor Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        5677361.198044325,
+        -16715685.9524707,
+        20317567.326582585,
+        -13046703.33912079,
+        4667794.619228022,
+        -882296.9160375095,
+        68863.59709647154
+      ]
+    },
+    "5.5\" Phone Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        -110912321.41149135,
+        50461107.51563171,
+        -9079490.127807735,
+        815148.8697247265,
+        -37712.984407641874,
+        854.6941149036079,
+        -6.261149027919645
+      ]
+    },
+    "UHDTV Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        1783462.6221675149,
+        -3813432.5606394163,
+        3326218.4642961356,
+        -1514886.1959663907,
+        380334.163146246,
+        -49956.87092015135,
+        2692.9566508574017
+      ]
+    },
+    "Small Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        6690980.837239251,
+        -12955277.716404187,
+        10300283.291740375,
+        -4303759.200708971,
+        996904.2653558743,
+        -121409.71509269004,
+        6084.6471373306085
+      ]
+    },
+    "Large Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        2355074.475971866,
+        -5276146.244338096,
+        4846781.143787682,
+        -2336594.295523967,
+        623766.4933095274,
+        -87476.30712136331,
+        5049.882965558553
+      ]
+    }
+  }
+}

--- a/algo/parity_benchmark_common.py
+++ b/algo/parity_benchmark_common.py
@@ -53,10 +53,10 @@ def center_crop_to_common_shape(
     return crop_center(reference), crop_center(observed)
 
 
-def align_patch_phase_correlation(
+def estimate_phase_correlation_shift(
     reference_patch: np.ndarray,
     observed_patch: np.ndarray,
-) -> tuple[np.ndarray, tuple[float, float], float]:
+) -> tuple[tuple[float, float], float]:
     reference, observed = center_crop_to_common_shape(reference_patch, observed_patch)
     window = np.outer(
         np.hanning(reference.shape[0]),
@@ -67,6 +67,15 @@ def align_patch_phase_correlation(
         observed.astype(np.float32),
         window,
     )
+    return (float(shift[0]), float(shift[1])), float(response)
+
+
+def align_patch_phase_correlation(
+    reference_patch: np.ndarray,
+    observed_patch: np.ndarray,
+) -> tuple[np.ndarray, tuple[float, float], float]:
+    reference, observed = center_crop_to_common_shape(reference_patch, observed_patch)
+    shift, response = estimate_phase_correlation_shift(reference, observed)
     transform = np.array(
         [
             [1.0, 0.0, -float(shift[0])],
@@ -82,6 +91,62 @@ def align_patch_phase_correlation(
         borderMode=cv2.BORDER_REFLECT,
     )
     return aligned.astype(np.float64), (float(shift[0]), float(shift[1])), float(response)
+
+
+def _prepare_patch_for_ecc(patch: np.ndarray) -> np.ndarray:
+    prepared = np.asarray(patch, dtype=np.float32)
+    prepared = prepared - float(np.mean(prepared))
+    prepared = cv2.GaussianBlur(prepared, (0, 0), 1.2)
+    std = float(np.std(prepared))
+    if std > EPS:
+        prepared = prepared / std
+    min_value = float(np.min(prepared))
+    max_value = float(np.max(prepared))
+    if max_value - min_value <= EPS:
+        return np.zeros_like(prepared, dtype=np.float32)
+    return ((prepared - min_value) / (max_value - min_value)).astype(np.float32)
+
+
+def align_patch_phase_ecc_affine(
+    reference_patch: np.ndarray,
+    observed_patch: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, float]:
+    reference, observed = center_crop_to_common_shape(reference_patch, observed_patch)
+    shift, _ = estimate_phase_correlation_shift(reference, observed)
+    initial_warp = np.array(
+        [
+            [1.0, 0.0, -float(shift[0])],
+            [0.0, 1.0, -float(shift[1])],
+        ],
+        dtype=np.float32,
+    )
+    criteria = (
+        cv2.TERM_CRITERIA_EPS | cv2.TERM_CRITERIA_COUNT,
+        200,
+        1e-6,
+    )
+    try:
+        correlation, warp = cv2.findTransformECC(
+            _prepare_patch_for_ecc(reference),
+            _prepare_patch_for_ecc(observed),
+            initial_warp.copy(),
+            cv2.MOTION_AFFINE,
+            criteria,
+            None,
+            5,
+        )
+    except cv2.error:
+        aligned, _, response = align_patch_phase_correlation(reference, observed)
+        return aligned, initial_warp.astype(np.float64), float(response)
+
+    aligned = cv2.warpAffine(
+        observed.astype(np.float32),
+        warp,
+        (reference.shape[1], reference.shape[0]),
+        flags=cv2.INTER_LINEAR | cv2.WARP_INVERSE_MAP,
+        borderMode=cv2.BORDER_REFLECT,
+    )
+    return aligned.astype(np.float64), warp.astype(np.float64), float(correlation)
 
 
 def _radial_bin_average(
@@ -141,6 +206,8 @@ def derive_intrinsic_transfer_curve(
     reference, observed = center_crop_to_common_shape(reference_patch, observed_patch)
     if registration_mode == "phase_correlation":
         observed_aligned, _, _ = align_patch_phase_correlation(reference, observed)
+    elif registration_mode == "phase_ecc_affine":
+        observed_aligned, _, _ = align_patch_phase_ecc_affine(reference, observed)
     elif registration_mode == "none":
         observed_aligned = observed
     else:
@@ -179,6 +246,8 @@ def derive_intrinsic_transfer_curve(
         if anchor > EPS:
             transfer_curve = transfer_curve / anchor
     return np.clip(transfer_curve, clip_lo, clip_hi)
+
+
 def derive_quantile_transfer_curve(
     source_image: np.ndarray,
     target_image: np.ndarray,

--- a/artifacts/issue44_intrinsic_phase_ecc_affine_acutance_benchmark.json
+++ b/artifacts/issue44_intrinsic_phase_ecc_affine_acutance_benchmark.json
@@ -1,0 +1,620 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.0426419082983667,
+        "0.25": 0.03450723056011866,
+        "0.4": 0.028162391114511045,
+        "0.65": 0.03351676542287892,
+        "0.8": 0.039890883676316505,
+        "ori": 0.044422165524720086
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 1.3421389514230824,
+        "0.25": 1.2825995432153037,
+        "0.4": 1.1337887188584643,
+        "0.65": 0.3646116302822078,
+        "0.8": 1.0109879373437751,
+        "ori": 2.317792173136315
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.04249131400289711,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.013802151888956607,
+          "Computer Monitor Acutance": 0.052691955741307875,
+          "Large Print Acutance": 0.05132126004290283,
+          "Small Print Acutance": 0.04670043959486586,
+          "UHDTV Display Acutance": 0.047940762746452356
+        },
+        "curve_mae_mean": 0.03683437582462248,
+        "overall_quality_loss_mae_mean": 1.2221434105099775,
+        "quality_loss_focus_preset_mae_mean": 1.2221434105099775,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 0.14297762642651196,
+          "Computer Monitor Quality Loss": 2.906111784076103,
+          "Large Print Quality Loss": 0.9547911309308169,
+          "Small Print Quality Loss": 0.6076983310559123,
+          "UHDTV Display Quality Loss": 1.499138180060543
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json"
+    },
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": null,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": null,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_hi_values": null,
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": null,
+        "matched_ori_acutance_preset_correction_delta_power_values": null,
+        "matched_ori_acutance_preset_strength_curve_relative_scales": null,
+        "matched_ori_acutance_preset_strength_curve_values": null,
+        "matched_ori_acutance_reference_anchor": false,
+        "matched_ori_acutance_strength_curve_relative_scales": null,
+        "matched_ori_acutance_strength_curve_values": null,
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": false,
+        "matched_ori_strength_curve_frequencies": null,
+        "matched_ori_strength_curve_values": null,
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "none",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.0,
+        "texture_support_scale": false
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.035196683613694144,
+        "0.25": 0.026063595116536987,
+        "0.4": 0.01753747396802398,
+        "0.65": 0.02312474254644139,
+        "0.8": 0.049338085629964015,
+        "ori": 0.07933816634336006
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 9.228172826352582,
+        "0.25": 5.167259124080752,
+        "0.4": 1.9657004646755276,
+        "0.65": 0.4897094076381619,
+        "0.8": 0.995854510684369,
+        "ori": 10.476408297514947
+      },
+      "delta_vs_first_profile": {
+        "acutance_focus_preset_mae_mean": -0.010839086413757582,
+        "curve_mae_mean": -0.0009609172699985083,
+        "overall_quality_loss_mae_mean": 3.3458657451639797,
+        "quality_loss_focus_preset_mae_mean": 3.3458657451639797
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.03165222758913953,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.019550144806142,
+          "Computer Monitor Acutance": 0.03459963699573056,
+          "Large Print Acutance": 0.035489754869580475,
+          "Small Print Acutance": 0.03236185429681691,
+          "UHDTV Display Acutance": 0.03625974697742769
+        },
+        "curve_mae_mean": 0.03587345855462397,
+        "overall_quality_loss_mae_mean": 4.568009155673957,
+        "quality_loss_focus_preset_mae_mean": 4.568009155673957,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 10.625076452435083,
+          "Computer Monitor Quality Loss": 8.429551248810423,
+          "Large Print Quality Loss": 0.8041006693709367,
+          "Small Print Quality Loss": 0.8460359016507393,
+          "UHDTV Display Quality Loss": 2.1352815061026047
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_profile.json"
+    },
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": null,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_ecc_affine",
+        "intrinsic_full_reference_scope": "replace_all",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": null,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_hi_values": null,
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": null,
+        "matched_ori_acutance_preset_correction_delta_power_values": null,
+        "matched_ori_acutance_preset_strength_curve_relative_scales": null,
+        "matched_ori_acutance_preset_strength_curve_values": null,
+        "matched_ori_acutance_reference_anchor": false,
+        "matched_ori_acutance_strength_curve_relative_scales": null,
+        "matched_ori_acutance_strength_curve_values": null,
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": false,
+        "matched_ori_strength_curve_frequencies": null,
+        "matched_ori_strength_curve_values": null,
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "none",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.0,
+        "texture_support_scale": false
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.037199414505831425,
+        "0.25": 0.027610183501652074,
+        "0.4": 0.018691766709722273,
+        "0.65": 0.027487135302266437,
+        "0.8": 0.048610505372787036,
+        "ori": 0.07933816634336006
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 9.697117196046587,
+        "0.25": 5.48555523765419,
+        "0.4": 2.05104216285524,
+        "0.65": 0.4802612361900531,
+        "0.8": 1.0004355556177034,
+        "ori": 10.476408297514947
+      },
+      "delta_vs_first_profile": {
+        "acutance_focus_preset_mae_mean": -0.009900729048731773,
+        "curve_mae_mean": 0.00027052835793873325,
+        "overall_quality_loss_mae_mean": 3.520353573295267,
+        "quality_loss_focus_preset_mae_mean": 3.520353573295267
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.032590584954165336,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.019635313854869444,
+          "Computer Monitor Acutance": 0.03549915245610975,
+          "Large Print Acutance": 0.03665088650637028,
+          "Small Print Acutance": 0.03356681285353623,
+          "UHDTV Display Acutance": 0.03760075909994096
+        },
+        "curve_mae_mean": 0.03710490418256121,
+        "overall_quality_loss_mae_mean": 4.742496983805244,
+        "quality_loss_focus_preset_mae_mean": 4.742496983805244,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 11.423153381841615,
+          "Computer Monitor Quality Loss": 8.43797156502082,
+          "Large Print Quality Loss": 0.8222035380914814,
+          "Small Print Quality Loss": 0.850638280028347,
+          "UHDTV Display Quality Loss": 2.1785181540439575
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_ecc_affine_profile.json"
+    }
+  ]
+}

--- a/artifacts/issue44_intrinsic_phase_ecc_affine_psd_benchmark.json
+++ b/artifacts/issue44_intrinsic_phase_ecc_affine_psd_benchmark.json
@@ -1,0 +1,425 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.045132331541343135,
+        "0.25": 0.03837972282290488,
+        "0.4": 0.03424583283108843,
+        "0.65": 0.04020915188141205,
+        "0.8": 0.049664991465143526,
+        "ori": 0.055589288189657284
+      },
+      "overall": {
+        "curve_mae_mean": 0.04306441973920293,
+        "mtf_abs_signed_rel_mean": 0.08692955889841379,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.017639268013990343,
+            "mre_mean": 0.08883603386012136,
+            "signed_rel_mean": 0.04964177427444007
+          },
+          "low": {
+            "mae_mean": 0.03704553941403868,
+            "mre_mean": 0.046572470331734825,
+            "signed_rel_mean": 0.0237949421475065
+          },
+          "mid": {
+            "mae_mean": 0.03898616152003224,
+            "mre_mean": 0.12397538768693758,
+            "signed_rel_mean": 0.10965436746685472
+          },
+          "top": {
+            "mae_mean": 0.0738124428343438,
+            "mre_mean": 0.20207246214765648,
+            "signed_rel_mean": -0.16462715170485387
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.033009025007104606,
+          "mtf30": 0.03693523768742383,
+          "mtf50": 0.009332615436071163
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.014469243052711292,
+          "Computer Monitor Acutance": 0.06145640899956405,
+          "Large Print Acutance": 0.05374582109239643,
+          "Small Print Acutance": 0.061691355516267324,
+          "UHDTV Display Acutance": 0.056009600718383366
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json"
+    },
+    {
+      "analysis_pipeline": {
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": null,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_hi_values": null,
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": null,
+        "matched_ori_acutance_preset_correction_delta_power_values": null,
+        "matched_ori_acutance_preset_strength_curve_relative_scales": null,
+        "matched_ori_acutance_preset_strength_curve_values": null,
+        "matched_ori_acutance_reference_anchor": false,
+        "matched_ori_acutance_strength_curve_relative_scales": null,
+        "matched_ori_acutance_strength_curve_values": null,
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": false,
+        "matched_ori_strength_curve_frequencies": null,
+        "matched_ori_strength_curve_values": null,
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "none",
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.0,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": false
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.035196683613694144,
+        "0.25": 0.026063595116536987,
+        "0.4": 0.01753747396802398,
+        "0.65": 0.02312474254644139,
+        "0.8": 0.049338085629964015,
+        "ori": 0.07933816634336006
+      },
+      "overall": {
+        "curve_mae_mean": 0.03587345855462397,
+        "mtf_abs_signed_rel_mean": 0.20631328511090832,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.05364693984972888,
+            "mre_mean": 0.4393614969865764,
+            "signed_rel_mean": 0.42543616835229364
+          },
+          "low": {
+            "mae_mean": 0.01376897213542222,
+            "mre_mean": 0.019784103888456157,
+            "signed_rel_mean": 0.01835499188457983
+          },
+          "mid": {
+            "mae_mean": 0.043064434659796536,
+            "mre_mean": 0.21014153510561587,
+            "signed_rel_mean": 0.19180123688322911
+          },
+          "top": {
+            "mae_mean": 0.044614178371310126,
+            "mre_mean": 0.23687141210944618,
+            "signed_rel_mean": 0.18966074332353067
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.08283943347415898,
+          "mtf30": 0.037939058443613165,
+          "mtf50": 0.005028927723658681
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.019550144806142,
+          "Computer Monitor Acutance": 0.03459963699573056,
+          "Large Print Acutance": 0.035489754869580475,
+          "Small Print Acutance": 0.03236185429681691,
+          "UHDTV Display Acutance": 0.03625974697742769
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_profile.json"
+    },
+    {
+      "analysis_pipeline": {
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_ecc_affine",
+        "intrinsic_full_reference_scope": "replace_all",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": null,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_hi_values": null,
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": null,
+        "matched_ori_acutance_preset_correction_delta_power_values": null,
+        "matched_ori_acutance_preset_strength_curve_relative_scales": null,
+        "matched_ori_acutance_preset_strength_curve_values": null,
+        "matched_ori_acutance_reference_anchor": false,
+        "matched_ori_acutance_strength_curve_relative_scales": null,
+        "matched_ori_acutance_strength_curve_values": null,
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": false,
+        "matched_ori_strength_curve_frequencies": null,
+        "matched_ori_strength_curve_values": null,
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "none",
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.0,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": false
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.037199414505831425,
+        "0.25": 0.027610183501652074,
+        "0.4": 0.018691766709722273,
+        "0.65": 0.027487135302266437,
+        "0.8": 0.048610505372787036,
+        "ori": 0.07933816634336006
+      },
+      "overall": {
+        "curve_mae_mean": 0.03710490418256121,
+        "mtf_abs_signed_rel_mean": 0.21560307775088186,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.054146627840666664,
+            "mre_mean": 0.4450337830338473,
+            "signed_rel_mean": 0.4358424078060407
+          },
+          "low": {
+            "mae_mean": 0.013929143334576236,
+            "mre_mean": 0.019837073556660516,
+            "signed_rel_mean": 0.01855778816688129
+          },
+          "mid": {
+            "mae_mean": 0.04358654789754748,
+            "mre_mean": 0.21170524630594176,
+            "signed_rel_mean": 0.19639856889092547
+          },
+          "top": {
+            "mae_mean": 0.04482309151349247,
+            "mre_mean": 0.23987523544580652,
+            "signed_rel_mean": 0.21161354613967998
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.08788120248932149,
+          "mtf30": 0.038586043438491036,
+          "mtf50": 0.005049808014793563
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.019635313854869444,
+          "Computer Monitor Acutance": 0.03549915245610975,
+          "Large Print Acutance": 0.03665088650637028,
+          "Small Print Acutance": 0.03356681285353623,
+          "UHDTV Display Acutance": 0.03760075909994096
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_ecc_affine_profile.json"
+    }
+  ]
+}

--- a/docs/issue44_intrinsic_phase_ecc_affine_followup.md
+++ b/docs/issue44_intrinsic_phase_ecc_affine_followup.md
@@ -1,0 +1,66 @@
+# Issue 44 Intrinsic Phase-ECC Affine Follow-up
+
+Issue: `#44`  
+Parent: `#29`  
+Context: `#33`, `#34`, `#38`, `#43`
+
+## What changed
+
+- Added a bounded intrinsic registration mode, `phase_ecc_affine`, for the paired-`ori` full-reference path.
+- Kept the existing phase-correlation translation estimate as the initializer, then refined the alignment with an ECC affine warp.
+- Added focused tests showing the affine mode improves small rotation/scale alignment while keeping the intrinsic transfer curve stable and clipped.
+- Checked in:
+  - `algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_ecc_affine_profile.json`
+  - `artifacts/issue44_intrinsic_phase_ecc_affine_psd_benchmark.json`
+  - `artifacts/issue44_intrinsic_phase_ecc_affine_acutance_benchmark.json`
+
+## Why this family
+
+Issue `#33` / PR `#34` only implemented the minimum intrinsic registration slice: translation-only alignment via phase correlation.
+
+The repo research inventory still marks reference-image warp/alignment as a major missing intrinsic family, so this issue tested one bounded refinement that stays inside the existing paired-`ori` source data: affine warp registration initialized from the current phase-correlation estimate.
+
+## Result
+
+Current PR `#30` baseline:
+
+- PSD `curve_mae_mean = 0.04306442`
+- PSD `mtf_abs_signed_rel_mean = 0.08692956`
+- PSD `MTF20 / MTF30 / MTF50 = 0.03300903 / 0.03693524 / 0.00933262`
+- Acutance `curve_mae_mean = 0.03683438`
+- `acutance_focus_preset_mae_mean = 0.04249131`
+- `overall_quality_loss_mae_mean = 1.22214341`
+
+PR `#34` intrinsic full-reference prototype:
+
+- PSD `curve_mae_mean = 0.03587346`
+- PSD `mtf_abs_signed_rel_mean = 0.20631329`
+- PSD `MTF20 / MTF30 / MTF50 = 0.08283943 / 0.03793906 / 0.00502893`
+- Acutance `curve_mae_mean = 0.03587346`
+- `acutance_focus_preset_mae_mean = 0.03165223`
+- `overall_quality_loss_mae_mean = 4.56800916`
+
+This issue's phase-ECC affine intrinsic candidate:
+
+- PSD `curve_mae_mean = 0.03710490`
+- PSD `mtf_abs_signed_rel_mean = 0.21560308`
+- PSD `MTF20 / MTF30 / MTF50 = 0.08788120 / 0.03858604 / 0.00504981`
+- Acutance `curve_mae_mean = 0.03710490`
+- `acutance_focus_preset_mae_mean = 0.03259058`
+- `overall_quality_loss_mae_mean = 4.74249698`
+
+Relative to PR `#30`, the affine-refined intrinsic path still improves curve fit and focus-preset Acutance, but it remains far outside the merged branch on overall Quality Loss and PSD signed-relative residuals.
+
+Relative to PR `#34`, the affine refinement is worse on every reported top-line metric:
+
+- PSD curve fit regresses from `0.03587346` to `0.03710490`
+- PSD signed-relative residual regresses from `0.20631329` to `0.21560308`
+- `MTF20 / MTF30 / MTF50` each worsen slightly
+- focus-preset Acutance regresses from `0.03165223` to `0.03259058`
+- overall Quality Loss regresses from `4.56800916` to `4.74249698`
+
+## Conclusion
+
+This is a bounded negative result, not a viable next main-line intrinsic registration direction.
+
+Affine ECC warp refinement does not recover the PR `#34` intrinsic prototype's guardrail regressions. It preserves the same broad mixed shape as the earlier intrinsic family, then nudges the already-bad PSD and Quality Loss metrics slightly further away from the README-facing branch.

--- a/tests/test_benchmark_parity_acutance_quality_loss.py
+++ b/tests/test_benchmark_parity_acutance_quality_loss.py
@@ -19,6 +19,7 @@ from algo.benchmark_parity_acutance_quality_loss import (
 )
 from algo.dead_leaves import AcutancePoint, RoiBounds
 from algo.parity_benchmark_common import (
+    align_patch_phase_ecc_affine,
     align_patch_phase_correlation,
     apply_quantile_transfer_curve,
     apply_reference_correction_curve,
@@ -297,6 +298,73 @@ class BenchmarkParityAcutanceQualityLossTest(unittest.TestCase):
             registration_mode="phase_correlation",
         )
         self.assertLess(float(np.mean(np.abs(transfer - 1.0))), 0.12)
+
+    def test_phase_ecc_affine_alignment_handles_small_rotation_and_scale(self) -> None:
+        rng = np.random.default_rng(123)
+        reference = rng.normal(size=(128, 128)).astype(np.float32)
+        reference = cv2.GaussianBlur(reference, (0, 0), 2.5)
+        center = (reference.shape[1] / 2.0, reference.shape[0] / 2.0)
+        transform = cv2.getRotationMatrix2D(center, 1.4, 1.015)
+        transform[:, 2] += np.array([2.0, -1.5], dtype=np.float32)
+        observed = cv2.warpAffine(
+            reference,
+            transform,
+            (reference.shape[1], reference.shape[0]),
+            flags=cv2.INTER_LINEAR,
+            borderMode=cv2.BORDER_REFLECT,
+        )
+
+        aligned_phase, _, _ = align_patch_phase_correlation(reference, observed)
+        aligned_affine, warp, score = align_patch_phase_ecc_affine(reference, observed)
+
+        self.assertGreater(score, 0.99)
+        self.assertEqual(warp.shape, (2, 3))
+        self.assertLess(
+            float(np.mean(np.abs(aligned_affine - reference))),
+            float(np.mean(np.abs(aligned_phase - reference))) * 0.75,
+        )
+
+    def test_intrinsic_transfer_curve_affine_mode_stays_bounded_on_rotated_patch(self) -> None:
+        rng = np.random.default_rng(123)
+        reference = rng.normal(size=(128, 128)).astype(np.float32)
+        reference = cv2.GaussianBlur(reference, (0, 0), 2.5)
+        center = (reference.shape[1] / 2.0, reference.shape[0] / 2.0)
+        transform = cv2.getRotationMatrix2D(center, 1.2, 1.01)
+        transform[:, 2] += np.array([2.0, -1.0], dtype=np.float32)
+        observed = cv2.warpAffine(
+            reference,
+            transform,
+            (reference.shape[1], reference.shape[0]),
+            flags=cv2.INTER_LINEAR,
+            borderMode=cv2.BORDER_REFLECT,
+        )
+
+        transfer_phase = derive_intrinsic_transfer_curve(
+            reference,
+            observed,
+            bin_centers=np.linspace(0.01, 0.49, 32, dtype=np.float64),
+            normalization_band=(0.01, 0.03),
+            normalization_mode="mean",
+            clip_lo=0.5,
+            clip_hi=1.5,
+            registration_mode="phase_correlation",
+        )
+        transfer_affine = derive_intrinsic_transfer_curve(
+            reference,
+            observed,
+            bin_centers=np.linspace(0.01, 0.49, 32, dtype=np.float64),
+            normalization_band=(0.01, 0.03),
+            normalization_mode="mean",
+            clip_lo=0.5,
+            clip_hi=1.5,
+            registration_mode="phase_ecc_affine",
+        )
+
+        self.assertEqual(transfer_phase.shape, transfer_affine.shape)
+        self.assertTrue(np.all(np.isfinite(transfer_affine)))
+        self.assertGreaterEqual(float(np.min(transfer_affine)), 0.5)
+        self.assertLessEqual(float(np.max(transfer_affine)), 1.5)
+        self.assertLess(float(np.mean(transfer_affine[:4])), 1.1)
 
     def test_intrinsic_transfer_curve_captures_high_frequency_rolloff(self) -> None:
         rng = np.random.default_rng(123)


### PR DESCRIPTION
## Summary

- add a bounded `phase_ecc_affine` intrinsic registration mode that keeps phase correlation as the initializer and refines with an ECC affine warp
- add focused intrinsic registration tests plus a dedicated phase-ECC affine intrinsic profile
- benchmark the new mode against the current PR #30 baseline and the earlier PR #34 intrinsic prototype, then record the result in `docs/issue44_intrinsic_phase_ecc_affine_followup.md`

## Validation

- `python3 -m pytest tests/test_benchmark_parity_psd_mtf.py tests/test_benchmark_parity_acutance_quality_loss.py -q`
- `python3 -m algo.benchmark_parity_psd_mtf 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json algo/deadleaf_13b10_imatest_intrinsic_full_reference_profile.json algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_ecc_affine_profile.json --output artifacts/issue44_intrinsic_phase_ecc_affine_psd_benchmark.json`
- `python3 -m algo.benchmark_parity_acutance_quality_loss 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json algo/deadleaf_13b10_imatest_intrinsic_full_reference_profile.json algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_ecc_affine_profile.json --output artifacts/issue44_intrinsic_phase_ecc_affine_acutance_benchmark.json`

## Result

This is a bounded negative result.

Compared with PR #34's translation-only intrinsic prototype, the phase-ECC affine refinement regresses every top-line metric that this issue tracks:

- PSD `curve_mae_mean`: `0.03587346 -> 0.03710490`
- PSD `mtf_abs_signed_rel_mean`: `0.20631329 -> 0.21560308`
- PSD `MTF20 / MTF30 / MTF50`: `0.08283943 / 0.03793906 / 0.00502893 -> 0.08788120 / 0.03858604 / 0.00504981`
- `acutance_focus_preset_mae_mean`: `0.03165223 -> 0.03259058`
- `overall_quality_loss_mae_mean`: `4.56800916 -> 4.74249698`

Compared with the merged PR #30 branch, the affine intrinsic path still improves curve fit and focus-preset Acutance, but it remains far worse on PSD guardrails and overall Quality Loss.

Refs #29
Refs #44
Context from #33
Context from #34
Context from #38
Context from #43
