### PR TITLE
Issue #48: audit hf-noise-share gated intrinsic shape correction

### DIFF
--- a/algo/benchmark_parity_psd_mtf.py
+++ b/algo/benchmark_parity_psd_mtf.py
@@ -12,6 +12,7 @@ from .dead_leaves import (
     BayerMode,
     BayerPattern,
     IMATEST_REFERENCE_BINS,
+    MTF_SHAPE_CORRECTION_SHARE_GATE,
     RoiBounds,
     acutance_curve_from_mtf,
     acutance_presets_from_mtf,
@@ -141,6 +142,17 @@ class Profile:
     )
     high_frequency_guard_start_cpp: float | None = None
     high_frequency_guard_stop_cpp: float = 0.5
+    mtf_shape_correction_mode: str = "none"
+    mtf_shape_correction_gain: float = 0.035
+    mtf_shape_correction_share_gate_lo: float = MTF_SHAPE_CORRECTION_SHARE_GATE[0]
+    mtf_shape_correction_share_gate_hi: float = MTF_SHAPE_CORRECTION_SHARE_GATE[1]
+    mtf_shape_correction_mid_start_cpp: float = 0.095
+    mtf_shape_correction_mid_peak_cpp: float = 0.145
+    mtf_shape_correction_mid_stop_cpp: float = 0.19
+    mtf_shape_correction_high_start_cpp: float = 0.36
+    mtf_shape_correction_high_peak_cpp: float = 0.40
+    mtf_shape_correction_high_stop_cpp: float = 0.49
+    mtf_shape_correction_high_weight: float = 0.25
     texture_support_scale: bool = False
     mtf_compensation_mode: str = "none"
     sensor_fill_factor: float = 1.0
@@ -709,6 +721,9 @@ def profile_payload(
             "frequency_scale": profile.frequency_scale,
             "texture_support_scale": profile.texture_support_scale,
             "signal_psd_correction_gain": profile.signal_psd_correction_gain,
+            "acutance_noise_scale_mode": profile.acutance_noise_scale_mode,
+            "high_frequency_guard_start_cpp": profile.high_frequency_guard_start_cpp,
+            "mtf_shape_correction_mode": profile.mtf_shape_correction_mode,
             "calibration_file": profile.calibration_file,
             "mtf_compensation_mode": profile.mtf_compensation_mode,
             "sensor_fill_factor": profile.sensor_fill_factor,

--- a/algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_hf_noise_share_shape_profile.json
+++ b/algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_hf_noise_share_shape_profile.json
@@ -1,0 +1,121 @@
+{
+  "name": "deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_hf_noise_share_shape",
+  "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+  "gamma": 0.5,
+  "linearization_mode": "toe_power",
+  "linearization_toe": 0.12,
+  "bayer_pattern": "RGGB",
+  "bayer_mode": "demosaic_red",
+  "roi_source": "reference_refined",
+  "roi_width": 1655,
+  "roi_height": 1673,
+  "roi_refine_percentile": 45.0,
+  "roi_refine_sigma": 5.0,
+  "roi_refine_min_border_margin": 8,
+  "roi_refine_search_radius": 4,
+  "roi_refine_step": 2,
+  "roi_refine_area_tolerance": 0.98,
+  "intrinsic_full_reference_mode": "paired_ori_transfer",
+  "intrinsic_full_reference_clip_lo": 0.5,
+  "intrinsic_full_reference_clip_hi": 1.5,
+  "intrinsic_full_reference_registration_mode": "phase_correlation",
+  "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+  "frequency_scale": 1.0,
+  "normalization_band_lo": 0.01,
+  "normalization_band_hi": 0.03,
+  "normalization_mode": "max",
+  "acutance_band_lo": 0.017,
+  "acutance_band_hi": 0.035,
+  "acutance_band_mode": "mean",
+  "noise_psd_model": "empirical",
+  "noise_psd_scale": 1.0,
+  "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+  "acutance_noise_share_band_lo": 0.36,
+  "acutance_noise_share_band_hi": 0.5,
+  "acutance_noise_share_scale_coefficients": [
+    521.08180962,
+    -26.62905791,
+    1.59615575
+  ],
+  "high_frequency_guard_start_cpp": 0.36,
+  "high_frequency_guard_stop_cpp": 0.5,
+  "mtf_shape_correction_mode": "hf_noise_share_gated_bump",
+  "mtf_shape_correction_gain": 0.035,
+  "mtf_shape_correction_share_gate_lo": 0.05,
+  "mtf_shape_correction_share_gate_hi": 0.08,
+  "mtf_shape_correction_mid_start_cpp": 0.095,
+  "mtf_shape_correction_mid_peak_cpp": 0.145,
+  "mtf_shape_correction_mid_stop_cpp": 0.19,
+  "mtf_shape_correction_high_start_cpp": 0.36,
+  "mtf_shape_correction_high_peak_cpp": 0.4,
+  "mtf_shape_correction_high_stop_cpp": 0.49,
+  "mtf_shape_correction_high_weight": 0.25,
+  "quality_loss_om_ceiling": 0.8851,
+  "quality_loss_coefficients": [
+    37.240228358776136,
+    26.54550669779819,
+    0.4538662637619741
+  ],
+  "quality_loss_preset_overrides": {
+    "Computer Monitor Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        5677361.198044325,
+        -16715685.9524707,
+        20317567.326582585,
+        -13046703.33912079,
+        4667794.619228022,
+        -882296.9160375095,
+        68863.59709647154
+      ]
+    },
+    "5.5\" Phone Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        -110912321.41149135,
+        50461107.51563171,
+        -9079490.127807735,
+        815148.8697247265,
+        -37712.984407641874,
+        854.6941149036079,
+        -6.261149027919645
+      ]
+    },
+    "UHDTV Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        1783462.6221675149,
+        -3813432.5606394163,
+        3326218.4642961356,
+        -1514886.1959663907,
+        380334.163146246,
+        -49956.87092015135,
+        2692.9566508574017
+      ]
+    },
+    "Small Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        6690980.837239251,
+        -12955277.716404187,
+        10300283.291740375,
+        -4303759.200708971,
+        996904.2653558743,
+        -121409.71509269004,
+        6084.6471373306085
+      ]
+    },
+    "Large Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        2355074.475971866,
+        -5276146.244338096,
+        4846781.143787682,
+        -2336594.295523967,
+        623766.4933095274,
+        -87476.30712136331,
+        5049.882965558553
+      ]
+    }
+  }
+}

