### PR TITLE
Issue #46: audit intrinsic phase-retention family

### DIFF
--- a/algo/benchmark_parity_acutance_quality_loss.py
+++ b/algo/benchmark_parity_acutance_quality_loss.py
@@ -90,6 +90,7 @@ class Profile:
     intrinsic_full_reference_clip_lo: float = 0.5
     intrinsic_full_reference_clip_hi: float = 1.5
     intrinsic_full_reference_registration_mode: str = "phase_correlation"
+    intrinsic_full_reference_transfer_mode: str = "magnitude_ratio"
     matched_ori_reference_anchor: bool = False
     matched_ori_anchor_mode: str = "all"
     matched_ori_correction_clip_lo: float = 0.5
@@ -694,6 +695,7 @@ def summarize_profile(
                     clip_lo=profile.intrinsic_full_reference_clip_lo,
                     clip_hi=profile.intrinsic_full_reference_clip_hi,
                     registration_mode=profile.intrinsic_full_reference_registration_mode,
+                    transfer_mode=profile.intrinsic_full_reference_transfer_mode,
                 )
                 scaled_frequencies = np.asarray(ori_reference.frequencies_cpp, dtype=np.float64)
                 compensated_mtf_for_acutance = (
@@ -989,6 +991,7 @@ def summarize_profile(
             "intrinsic_full_reference_clip_lo": profile.intrinsic_full_reference_clip_lo,
             "intrinsic_full_reference_clip_hi": profile.intrinsic_full_reference_clip_hi,
             "intrinsic_full_reference_registration_mode": profile.intrinsic_full_reference_registration_mode,
+            "intrinsic_full_reference_transfer_mode": profile.intrinsic_full_reference_transfer_mode,
             "matched_ori_reference_anchor": profile.matched_ori_reference_anchor,
             "matched_ori_anchor_mode": profile.matched_ori_anchor_mode,
             "matched_ori_correction_clip_lo": profile.matched_ori_correction_clip_lo,

--- a/algo/benchmark_parity_psd_mtf.py
+++ b/algo/benchmark_parity_psd_mtf.py
@@ -75,6 +75,7 @@ class Profile:
     intrinsic_full_reference_clip_lo: float = 0.5
     intrinsic_full_reference_clip_hi: float = 1.5
     intrinsic_full_reference_registration_mode: str = "phase_correlation"
+    intrinsic_full_reference_transfer_mode: str = "magnitude_ratio"
     matched_ori_reference_anchor: bool = False
     matched_ori_anchor_mode: str = "all"
     matched_ori_correction_clip_lo: float = 0.5
@@ -457,6 +458,7 @@ def profile_payload(
                     clip_lo=profile.intrinsic_full_reference_clip_lo,
                     clip_hi=profile.intrinsic_full_reference_clip_hi,
                     registration_mode=profile.intrinsic_full_reference_registration_mode,
+                    transfer_mode=profile.intrinsic_full_reference_transfer_mode,
                 )
                 scaled_frequencies = np.asarray(ori_reference.frequencies_cpp, dtype=np.float64)
                 intrinsic_mtf = np.asarray(ori_reference.mtf, dtype=np.float64) * transfer_curve
@@ -663,6 +665,7 @@ def profile_payload(
             "intrinsic_full_reference_clip_lo": profile.intrinsic_full_reference_clip_lo,
             "intrinsic_full_reference_clip_hi": profile.intrinsic_full_reference_clip_hi,
             "intrinsic_full_reference_registration_mode": profile.intrinsic_full_reference_registration_mode,
+            "intrinsic_full_reference_transfer_mode": profile.intrinsic_full_reference_transfer_mode,
             "matched_ori_reference_anchor": profile.matched_ori_reference_anchor,
             "matched_ori_anchor_mode": profile.matched_ori_anchor_mode,
             "matched_ori_correction_clip_lo": profile.matched_ori_correction_clip_lo,

--- a/algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_profile.json
+++ b/algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_profile.json
@@ -1,0 +1,100 @@
+{
+  "name": "deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real",
+  "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+  "gamma": 0.5,
+  "linearization_mode": "toe_power",
+  "linearization_toe": 0.12,
+  "bayer_pattern": "RGGB",
+  "bayer_mode": "demosaic_red",
+  "roi_source": "reference_refined",
+  "roi_width": 1655,
+  "roi_height": 1673,
+  "roi_refine_percentile": 45.0,
+  "roi_refine_sigma": 5.0,
+  "roi_refine_min_border_margin": 8,
+  "roi_refine_search_radius": 4,
+  "roi_refine_step": 2,
+  "roi_refine_area_tolerance": 0.98,
+  "intrinsic_full_reference_mode": "paired_ori_transfer",
+  "intrinsic_full_reference_clip_lo": 0.5,
+  "intrinsic_full_reference_clip_hi": 1.5,
+  "intrinsic_full_reference_registration_mode": "phase_correlation",
+  "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+  "frequency_scale": 1.0,
+  "normalization_band_lo": 0.01,
+  "normalization_band_hi": 0.03,
+  "normalization_mode": "max",
+  "acutance_band_lo": 0.017,
+  "acutance_band_hi": 0.035,
+  "acutance_band_mode": "mean",
+  "noise_psd_model": "empirical",
+  "noise_psd_scale": 1.0,
+  "quality_loss_om_ceiling": 0.8851,
+  "quality_loss_coefficients": [
+    37.240228358776136,
+    26.54550669779819,
+    0.4538662637619741
+  ],
+  "quality_loss_preset_overrides": {
+    "Computer Monitor Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        5677361.198044325,
+        -16715685.9524707,
+        20317567.326582585,
+        -13046703.33912079,
+        4667794.619228022,
+        -882296.9160375095,
+        68863.59709647154
+      ]
+    },
+    "5.5\" Phone Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        -110912321.41149135,
+        50461107.51563171,
+        -9079490.127807735,
+        815148.8697247265,
+        -37712.984407641874,
+        854.6941149036079,
+        -6.261149027919645
+      ]
+    },
+    "UHDTV Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        1783462.6221675149,
+        -3813432.5606394163,
+        3326218.4642961356,
+        -1514886.1959663907,
+        380334.163146246,
+        -49956.87092015135,
+        2692.9566508574017
+      ]
+    },
+    "Small Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        6690980.837239251,
+        -12955277.716404187,
+        10300283.291740375,
+        -4303759.200708971,
+        996904.2653558743,
+        -121409.71509269004,
+        6084.6471373306085
+      ]
+    },
+    "Large Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        2355074.475971866,
+        -5276146.244338096,
+        4846781.143787682,
+        -2336594.295523967,
+        623766.4933095274,
+        -87476.30712136331,
+        5049.882965558553
+      ]
+    }
+  }
+}

