### PR TITLE
Issue #50: audit captured-image-size mean correction

### DIFF
--- a/algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_captured_image_size_mean_profile.json
+++ b/algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_captured_image_size_mean_profile.json
@@ -1,0 +1,191 @@
+{
+  "name": "deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_captured_image_size_mean",
+  "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+  "gamma": 0.5,
+  "linearization_mode": "toe_power",
+  "linearization_toe": 0.12,
+  "bayer_pattern": "RGGB",
+  "bayer_mode": "demosaic_red",
+  "roi_source": "reference_refined",
+  "roi_width": 1655,
+  "roi_height": 1673,
+  "roi_refine_percentile": 45.0,
+  "roi_refine_sigma": 5.0,
+  "roi_refine_min_border_margin": 8,
+  "roi_refine_search_radius": 4,
+  "roi_refine_step": 2,
+  "roi_refine_area_tolerance": 0.98,
+  "matched_ori_reference_anchor": true,
+  "matched_ori_correction_clip_lo": 0.5,
+  "matched_ori_correction_clip_hi": 2.0,
+  "matched_ori_anchor_mode": "acutance_only",
+  "matched_ori_strength_curve_frequencies": [
+    0.0,
+    0.12,
+    0.22,
+    0.35,
+    0.5
+  ],
+  "matched_ori_strength_curve_values": [
+    1.0,
+    1.0,
+    0.82,
+    0.95,
+    1.0
+  ],
+  "matched_ori_acutance_reference_anchor": true,
+  "matched_ori_acutance_correction_clip_lo": 0.9,
+  "matched_ori_acutance_correction_clip_hi": 1.1,
+  "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+  "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+    0.0,
+    0.25,
+    0.6,
+    0.8,
+    1.6,
+    2.5
+  ],
+  "matched_ori_acutance_curve_correction_clip_hi_values": [
+    1.02,
+    1.03,
+    0.895,
+    0.895,
+    1.05,
+    1.06
+  ],
+  "matched_ori_acutance_strength_curve_relative_scales": [
+    0.0,
+    0.2,
+    0.8,
+    1.6,
+    2.5
+  ],
+  "matched_ori_acutance_strength_curve_values": [
+    0.7,
+    0.69,
+    0.64,
+    0.62,
+    0.6
+  ],
+  "matched_ori_acutance_correction_delta_power": 1.0,
+  "matched_ori_acutance_curve_correction_delta_power": 0.95,
+  "matched_ori_acutance_preset_correction_delta_power": null,
+  "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+    0.0,
+    4.5,
+    5.8,
+    6.2
+  ],
+  "matched_ori_acutance_preset_correction_delta_power_values": [
+    1.05,
+    1.05,
+    1.85,
+    1.85
+  ],
+  "matched_ori_acutance_preset_strength_curve_relative_scales": [
+    0.0,
+    3.0,
+    4.5,
+    5.8,
+    6.2
+  ],
+  "matched_ori_acutance_preset_strength_curve_values": [
+    1.0,
+    1.0,
+    0.85,
+    0.45,
+    0.45
+  ],
+  "frequency_scale": 1.3268939965725617,
+  "texture_support_scale": false,
+  "normalization_band_lo": 0.01,
+  "normalization_band_hi": 0.03,
+  "normalization_mode": "max",
+  "acutance_band_lo": 0.017,
+  "acutance_band_hi": 0.035,
+  "acutance_band_mode": "mean",
+  "noise_psd_model": "empirical",
+  "noise_psd_scale": 1.0,
+  "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+  "acutance_noise_share_band_lo": 0.36,
+  "acutance_noise_share_band_hi": 0.5,
+  "acutance_noise_share_scale_coefficients": [
+    521.08180962,
+    -26.62905791,
+    1.59615575
+  ],
+  "high_frequency_guard_start_cpp": 0.36,
+  "high_frequency_guard_stop_cpp": 0.5,
+  "mtf_compensation_mode": "sensor_aperture_sinc",
+  "sensor_fill_factor": 1.5,
+  "compensation_denominator_clip": 0.25,
+  "compensation_max_gain": 3.0,
+  "quality_loss_om_ceiling": 0.8851,
+  "quality_loss_coefficients": [
+    37.240228358776136,
+    26.54550669779819,
+    0.4538662637619741
+  ],
+  "quality_loss_preset_overrides": {
+    "Computer Monitor Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        5677361.198044325,
+        -16715685.9524707,
+        20317567.326582585,
+        -13046703.33912079,
+        4667794.619228022,
+        -882296.9160375095,
+        68863.59709647154
+      ]
+    },
+    "5.5\" Phone Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        -110912321.41149135,
+        50461107.51563171,
+        -9079490.127807735,
+        815148.8697247265,
+        -37712.984407641874,
+        854.6941149036079,
+        -6.261149027919645
+      ]
+    },
+    "UHDTV Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        1783462.6221675149,
+        -3813432.5606394163,
+        3326218.4642961356,
+        -1514886.1959663907,
+        380334.163146246,
+        -49956.87092015135,
+        2692.9566508574017
+      ]
+    },
+    "Small Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        6690980.837239251,
+        -12955277.716404187,
+        10300283.291740375,
+        -4303759.200708971,
+        996904.2653558743,
+        -121409.71509269004,
+        6084.6471373306085
+      ]
+    },
+    "Large Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        2355074.475971866,
+        -5276146.244338096,
+        4846781.143787682,
+        -2336594.295523967,
+        623766.4933095274,
+        -87476.30712136331,
+        5049.882965558553
+      ]
+    }
+  }
+}