--- a/artifacts/issue48_hf_noise_share_shape_acutance_benchmark.json
+++ b/artifacts/issue48_hf_noise_share_shape_acutance_benchmark.json
@@ -1,0 +1,187 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": null,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_hi_values": null,
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": null,
+        "matched_ori_acutance_preset_correction_delta_power_values": null,
+        "matched_ori_acutance_preset_strength_curve_relative_scales": null,
+        "matched_ori_acutance_preset_strength_curve_values": null,
+        "matched_ori_acutance_reference_anchor": false,
+        "matched_ori_acutance_strength_curve_relative_scales": null,
+        "matched_ori_acutance_strength_curve_values": null,
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": false,
+        "matched_ori_strength_curve_frequencies": null,
+        "matched_ori_strength_curve_values": null,
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "none",
+        "mtf_shape_correction_mode": "hf_noise_share_gated_bump",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.0,
+        "texture_support_scale": false
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.02903085178693443,
+        "0.25": 0.024545898370561828,
+        "0.4": 0.01914247647447554,
+        "0.65": 0.01238139734371468,
+        "0.8": 0.04531782111760553,
+        "ori": 0.07994355828105208
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 43.063878073172084,
+        "0.25": 18.7477686205082,
+        "0.4": 3.7967399994369946,
+        "0.65": 0.6364708265600558,
+        "0.8": 1.0533318892603831,
+        "ori": 10.77298334525274
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.028903242496582944,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.0351395395799604,
+          "Computer Monitor Acutance": 0.02421576177633433,
+          "Large Print Acutance": 0.028621217802160325,
+          "Small Print Acutance": 0.031779703258924784,
+          "UHDTV Display Acutance": 0.024759990065534872
+        },
+        "curve_mae_mean": 0.03283990511239214,
+        "overall_quality_loss_mae_mean": 14.473289133656815,
+        "quality_loss_focus_preset_mae_mean": 14.473289133656815,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 60.68418298188983,
+          "Computer Monitor Quality Loss": 6.062217452419302,
+          "Large Print Quality Loss": 1.7367456506763308,
+          "Small Print Quality Loss": 1.5542082416488658,
+          "UHDTV Display Quality Loss": 2.329091341649736
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_hf_noise_share_shape_profile.json"
+    }
+  ]
+}