--- a/algo/parity_benchmark_common.py
+++ b/algo/parity_benchmark_common.py
@@ -192,6 +192,49 @@ def _radial_bin_average(
     return averaged
 
 
+def _radial_bin_average_real(
+    values2d: np.ndarray,
+    *,
+    bin_centers: np.ndarray,
+    valid_mask: np.ndarray | None = None,
+) -> np.ndarray:
+    centers = np.asarray(bin_centers, dtype=np.float64)
+    values = np.asarray(values2d, dtype=np.complex128)
+    fy = np.fft.fftshift(np.fft.fftfreq(values.shape[0], d=1.0))
+    fx = np.fft.fftshift(np.fft.fftfreq(values.shape[1], d=1.0))
+    yy, xx = np.meshgrid(fy, fx, indexing="ij")
+    radius = np.sqrt(xx * xx + yy * yy)
+
+    edges = np.empty(centers.size + 1, dtype=np.float64)
+    edges[0] = 0.0
+    edges[-1] = 0.5
+    if centers.size > 1:
+        edges[1:-1] = 0.5 * (centers[:-1] + centers[1:])
+    else:
+        edges[1:-1] = centers[0]
+
+    mask = radius <= 0.5
+    if valid_mask is not None:
+        mask &= np.asarray(valid_mask, dtype=bool)
+    radius = radius[mask]
+    sample_values = values[mask]
+
+    averaged = np.ones(centers.size, dtype=np.float64)
+    counts = np.zeros(centers.size, dtype=np.int64)
+    if radius.size == 0:
+        return averaged
+
+    sums = np.zeros(centers.size, dtype=np.float64)
+    bin_ids = np.digitize(radius, edges) - 1
+    valid = (bin_ids >= 0) & (bin_ids < centers.size)
+    for idx, value in zip(bin_ids[valid], sample_values[valid]):
+        sums[idx] += float(np.real(value))
+        counts[idx] += 1
+    nonzero = counts > 0
+    averaged[nonzero] = sums[nonzero] / counts[nonzero]
+    return averaged
+
+
 def derive_intrinsic_transfer_curve(
     reference_patch: np.ndarray,
     observed_patch: np.ndarray,
@@ -202,6 +245,7 @@ def derive_intrinsic_transfer_curve(
     clip_lo: float,
     clip_hi: float,
     registration_mode: str = "phase_correlation",
+    transfer_mode: str = "magnitude_ratio",
 ) -> np.ndarray:
     reference, observed = center_crop_to_common_shape(reference_patch, observed_patch)
     if registration_mode == "phase_correlation":
@@ -222,17 +266,26 @@ def derive_intrinsic_transfer_curve(
     reference_spectrum = np.fft.fftshift(np.fft.fft2(reference * window))
     observed_spectrum = np.fft.fftshift(np.fft.fft2(observed_aligned * window))
     reference_power = np.abs(reference_spectrum) ** 2
-    transfer_2d = np.abs(observed_spectrum * np.conj(reference_spectrum)) / np.maximum(
+    complex_transfer_2d = (observed_spectrum * np.conj(reference_spectrum)) / np.maximum(
         reference_power,
         EPS,
     )
     support = reference_power[reference_power > EPS]
     power_floor = max(float(np.percentile(support, 10)) * 0.1, EPS) if support.size else EPS
-    transfer_curve = _radial_bin_average(
-        np.clip(transfer_2d, clip_lo, clip_hi),
-        bin_centers=np.asarray(bin_centers, dtype=np.float64),
-        valid_mask=reference_power >= power_floor,
-    )
+    if transfer_mode == "magnitude_ratio":
+        transfer_curve = _radial_bin_average(
+            np.clip(np.abs(complex_transfer_2d), clip_lo, clip_hi),
+            bin_centers=np.asarray(bin_centers, dtype=np.float64),
+            valid_mask=reference_power >= power_floor,
+        )
+    elif transfer_mode == "radial_real_mean":
+        transfer_curve = _radial_bin_average_real(
+            complex_transfer_2d,
+            bin_centers=np.asarray(bin_centers, dtype=np.float64),
+            valid_mask=reference_power >= power_floor,
+        )
+    else:
+        raise ValueError(f"Unsupported intrinsic transfer mode: {transfer_mode}")
     lo, hi = normalization_band
     band = (
         (np.asarray(bin_centers, dtype=np.float64) >= float(lo))

--- a/artifacts/issue46_intrinsic_phase_retention_acutance_benchmark.json
+++ b/artifacts/issue46_intrinsic_phase_retention_acutance_benchmark.json
@@ -1,0 +1,811 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.0426419082983667,
+        "0.25": 0.03450723056011866,
+        "0.4": 0.028162391114511045,
+        "0.65": 0.03351676542287892,
+        "0.8": 0.039890883676316505,
+        "ori": 0.044422165524720086
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 1.3421389514230824,
+        "0.25": 1.2825995432153037,
+        "0.4": 1.1337887188584643,
+        "0.65": 0.3646116302822078,
+        "0.8": 1.0109879373437751,
+        "ori": 2.317792173136315
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.04249131400289711,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.013802151888956607,
+          "Computer Monitor Acutance": 0.052691955741307875,
+          "Large Print Acutance": 0.05132126004290283,
+          "Small Print Acutance": 0.04670043959486586,
+          "UHDTV Display Acutance": 0.047940762746452356
+        },
+        "curve_mae_mean": 0.03683437582462248,
+        "overall_quality_loss_mae_mean": 1.2221434105099775,
+        "quality_loss_focus_preset_mae_mean": 1.2221434105099775,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 0.14297762642651196,
+          "Computer Monitor Quality Loss": 2.906111784076103,
+          "Large Print Quality Loss": 0.9547911309308169,
+          "Small Print Quality Loss": 0.6076983310559123,
+          "UHDTV Display Quality Loss": 1.499138180060543
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json"
+    },
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": null,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": null,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_hi_values": null,
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": null,
+        "matched_ori_acutance_preset_correction_delta_power_values": null,
+        "matched_ori_acutance_preset_strength_curve_relative_scales": null,
+        "matched_ori_acutance_preset_strength_curve_values": null,
+        "matched_ori_acutance_reference_anchor": false,
+        "matched_ori_acutance_strength_curve_relative_scales": null,
+        "matched_ori_acutance_strength_curve_values": null,
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": false,
+        "matched_ori_strength_curve_frequencies": null,
+        "matched_ori_strength_curve_values": null,
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "none",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.0,
+        "texture_support_scale": false
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.035196683613694144,
+        "0.25": 0.026063595116536973,
+        "0.4": 0.01753747396802398,
+        "0.65": 0.023124742546441375,
+        "0.8": 0.04933808562996401,
+        "ori": 0.07933816634336006
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 9.228172826355209,
+        "0.25": 5.167259124079623,
+        "0.4": 1.9657004646740774,
+        "0.65": 0.4897094076392309,
+        "0.8": 0.9958545106819245,
+        "ori": 10.476408297514947
+      },
+      "delta_vs_first_profile": {
+        "acutance_focus_preset_mae_mean": -0.010839086413757582,
+        "curve_mae_mean": -0.0009609172699985083,
+        "overall_quality_loss_mae_mean": 3.3458657451636067,
+        "quality_loss_focus_preset_mae_mean": 3.3458657451636067
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.03165222758913953,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.019550144806142027,
+          "Computer Monitor Acutance": 0.03459963699573056,
+          "Large Print Acutance": 0.03548975486958047,
+          "Small Print Acutance": 0.03236185429681689,
+          "UHDTV Display Acutance": 0.03625974697742767
+        },
+        "curve_mae_mean": 0.03587345855462397,
+        "overall_quality_loss_mae_mean": 4.568009155673584,
+        "quality_loss_focus_preset_mae_mean": 4.568009155673584,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 10.625076452435163,
+          "Computer Monitor Quality Loss": 8.429551248808604,
+          "Large Print Quality Loss": 0.8041006693713459,
+          "Small Print Quality Loss": 0.8460359016499208,
+          "UHDTV Display Quality Loss": 2.135281506102889
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_profile.json"
+    },
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": null,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_ecc_affine",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": null,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_hi_values": null,
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": null,
+        "matched_ori_acutance_preset_correction_delta_power_values": null,
+        "matched_ori_acutance_preset_strength_curve_relative_scales": null,
+        "matched_ori_acutance_preset_strength_curve_values": null,
+        "matched_ori_acutance_reference_anchor": false,
+        "matched_ori_acutance_strength_curve_relative_scales": null,
+        "matched_ori_acutance_strength_curve_values": null,
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": false,
+        "matched_ori_strength_curve_frequencies": null,
+        "matched_ori_strength_curve_values": null,
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "none",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.0,
+        "texture_support_scale": false
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.03719941450583143,
+        "0.25": 0.02761018350165209,
+        "0.4": 0.01869176670972228,
+        "0.65": 0.02748713530226645,
+        "0.8": 0.04861050537278703,
+        "ori": 0.07933816634336006
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 9.697117196042017,
+        "0.25": 5.485555237659748,
+        "0.4": 2.0510421628633435,
+        "0.65": 0.4802612361899852,
+        "0.8": 1.0004355556202955,
+        "ori": 10.476408297514947
+      },
+      "delta_vs_first_profile": {
+        "acutance_focus_preset_mae_mean": -0.009900729048731773,
+        "curve_mae_mean": 0.0002705283579387402,
+        "overall_quality_loss_mae_mean": 3.5203535732975966,
+        "quality_loss_focus_preset_mae_mean": 3.5203535732975966
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.032590584954165336,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.019635313854869437,
+          "Computer Monitor Acutance": 0.035499152456109774,
+          "Large Print Acutance": 0.03665088650637027,
+          "Small Print Acutance": 0.03356681285353623,
+          "UHDTV Display Acutance": 0.03760075909994095
+        },
+        "curve_mae_mean": 0.03710490418256122,
+        "overall_quality_loss_mae_mean": 4.742496983807574,
+        "quality_loss_focus_preset_mae_mean": 4.742496983807574,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 11.423153381841587,
+          "Computer Monitor Quality Loss": 8.437971565031734,
+          "Large Print Quality Loss": 0.8222035380907083,
+          "Small Print Quality Loss": 0.8506382800300296,
+          "UHDTV Display Quality Loss": 2.17851815404381
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_ecc_affine_profile.json"
+    },
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": null,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": null,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_hi_values": null,
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": null,
+        "matched_ori_acutance_preset_correction_delta_power_values": null,
+        "matched_ori_acutance_preset_strength_curve_relative_scales": null,
+        "matched_ori_acutance_preset_strength_curve_values": null,
+        "matched_ori_acutance_reference_anchor": false,
+        "matched_ori_acutance_strength_curve_relative_scales": null,
+        "matched_ori_acutance_strength_curve_values": null,
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": false,
+        "matched_ori_strength_curve_frequencies": null,
+        "matched_ori_strength_curve_values": null,
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "none",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.0,
+        "texture_support_scale": false
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.029378599163150443,
+        "0.25": 0.02479729017929424,
+        "0.4": 0.019363342842858032,
+        "0.65": 0.011953815251775047,
+        "0.8": 0.04482380483621107,
+        "ori": 0.07933816634336006
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 43.12764104118196,
+        "0.25": 18.808732202836907,
+        "0.4": 3.820570635679129,
+        "0.65": 0.6457076157060873,
+        "0.8": 1.0607923938498014,
+        "ori": 10.476408297514947
+      },
+      "delta_vs_first_profile": {
+        "acutance_focus_preset_mae_mean": -0.013570787594171976,
+        "curve_mae_mean": -0.004032570260806209,
+        "overall_quality_loss_mae_mean": 13.25361543552169,
+        "quality_loss_focus_preset_mae_mean": 13.25361543552169
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.028920526408725132,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.035256377739795786,
+          "Computer Monitor Acutance": 0.024146307932311834,
+          "Large Print Acutance": 0.028624302638652583,
+          "Small Print Acutance": 0.031726251556383624,
+          "UHDTV Display Acutance": 0.024849392176481848
+        },
+        "curve_mae_mean": 0.03280180556381627,
+        "overall_quality_loss_mae_mean": 14.475758846031667,
+        "quality_loss_focus_preset_mae_mean": 14.475758846031667,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 60.77410532227128,
+          "Computer Monitor Quality Loss": 5.980201776489433,
+          "Large Print Quality Loss": 1.759265006038341,
+          "Small Print Quality Loss": 1.5336822926986944,
+          "UHDTV Display Quality Loss": 2.331539832660566
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_profile.json"
+    }
+  ]
+}