--- a/artifacts/issue50_captured_image_size_mean_acutance_benchmark.json
+++ b/artifacts/issue50_captured_image_size_mean_acutance_benchmark.json
@@ -1,0 +1,247 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.3268939965725617,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": false
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.04270496227640477,
+        "0.25": 0.03455167144732534,
+        "0.4": 0.028294850743527916,
+        "0.65": 0.03368832933603632,
+        "0.8": 0.039991905135975864,
+        "ori": 0.044511001381637126
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 1.3820414276207917,
+        "0.25": 1.2807663080583818,
+        "0.4": 1.1538825578323229,
+        "0.65": 0.36203644101974797,
+        "0.8": 1.008656608832441,
+        "ori": 2.314147344494331
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.04314809427659351,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.014159521391550616,
+          "Computer Monitor Acutance": 0.053256454824919516,
+          "Large Print Acutance": 0.052144791887639916,
+          "Small Print Acutance": 0.04746876697792299,
+          "UHDTV Display Acutance": 0.0487109363009345
+        },
+        "curve_mae_mean": 0.036928610992414124,
+        "overall_quality_loss_mae_mean": 1.2326877590201955,
+        "quality_loss_focus_preset_mae_mean": 1.2326877590201955,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 0.14301311122477994,
+          "Computer Monitor Quality Loss": 2.917619137901903,
+          "Large Print Quality Loss": 0.9653523550513278,
+          "Small Print Quality Loss": 0.6131123455647334,
+          "UHDTV Display Quality Loss": 1.5243418453582327
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_captured_image_size_mean_profile.json"
+    }
+  ]
+}

--- a/artifacts/issue50_captured_image_size_mean_psd_benchmark.json
+++ b/artifacts/issue50_captured_image_size_mean_psd_benchmark.json
@@ -1,0 +1,189 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.3268939965725617,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": false
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.0454825040793059,
+        "0.25": 0.03871931809153297,
+        "0.4": 0.03446731355399397,
+        "0.65": 0.040245402364809224,
+        "0.8": 0.049670206420643216,
+        "ori": 0.05559650579562947
+      },
+      "overall": {
+        "curve_mae_mean": 0.04325205924513908,
+        "mtf_abs_signed_rel_mean": 0.08726212951669865,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.01759557313451552,
+            "mre_mean": 0.08895304571416016,
+            "signed_rel_mean": 0.04989740771695915
+          },
+          "low": {
+            "mae_mean": 0.03722008349328533,
+            "mre_mean": 0.04681562171768595,
+            "signed_rel_mean": 0.023881241688028684
+          },
+          "mid": {
+            "mae_mean": 0.03927246342050306,
+            "mre_mean": 0.12495837623368904,
+            "signed_rel_mean": 0.11022480001653887
+          },
+          "top": {
+            "mae_mean": 0.07393537706214356,
+            "mre_mean": 0.20229843511127274,
+            "signed_rel_mean": -0.16504506864526788
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.03310971164151786,
+          "mtf30": 0.036985180822644924,
+          "mtf50": 0.009407622710176516
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.014906640324711992,
+          "Computer Monitor Acutance": 0.06182613603117455,
+          "Large Print Acutance": 0.05417655891841404,
+          "Small Print Acutance": 0.06213218021192739,
+          "UHDTV Display Acutance": 0.056519017849398036
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_captured_image_size_mean_profile.json"
+    }
+  ]
+}