--- a/artifacts/issue48_hf_noise_share_shape_psd_benchmark.json
+++ b/artifacts/issue48_hf_noise_share_shape_psd_benchmark.json
@@ -1,0 +1,129 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": null,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_hi_values": null,
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": null,
+        "matched_ori_acutance_preset_correction_delta_power_values": null,
+        "matched_ori_acutance_preset_strength_curve_relative_scales": null,
+        "matched_ori_acutance_preset_strength_curve_values": null,
+        "matched_ori_acutance_reference_anchor": false,
+        "matched_ori_acutance_strength_curve_relative_scales": null,
+        "matched_ori_acutance_strength_curve_values": null,
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": false,
+        "matched_ori_strength_curve_frequencies": null,
+        "matched_ori_strength_curve_values": null,
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "none",
+        "mtf_shape_correction_mode": "hf_noise_share_gated_bump",
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.0,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": false
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.029378599163150443,
+        "0.25": 0.02479729017929424,
+        "0.4": 0.019363342842858032,
+        "0.65": 0.011953815251775047,
+        "0.8": 0.04482380483621107,
+        "ori": 0.07933816634336006
+      },
+      "overall": {
+        "curve_mae_mean": 0.03280180556381627,
+        "mtf_abs_signed_rel_mean": 0.13993778559089318,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.046538330006884135,
+            "mre_mean": 0.37889639493221694,
+            "signed_rel_mean": 0.350265151882866
+          },
+          "low": {
+            "mae_mean": 0.009354903091206065,
+            "mre_mean": 0.011801273896748076,
+            "signed_rel_mean": -0.0036495976267245525
+          },
+          "mid": {
+            "mae_mean": 0.04532695609684774,
+            "mre_mean": 0.19162616575660346,
+            "signed_rel_mean": 0.10026578142446776
+          },
+          "top": {
+            "mae_mean": 0.045570940534890705,
+            "mre_mean": 0.21177494150079243,
+            "signed_rel_mean": 0.1055706114295144
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.08576635073450163,
+          "mtf30": 0.017891546542091085,
+          "mtf50": 0.007196087410606654
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.035256377739795786,
+          "Computer Monitor Acutance": 0.024146307932311834,
+          "Large Print Acutance": 0.028624302638652583,
+          "Small Print Acutance": 0.031726251556383624,
+          "UHDTV Display Acutance": 0.024849392176481848
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_hf_noise_share_shape_profile.json"
+    }
+  ]
+}