--- a/artifacts/issue46_intrinsic_phase_retention_psd_benchmark.json
+++ b/artifacts/issue46_intrinsic_phase_retention_psd_benchmark.json
@@ -1,0 +1,549 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.045132331541343135,
+        "0.25": 0.03837972282290488,
+        "0.4": 0.03424583283108843,
+        "0.65": 0.04020915188141205,
+        "0.8": 0.049664991465143526,
+        "ori": 0.055589288189657284
+      },
+      "overall": {
+        "curve_mae_mean": 0.04306441973920293,
+        "mtf_abs_signed_rel_mean": 0.08692955889841379,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.017639268013990343,
+            "mre_mean": 0.08883603386012136,
+            "signed_rel_mean": 0.04964177427444007
+          },
+          "low": {
+            "mae_mean": 0.03704553941403868,
+            "mre_mean": 0.046572470331734825,
+            "signed_rel_mean": 0.0237949421475065
+          },
+          "mid": {
+            "mae_mean": 0.03898616152003224,
+            "mre_mean": 0.12397538768693758,
+            "signed_rel_mean": 0.10965436746685472
+          },
+          "top": {
+            "mae_mean": 0.0738124428343438,
+            "mre_mean": 0.20207246214765648,
+            "signed_rel_mean": -0.16462715170485387
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.033009025007104606,
+          "mtf30": 0.03693523768742383,
+          "mtf50": 0.009332615436071163
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.014469243052711292,
+          "Computer Monitor Acutance": 0.06145640899956405,
+          "Large Print Acutance": 0.05374582109239643,
+          "Small Print Acutance": 0.061691355516267324,
+          "UHDTV Display Acutance": 0.056009600718383366
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json"
+    },
+    {
+      "analysis_pipeline": {
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": null,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_hi_values": null,
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": null,
+        "matched_ori_acutance_preset_correction_delta_power_values": null,
+        "matched_ori_acutance_preset_strength_curve_relative_scales": null,
+        "matched_ori_acutance_preset_strength_curve_values": null,
+        "matched_ori_acutance_reference_anchor": false,
+        "matched_ori_acutance_strength_curve_relative_scales": null,
+        "matched_ori_acutance_strength_curve_values": null,
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": false,
+        "matched_ori_strength_curve_frequencies": null,
+        "matched_ori_strength_curve_values": null,
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "none",
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.0,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": false
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.035196683613694144,
+        "0.25": 0.026063595116536973,
+        "0.4": 0.01753747396802398,
+        "0.65": 0.023124742546441375,
+        "0.8": 0.04933808562996401,
+        "ori": 0.07933816634336006
+      },
+      "overall": {
+        "curve_mae_mean": 0.03587345855462397,
+        "mtf_abs_signed_rel_mean": 0.2063132851109083,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.05364693984972889,
+            "mre_mean": 0.4393614969865764,
+            "signed_rel_mean": 0.42543616835229364
+          },
+          "low": {
+            "mae_mean": 0.013768972135422223,
+            "mre_mean": 0.01978410388845616,
+            "signed_rel_mean": 0.018354991884579817
+          },
+          "mid": {
+            "mae_mean": 0.043064434659796536,
+            "mre_mean": 0.2101415351056158,
+            "signed_rel_mean": 0.19180123688322911
+          },
+          "top": {
+            "mae_mean": 0.04461417837131011,
+            "mre_mean": 0.23687141210944612,
+            "signed_rel_mean": 0.1896607433235306
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.08283943347415898,
+          "mtf30": 0.037939058443613165,
+          "mtf50": 0.005028927723658685
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.019550144806142027,
+          "Computer Monitor Acutance": 0.03459963699573056,
+          "Large Print Acutance": 0.03548975486958047,
+          "Small Print Acutance": 0.03236185429681689,
+          "UHDTV Display Acutance": 0.03625974697742767
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_profile.json"
+    },
+    {
+      "analysis_pipeline": {
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_ecc_affine",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": null,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_hi_values": null,
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": null,
+        "matched_ori_acutance_preset_correction_delta_power_values": null,
+        "matched_ori_acutance_preset_strength_curve_relative_scales": null,
+        "matched_ori_acutance_preset_strength_curve_values": null,
+        "matched_ori_acutance_reference_anchor": false,
+        "matched_ori_acutance_strength_curve_relative_scales": null,
+        "matched_ori_acutance_strength_curve_values": null,
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": false,
+        "matched_ori_strength_curve_frequencies": null,
+        "matched_ori_strength_curve_values": null,
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "none",
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.0,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": false
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.03719941450583143,
+        "0.25": 0.02761018350165209,
+        "0.4": 0.01869176670972228,
+        "0.65": 0.02748713530226645,
+        "0.8": 0.04861050537278703,
+        "ori": 0.07933816634336006
+      },
+      "overall": {
+        "curve_mae_mean": 0.03710490418256122,
+        "mtf_abs_signed_rel_mean": 0.2156030777508819,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.054146627840666664,
+            "mre_mean": 0.4450337830338473,
+            "signed_rel_mean": 0.4358424078060407
+          },
+          "low": {
+            "mae_mean": 0.013929143334576252,
+            "mre_mean": 0.01983707355666054,
+            "signed_rel_mean": 0.018557788166881313
+          },
+          "mid": {
+            "mae_mean": 0.04358654789754749,
+            "mre_mean": 0.21170524630594176,
+            "signed_rel_mean": 0.1963985688909255
+          },
+          "top": {
+            "mae_mean": 0.04482309151349247,
+            "mre_mean": 0.23987523544580655,
+            "signed_rel_mean": 0.21161354613967998
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.08788120248932149,
+          "mtf30": 0.038586043438491036,
+          "mtf50": 0.005049808014793564
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.019635313854869437,
+          "Computer Monitor Acutance": 0.035499152456109774,
+          "Large Print Acutance": 0.03665088650637027,
+          "Small Print Acutance": 0.03356681285353623,
+          "UHDTV Display Acutance": 0.03760075909994095
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_ecc_affine_profile.json"
+    },
+    {
+      "analysis_pipeline": {
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": null,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_hi_values": null,
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": null,
+        "matched_ori_acutance_preset_correction_delta_power_values": null,
+        "matched_ori_acutance_preset_strength_curve_relative_scales": null,
+        "matched_ori_acutance_preset_strength_curve_values": null,
+        "matched_ori_acutance_reference_anchor": false,
+        "matched_ori_acutance_strength_curve_relative_scales": null,
+        "matched_ori_acutance_strength_curve_values": null,
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": false,
+        "matched_ori_strength_curve_frequencies": null,
+        "matched_ori_strength_curve_values": null,
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "none",
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.0,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": false
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.029378599163150443,
+        "0.25": 0.02479729017929424,
+        "0.4": 0.019363342842858032,
+        "0.65": 0.011953815251775047,
+        "0.8": 0.04482380483621107,
+        "ori": 0.07933816634336006
+      },
+      "overall": {
+        "curve_mae_mean": 0.03280180556381627,
+        "mtf_abs_signed_rel_mean": 0.13993778559089318,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.046538330006884135,
+            "mre_mean": 0.37889639493221694,
+            "signed_rel_mean": 0.350265151882866
+          },
+          "low": {
+            "mae_mean": 0.009354903091206065,
+            "mre_mean": 0.011801273896748076,
+            "signed_rel_mean": -0.0036495976267245525
+          },
+          "mid": {
+            "mae_mean": 0.04532695609684774,
+            "mre_mean": 0.19162616575660346,
+            "signed_rel_mean": 0.10026578142446776
+          },
+          "top": {
+            "mae_mean": 0.045570940534890705,
+            "mre_mean": 0.21177494150079243,
+            "signed_rel_mean": 0.1055706114295144
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.08576635073450163,
+          "mtf30": 0.017891546542091085,
+          "mtf50": 0.007196087410606654
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.035256377739795786,
+          "Computer Monitor Acutance": 0.024146307932311834,
+          "Large Print Acutance": 0.028624302638652583,
+          "Small Print Acutance": 0.031726251556383624,
+          "UHDTV Display Acutance": 0.024849392176481848
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_profile.json"
+    }
+  ]
+}

--- a/docs/issue46_intrinsic_phase_retention_followup.md
+++ b/docs/issue46_intrinsic_phase_retention_followup.md
@@ -1,0 +1,86 @@
+# Issue 46 Intrinsic Phase-Retention Follow-up
+
+Issue: `#46`  
+Parent: `#29`  
+Context: `#33`, `#34`, `#44`, `#45`
+
+## What changed
+
+- Added a bounded intrinsic transfer mode, `radial_real_mean`, for the paired-`ori` full-reference path.
+- Kept the existing intrinsic registration path fixed, then changed the transfer formulation to retain the in-phase component of the complex intrinsic transfer within each radial frequency bin instead of collapsing immediately to a magnitude-only ratio.
+- Added focused tests showing the new mode stays near identity for registered translations and suppresses incoherent high-frequency gain in a synthetic phase-noise case.
+- Checked in:
+  - `algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_profile.json`
+  - `artifacts/issue46_intrinsic_phase_retention_psd_benchmark.json`
+  - `artifacts/issue46_intrinsic_phase_retention_acutance_benchmark.json`
+
+## Why this family
+
+The research inventory still marks intrinsic phase retention as a missing method family even after issue `#44` ruled out a more faithful affine warp/alignment refinement.
+
+The earlier intrinsic prototype in issue `#33` / PR `#34` aligned the paired-`ori` patch, then converted the complex cross-spectrum into a magnitude-only transfer before radial averaging. That means phase-incoherent energy is still turned into positive gain. This issue tests the bounded next slice that remains after PR `#45`: keep the warp/alignment path fixed and only change the intrinsic transfer to retain the in-phase component within each radial bin.
+
+## Result
+
+Current PR `#30` baseline:
+
+- PSD `curve_mae_mean = 0.04306442`
+- PSD `mtf_abs_signed_rel_mean = 0.08692956`
+- PSD `MTF20 / MTF30 / MTF50 = 0.03300903 / 0.03693524 / 0.00933262`
+- Acutance `curve_mae_mean = 0.03683438`
+- `acutance_focus_preset_mae_mean = 0.04249131`
+- `overall_quality_loss_mae_mean = 1.22214341`
+
+PR `#34` intrinsic full-reference prototype:
+
+- PSD `curve_mae_mean = 0.03587346`
+- PSD `mtf_abs_signed_rel_mean = 0.20631329`
+- PSD `MTF20 / MTF30 / MTF50 = 0.08283943 / 0.03793906 / 0.00502893`
+- Acutance `curve_mae_mean = 0.03587346`
+- `acutance_focus_preset_mae_mean = 0.03165223`
+- `overall_quality_loss_mae_mean = 4.56800916`
+
+PR `#45` affine warp/alignment follow-up:
+
+- PSD `curve_mae_mean = 0.03710490`
+- PSD `mtf_abs_signed_rel_mean = 0.21560308`
+- PSD `MTF20 / MTF30 / MTF50 = 0.08788120 / 0.03858604 / 0.00504981`
+- Acutance `curve_mae_mean = 0.03710490`
+- `acutance_focus_preset_mae_mean = 0.03259058`
+- `overall_quality_loss_mae_mean = 4.74249698`
+
+This issue's phase-retention intrinsic candidate:
+
+- PSD `curve_mae_mean = 0.03280181`
+- PSD `mtf_abs_signed_rel_mean = 0.13993779`
+- PSD `MTF20 / MTF30 / MTF50 = 0.08576635 / 0.01789155 / 0.00719609`
+- Acutance `curve_mae_mean = 0.03280181`
+- `acutance_focus_preset_mae_mean = 0.02892053`
+- `overall_quality_loss_mae_mean = 14.47575885`
+
+Relative to PR `#34`, this bounded phase-retention slice:
+
+- improves PSD curve fit from `0.03587346` to `0.03280181`
+- improves PSD signed-relative residual from `0.20631329` to `0.13993779`
+- improves `MTF30` sharply from `0.03793906` to `0.01789155`
+- improves focus-preset Acutance mean from `0.03165223` to `0.02892053`
+- regresses `MTF20` slightly from `0.08283943` to `0.08576635`
+- regresses `MTF50` from `0.00502893` to `0.00719609`
+- regresses overall Quality Loss dramatically from `4.56800916` to `14.47575885`
+
+Relative to PR `#45`, the new phase-retention slice is better on every reported PSD and Acutance aggregate, but still much worse on Quality Loss:
+
+- PSD curve fit improves from `0.03710490` to `0.03280181`
+- PSD signed-relative residual improves from `0.21560308` to `0.13993779`
+- focus-preset Acutance mean improves from `0.03259058` to `0.02892053`
+- overall Quality Loss worsens further from `4.74249698` to `14.47575885`
+
+The Quality Loss regression is dominated by the phone preset:
+
+- `5.5" Phone Display Quality Loss` MAE rises to `60.77410532`
+
+## Conclusion
+
+This is a bounded mixed result, not a new main-line replacement.
+
+The phase-retention family is more promising than the affine warp/alignment follow-up because it materially improves curve fit, focus-preset Acutance, and PSD signed-relative residuals at the same time. But the current in-phase transfer formulation destabilizes the downstream Quality Loss mapping even more severely than PR `#34` and PR `#45`, so it should remain experiment-only.

--- a/tests/test_benchmark_parity_acutance_quality_loss.py
+++ b/tests/test_benchmark_parity_acutance_quality_loss.py
@@ -299,6 +299,70 @@ class BenchmarkParityAcutanceQualityLossTest(unittest.TestCase):
         )
         self.assertLess(float(np.mean(np.abs(transfer - 1.0))), 0.12)
 