--- a/docs/issue50_captured_image_size_followup.md
+++ b/docs/issue50_captured_image_size_followup.md
@@ -1,0 +1,98 @@
+# Issue 50 Captured-Image-Size Follow-up
+
+This note records the first bounded chart-scale / captured-image-size follow-up for issue `#50`.
+
+## Family
+
+This pass stays inside the current direct-method branch and tests one explicit captured-image-size correction derived from current repo evidence:
+
+- start from the current direct-method lower-layer branch from PR `#42`
+- replace the per-capture `texture_support_scale` heuristic with one fixed captured-image-size correction
+- derive that fixed correction from the measured support statistics of the current dataset
+
+Measured support statistics across the 40 `R_Random.csv` captures in `20260318_deadleaf_13b10`:
+
+- min `texture_support_scale = 1.32244595`
+- max `texture_support_scale = 1.33038222`
+- mean `texture_support_scale = 1.32689400`
+- median `texture_support_scale = 1.32666680`
+
+The tracked candidate therefore uses:
+
+- `texture_support_scale = false`
+- `frequency_scale = 1.3268939965725617`
+
+This is distinct from issue `#41` because it does not change the chart-prior slope or ideal-PSD calibration. It is also distinct from issue `#48` because it stays in the direct-method branch and changes only the chart-scale / frequency-mapping family.
+
+## Comparison Set
+
+PR `#30` baseline:
+
+- PSD `curve_mae_mean = 0.04306442`
+- PSD `mtf_abs_signed_rel_mean = 0.08692956`
+- PSD `MTF20 / MTF30 / MTF50 = 0.03300903 / 0.03693524 / 0.00933262`
+- Acutance `curve_mae_mean = 0.03683438`
+- `acutance_focus_preset_mae_mean = 0.04249131`
+- `overall_quality_loss_mae_mean = 1.22214341`
+
+PR `#42` anchored high-frequency PSD follow-up:
+
+- PSD `curve_mae_mean = 0.04300089`
+- PSD `mtf_abs_signed_rel_mean = 0.08671417`
+- PSD `MTF20 / MTF30 / MTF50 = 0.03301077 / 0.03693639 / 0.00933262`
+- Acutance `curve_mae_mean = 0.03678903`
+- `acutance_focus_preset_mae_mean = 0.04248683`
+- `overall_quality_loss_mae_mean = 1.22149895`
+
+PR `#43` chart-prior slope mixed negative:
+
+- PSD `curve_mae_mean = 0.02660758`
+- PSD `mtf_abs_signed_rel_mean = 0.33273968`
+- PSD `MTF20 / MTF30 / MTF50 = 0.03801027 / 0.05639194 / 0.03366694`
+- Acutance `curve_mae_mean = 0.02681195`
+- `acutance_focus_preset_mae_mean = 0.02882649`
+- `overall_quality_loss_mae_mean = 1.47355548`
+
+Issue `#50` captured-image-size mean candidate:
+
+- PSD `curve_mae_mean = 0.04325206`
+- PSD `mtf_abs_signed_rel_mean = 0.08726213`
+- PSD `MTF20 / MTF30 / MTF50 = 0.03310971 / 0.03698518 / 0.00940762`
+- Acutance `curve_mae_mean = 0.03692861`
+- `acutance_focus_preset_mae_mean = 0.04314809`
+- `overall_quality_loss_mae_mean = 1.23268776`
+
+## Result
+
+Relative to PR `#42`, the explicit captured-image-size replacement is worse on every reported top-line metric:
+
+- PSD `curve_mae_mean`: `0.04300089 -> 0.04325206`
+- PSD signed-relative residual: `0.08671417 -> 0.08726213`
+- `MTF20`: `0.03301077 -> 0.03310971`
+- `MTF30`: `0.03693639 -> 0.03698518`
+- `MTF50`: `0.00933262 -> 0.00940762`
+- Acutance `curve_mae_mean`: `0.03678903 -> 0.03692861`
+- `acutance_focus_preset_mae_mean`: `0.04248683 -> 0.04314809`
+- `overall_quality_loss_mae_mean`: `1.22149895 -> 1.23268776`
+
+Relative to PR `#30`, the candidate also regresses every reported top-line metric:
+
+- PSD `curve_mae_mean`: `0.04306442 -> 0.04325206`
+- PSD signed-relative residual: `0.08692956 -> 0.08726213`
+- `MTF20`: `0.03300903 -> 0.03310971`
+- `MTF30`: `0.03693524 -> 0.03698518`
+- `MTF50`: `0.00933262 -> 0.00940762`
+- Acutance `curve_mae_mean`: `0.03683438 -> 0.03692861`
+- `acutance_focus_preset_mae_mean`: `0.04249131 -> 0.04314809`
+- `overall_quality_loss_mae_mean`: `1.22214341 -> 1.23268776`
+
+Relative to PR `#43`, this candidate avoids the catastrophic chart-prior slope failure, but it still does not become a viable direct-method improvement:
+
+- the lower-layer threshold and signed-relative metrics remain close to the PR `#30` / PR `#42` branch rather than collapsing like PR `#43`
+- but every reported top-line metric is still slightly worse than the current direct-method branch
+
+## Conclusion
+
+This is a bounded negative result, not a new main-line direction.
+
+Replacing the current per-capture `texture_support_scale` heuristic with one explicit fixed captured-image-size correction derived from the dataset mean does not help. The effect is small but uniformly worse, which suggests the existing per-capture support estimate is a better approximation than this first explicit fixed-size substitute.