--- a/docs/issue48_hf_noise_share_shape_followup.md
+++ b/docs/issue48_hf_noise_share_shape_followup.md
@@ -1,0 +1,88 @@
+## Issue
+
+Issue `#48` asks for one bounded scene-/process-dependent ISP family after PR `#47`, using only source-backed proxies already supported by the dead-leaves repo contents.
+
+## Family
+
+This pass tests the narrowest currently source-backed proxy that still moves the post-PR-47 intrinsic branch:
+
+- keep PR `#47`'s intrinsic phase-retained full-reference transfer fixed
+- derive per-capture high-frequency noise share from the existing dead-leaves estimate
+- gate one small MTF shape correction bump from that measured share
+
+The initial attempt to reuse the existing `acutance_noise_scale_mode` plus `high_frequency_guard` settings from PR `#30` produced a no-op on the intrinsic `replace_all` path: those knobs are applied inside `estimate_dead_leaves_mtf()`, but issue `#48`'s active intrinsic branch later overwrites the MTF with the paired-`ori` transfer result. The moving part in this family is therefore the downstream `hf_noise_share_gated_bump` correction, which still uses the measured high-frequency noise share as its scene-/process-dependent gate.
+
+## Result
+
+Current PR `#30` baseline:
+
+- PSD `curve_mae_mean = 0.04306442`
+- PSD `mtf_abs_signed_rel_mean = 0.08692956`
+- PSD `MTF20 / MTF30 / MTF50 = 0.03300903 / 0.03693524 / 0.00933262`
+- Acutance `curve_mae_mean = 0.03683438`
+- `acutance_focus_preset_mae_mean = 0.04249131`
+- `overall_quality_loss_mae_mean = 1.22214341`
+- `5.5" Phone Display Quality Loss` MAE = `0.14297763`
+- `5.5" Phone Display Acutance` MAE = `0.01380215`
+
+PR `#34` intrinsic full-reference prototype:
+
+- PSD `curve_mae_mean = 0.03587346`
+- PSD `mtf_abs_signed_rel_mean = 0.20631329`
+- PSD `MTF20 / MTF30 / MTF50 = 0.08283943 / 0.03793906 / 0.00502893`
+- Acutance `curve_mae_mean = 0.03587346`
+- `acutance_focus_preset_mae_mean = 0.03165223`
+- `overall_quality_loss_mae_mean = 4.56800916`
+- `5.5" Phone Display Quality Loss` MAE = `10.62507645`
+- `5.5" Phone Display Acutance` MAE = `0.01955014`
+
+PR `#47` phase-retention follow-up:
+
+- PSD `curve_mae_mean = 0.03280181`
+- PSD `mtf_abs_signed_rel_mean = 0.13993779`
+- PSD `MTF20 / MTF30 / MTF50 = 0.08576635 / 0.01789155 / 0.00719609`
+- Acutance `curve_mae_mean = 0.03280181`
+- `acutance_focus_preset_mae_mean = 0.02892053`
+- `overall_quality_loss_mae_mean = 14.47575885`
+- `5.5" Phone Display Quality Loss` MAE = `60.77410532`
+- `5.5" Phone Display Acutance` MAE = `0.03525638`
+
+Issue `#48` noise-share-gated shape candidate:
+
+- PSD `curve_mae_mean = 0.03280181`
+- PSD `mtf_abs_signed_rel_mean = 0.13993779`
+- PSD `MTF20 / MTF30 / MTF50 = 0.08576635 / 0.01789155 / 0.00719609`
+- Acutance `curve_mae_mean = 0.03283991`
+- `acutance_focus_preset_mae_mean = 0.02890324`
+- `overall_quality_loss_mae_mean = 14.47328913`
+- `5.5" Phone Display Quality Loss` MAE = `60.68418298`
+- `5.5" Phone Display Acutance` MAE = `0.03513954`
+
+Relative to PR `#47`, this bounded ISP proxy:
+
+- leaves the PSD / MTF path unchanged in practice
+- regresses Acutance `curve_mae_mean` slightly from `0.03280181` to `0.03283991`
+- improves `acutance_focus_preset_mae_mean` slightly from `0.02892053` to `0.02890324`
+- improves `overall_quality_loss_mae_mean` slightly from `14.47575885` to `14.47328913`
+- improves `5.5" Phone Display Quality Loss` MAE slightly from `60.77410532` to `60.68418298`
+- improves `5.5" Phone Display Acutance` MAE slightly from `0.03525638` to `0.03513954`
+
+Relative to PR `#34`, this candidate is still much better on curve fit and focus-preset Acutance, but it remains dramatically worse on downstream Quality Loss:
+
+- `curve_mae_mean`: `0.03587346 -> 0.03283991`
+- `acutance_focus_preset_mae_mean`: `0.03165223 -> 0.02890324`
+- `overall_quality_loss_mae_mean`: `4.56800916 -> 14.47328913`
+- `5.5" Phone Display Quality Loss` MAE: `10.62507645 -> 60.68418298`
+
+Relative to PR `#30`, the candidate is still nowhere near the current merged branch on Quality Loss despite better curve fit:
+
+- `curve_mae_mean`: `0.03683438 -> 0.03283991`
+- `acutance_focus_preset_mae_mean`: `0.04249131 -> 0.02890324`
+- `overall_quality_loss_mae_mean`: `1.22214341 -> 14.47328913`
+- `5.5" Phone Display Quality Loss` MAE: `0.14297763 -> 60.68418298`
+
+## Conclusion
+
+This is a bounded mixed result, not a new main-line direction.
+
+The measured high-frequency-noise-share gate does slightly improve the phone-dominated downstream failure that PR `#47` exposed, but the effect size is tiny and it does not materially reduce the intrinsic branch's Quality Loss regression. The family is still useful as a source-backed negative: the current missing latent variable is not solved by a small noise-share-gated shape tweak alone.