+    def test_phase_retention_transfer_mode_stays_near_identity_for_translation(self) -> None:
+        rng = np.random.default_rng(123)
+        reference = rng.normal(size=(96, 96)).astype(np.float32)
+        transform = np.array([[1.0, 0.0, 4.0], [0.0, 1.0, 2.0]], dtype=np.float32)
+        observed = cv2.warpAffine(
+            reference,
+            transform,
+            (reference.shape[1], reference.shape[0]),
+            flags=cv2.INTER_LINEAR,
+            borderMode=cv2.BORDER_REFLECT,
+        )
+        transfer = derive_intrinsic_transfer_curve(
+            reference,
+            observed,
+            bin_centers=np.linspace(0.01, 0.49, 32, dtype=np.float64),
+            normalization_band=(0.01, 0.03),
+            normalization_mode="mean",
+            clip_lo=0.5,
+            clip_hi=1.5,
+            registration_mode="phase_correlation",
+            transfer_mode="radial_real_mean",
+        )
+        self.assertLess(float(np.mean(np.abs(transfer - 1.0))), 0.15)
+
+    def test_phase_retention_transfer_mode_reduces_incoherent_high_frequency_gain(self) -> None:
+        rng = np.random.default_rng(123)
+        reference = rng.normal(size=(128, 128)).astype(np.float32)
+        reference = cv2.GaussianBlur(reference, (0, 0), 1.8)
+        blurred = cv2.GaussianBlur(reference, (0, 0), 1.4)
+        incoherent_noise = rng.normal(
+            scale=float(np.std(blurred)) * 0.5,
+            size=reference.shape,
+        ).astype(np.float32)
+        observed = blurred + incoherent_noise
+
+        magnitude_transfer = derive_intrinsic_transfer_curve(
+            reference,
+            observed,
+            bin_centers=np.linspace(0.01, 0.49, 32, dtype=np.float64),
+            normalization_band=(0.01, 0.03),
+            normalization_mode="mean",
+            clip_lo=0.5,
+            clip_hi=1.5,
+            registration_mode="none",
+            transfer_mode="magnitude_ratio",
+        )
+        phase_retained_transfer = derive_intrinsic_transfer_curve(
+            reference,
+            observed,
+            bin_centers=np.linspace(0.01, 0.49, 32, dtype=np.float64),
+            normalization_band=(0.01, 0.03),
+            normalization_mode="mean",
+            clip_lo=0.5,
+            clip_hi=1.5,
+            registration_mode="none",
+            transfer_mode="radial_real_mean",
+        )
+
+        self.assertLess(
+            float(np.mean(phase_retained_transfer[-4:])),
+            float(np.mean(magnitude_transfer[-4:])) - 0.1,
+        )
+        self.assertGreater(float(np.mean(phase_retained_transfer[:4])), 0.9)
+
     def test_phase_ecc_affine_alignment_handles_small_rotation_and_scale(self) -> None:
         rng = np.random.default_rng(123)
         reference = rng.normal(size=(128, 128)).astype(np.float32)