### PR DESCRIPTION
## Summary

This follows umbrella issue `#29` via issue `#50` after the bounded ISP-proxy result in issue `#48` / PR `#49`.

This pass tests one bounded source-backed chart-scale / captured-image-size correction family inside the current direct-method path:

- start from the current direct-method lower-layer branch from PR `#42`
- replace the per-capture `texture_support_scale` heuristic with one explicit captured-image-size correction
- derive that fixed correction from the measured support statistics of the current dataset

The tracked result is a bounded negative. The explicit fixed captured-image-size correction regresses every reported PSD / MTF and Acutance / Quality Loss top-line metric versus PR `#30` and PR `#42`.

## Changes

- add a tracked issue `#50` candidate profile using a fixed captured-image-size frequency correction derived from the dataset mean support scale
- add the issue benchmark note and tracked benchmark artifacts documenting the negative result

## Validation

- `python3 -m algo.benchmark_parity_psd_mtf 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_captured_image_size_mean_profile.json --output artifacts/issue50_captured_image_size_mean_psd_benchmark.json`
- `python3 -m algo.benchmark_parity_acutance_quality_loss 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_captured_image_size_mean_profile.json --output artifacts/issue50_captured_image_size_mean_acutance_benchmark.json`

## Result

Measured support statistics across the 40 `R_Random.csv` captures are narrow but stable:

- min `texture_support_scale = 1.32244595`
- max `texture_support_scale = 1.33038222`
- mean `texture_support_scale = 1.32689400`

The tracked candidate uses `texture_support_scale = false` and `frequency_scale = 1.3268939965725617`.

Against PR `#42`:

- PSD `curve_mae_mean`: `0.04300089 -> 0.04325206`
- PSD signed-relative residual: `0.08671417 -> 0.08726213`
- `MTF20 / MTF30 / MTF50`: `0.03301077 / 0.03693639 / 0.00933262 -> 0.03310971 / 0.03698518 / 0.00940762`
- Acutance `curve_mae_mean`: `0.03678903 -> 0.03692861`
- `acutance_focus_preset_mae_mean`: `0.04248683 -> 0.04314809`
- `overall_quality_loss_mae_mean`: `1.22149895 -> 1.23268776`

Against PR `#30`, the candidate also regresses every top-line metric. Against PR `#43`, it avoids the catastrophic chart-prior failure but still does not produce a viable direct-method improvement.

Refs #29
Refs #50
Context from #41
Context from #42
Context from #43
Context from #48
Context from #49