--- a/tests/test_benchmark_parity_psd_mtf.py
+++ b/tests/test_benchmark_parity_psd_mtf.py
@@ -158,6 +158,16 @@ class BenchmarkParityPsdMtfTest(unittest.TestCase):
         )
         self.assertEqual(profile.intrinsic_full_reference_transfer_mode, "radial_real_mean")
 
+    def test_profile_allows_hf_noise_share_shape_correction_fields(self) -> None:
+        profile = Profile(
+            name="test",
+            calibration_file="algo/deadleaf_13b10_psd_calibration.json",
+            acutance_noise_scale_mode="high_frequency_noise_share_quadratic",
+            mtf_shape_correction_mode="hf_noise_share_gated_bump",
+        )
+        self.assertEqual(profile.acutance_noise_scale_mode, "high_frequency_noise_share_quadratic")
+        self.assertEqual(profile.mtf_shape_correction_mode, "hf_noise_share_gated_bump")
+
     def test_profile_allows_chart_fill_factor_for_compensation_family(self) -> None:
         profile = Profile(
             name="test",


### PR DESCRIPTION
## Summary

This follows umbrella issue `#29` via issue `#48` after the intrinsic phase-retention result in issue `#46` / PR `#47`.

This pass stays bounded to one source-backed scene-/process-dependent ISP proxy family built from the existing dead-leaves data:

- keep PR `#47`'s intrinsic phase-retained full-reference transfer fixed
- derive high-frequency noise share from the existing dead-leaves estimate
- gate one small downstream MTF shape correction bump from that measured share

The tracked result is a bounded mixed negative. It slightly improves the phone-dominated downstream failure exposed by PR `#47`, but the effect size is tiny and the intrinsic branch remains far from viable on overall Quality Loss.

## Changes

- add a tracked issue `#48` candidate profile for the high-frequency-noise-share gated shape-correction family
- add the issue benchmark note and tracked benchmark artifacts
- extend `algo.benchmark_parity_psd_mtf.Profile` so the shared candidate profile schema can be loaded by both parity benchmarks
- add a focused PSD benchmark test covering the new profile fields

## Validation

- `python3 -m pytest tests/test_benchmark_parity_psd_mtf.py tests/test_benchmark_parity_acutance_quality_loss.py -q`
- `python3 -m algo.benchmark_parity_acutance_quality_loss 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_hf_noise_share_shape_profile.json --output artifacts/issue48_hf_noise_share_shape_acutance_benchmark.json`
- `python3 -m algo.benchmark_parity_psd_mtf 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_hf_noise_share_shape_profile.json --output artifacts/issue48_hf_noise_share_shape_psd_benchmark.json`

## Result

Against PR `#47`:

- PSD is unchanged in practice: `curve_mae_mean 0.03280181`, `mtf_abs_signed_rel_mean 0.13993779`, `MTF20 / MTF30 / MTF50 = 0.08576635 / 0.01789155 / 0.00719609`
- Acutance `curve_mae_mean` regresses slightly: `0.03280181 -> 0.03283991`
- `acutance_focus_preset_mae_mean` improves slightly: `0.02892053 -> 0.02890324`
- `overall_quality_loss_mae_mean` improves slightly: `14.47575885 -> 14.47328913`
- `5.5" Phone Display Quality Loss` MAE improves slightly: `60.77410532 -> 60.68418298`
- `5.5" Phone Display Acutance` MAE improves slightly: `0.03525638 -> 0.03513954`

Against PR `#30` and PR `#34`, the candidate still remains far outside a viable main-line Quality Loss range.

Refs #29
Refs #48
Context from #33
Context from #34
Context from #46
Context from #47