--- a/tests/test_benchmark_parity_psd_mtf.py
+++ b/tests/test_benchmark_parity_psd_mtf.py
@@ -149,6 +149,15 @@ class BenchmarkParityPsdMtfTest(unittest.TestCase):
         )
         self.assertEqual(profile.intrinsic_full_reference_mode, "paired_ori_transfer")
 
+    def test_profile_allows_intrinsic_phase_retention_transfer_mode(self) -> None:
+        profile = Profile(
+            name="test",
+            calibration_file="algo/deadleaf_13b10_psd_calibration.json",
+            intrinsic_full_reference_mode="paired_ori_transfer",
+            intrinsic_full_reference_transfer_mode="radial_real_mean",
+        )
+        self.assertEqual(profile.intrinsic_full_reference_transfer_mode, "radial_real_mean")
+
     def test_profile_allows_chart_fill_factor_for_compensation_family(self) -> None:
         profile = Profile(
             name="test",


### PR DESCRIPTION
## Summary

- add one bounded intrinsic phase-retention transfer mode, `radial_real_mean`, that keeps the in-phase component of the complex intrinsic transfer within each radial bin instead of collapsing immediately to a magnitude-only ratio
- plumb the new intrinsic transfer mode through both parity benchmark entrypoints, add focused tests, and add a dedicated tracked phase-retention profile
- benchmark the phase-retention candidate against the current PR #30 best branch, the earlier PR #34 intrinsic prototype, and the negative affine warp/alignment follow-up from PR #45, then record the outcome in `docs/issue46_intrinsic_phase_retention_followup.md`

## Validation

- `python3 -m pytest tests/test_benchmark_parity_psd_mtf.py tests/test_benchmark_parity_acutance_quality_loss.py -q`
- `python3 -m algo.benchmark_parity_psd_mtf 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json algo/deadleaf_13b10_imatest_intrinsic_full_reference_profile.json algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_ecc_affine_profile.json algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_profile.json --output artifacts/issue46_intrinsic_phase_retention_psd_benchmark.json`
- `python3 -m algo.benchmark_parity_acutance_quality_loss 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json algo/deadleaf_13b10_imatest_intrinsic_full_reference_profile.json algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_ecc_affine_profile.json algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_profile.json --output artifacts/issue46_intrinsic_phase_retention_acutance_benchmark.json`

## Result

This is a bounded mixed result.

Compared with PR #34's translation-only intrinsic prototype, the phase-retention candidate improves several lower-layer and acutance-facing metrics at once:

- PSD `curve_mae_mean`: `0.03587346 -> 0.03280181`
- PSD `mtf_abs_signed_rel_mean`: `0.20631329 -> 0.13993779`
- PSD `MTF30`: `0.03793906 -> 0.01789155`
- `acutance_focus_preset_mae_mean`: `0.03165223 -> 0.02892053`

But it still regresses other readouts and it makes the downstream Quality Loss path much worse:

- PSD `MTF20`: `0.08283943 -> 0.08576635`
- PSD `MTF50`: `0.00502893 -> 0.00719609`
- `overall_quality_loss_mae_mean`: `4.56800916 -> 14.47575885`
- `5.5" Phone Display Quality Loss` MAE rises to `60.77410532`

Compared with PR #45's affine warp/alignment follow-up, the phase-retention slice is better on every reported PSD and Acutance aggregate, but it still loses badly on overall Quality Loss.

Refs #29
Refs #46
Context from #33
Context from #34
Context from #44
Context from #45
