### PR TITLE
Issue #52: audit direct observable ROI policy

### DIFF
--- a/algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json
+++ b/algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json
@@ -1,0 +1,191 @@
+{
+  "name": "deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only",
+  "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+  "gamma": 0.5,
+  "linearization_mode": "toe_power",
+  "linearization_toe": 0.12,
+  "bayer_pattern": "RGGB",
+  "bayer_mode": "demosaic_red",
+  "roi_source": "reference",
+  "roi_width": 1655,
+  "roi_height": 1673,
+  "roi_refine_percentile": 45.0,
+  "roi_refine_sigma": 5.0,
+  "roi_refine_min_border_margin": 8,
+  "roi_refine_search_radius": 4,
+  "roi_refine_step": 2,
+  "roi_refine_area_tolerance": 0.98,
+  "matched_ori_reference_anchor": true,
+  "matched_ori_correction_clip_lo": 0.5,
+  "matched_ori_correction_clip_hi": 2.0,
+  "matched_ori_anchor_mode": "acutance_only",
+  "matched_ori_strength_curve_frequencies": [
+    0.0,
+    0.12,
+    0.22,
+    0.35,
+    0.5
+  ],
+  "matched_ori_strength_curve_values": [
+    1.0,
+    1.0,
+    0.82,
+    0.95,
+    1.0
+  ],
+  "matched_ori_acutance_reference_anchor": true,
+  "matched_ori_acutance_correction_clip_lo": 0.9,
+  "matched_ori_acutance_correction_clip_hi": 1.1,
+  "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+  "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+    0.0,
+    0.25,
+    0.6,
+    0.8,
+    1.6,
+    2.5
+  ],
+  "matched_ori_acutance_curve_correction_clip_hi_values": [
+    1.02,
+    1.03,
+    0.895,
+    0.895,
+    1.05,
+    1.06
+  ],
+  "matched_ori_acutance_strength_curve_relative_scales": [
+    0.0,
+    0.2,
+    0.8,
+    1.6,
+    2.5
+  ],
+  "matched_ori_acutance_strength_curve_values": [
+    0.7,
+    0.69,
+    0.64,
+    0.62,
+    0.6
+  ],
+  "matched_ori_acutance_correction_delta_power": 1.0,
+  "matched_ori_acutance_curve_correction_delta_power": 0.95,
+  "matched_ori_acutance_preset_correction_delta_power": null,
+  "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+    0.0,
+    4.5,
+    5.8,
+    6.2
+  ],
+  "matched_ori_acutance_preset_correction_delta_power_values": [
+    1.05,
+    1.05,
+    1.85,
+    1.85
+  ],
+  "matched_ori_acutance_preset_strength_curve_relative_scales": [
+    0.0,
+    3.0,
+    4.5,
+    5.8,
+    6.2
+  ],
+  "matched_ori_acutance_preset_strength_curve_values": [
+    1.0,
+    1.0,
+    0.85,
+    0.45,
+    0.45
+  ],
+  "frequency_scale": 1.0,
+  "texture_support_scale": true,
+  "normalization_band_lo": 0.01,
+  "normalization_band_hi": 0.03,
+  "normalization_mode": "max",
+  "acutance_band_lo": 0.017,
+  "acutance_band_hi": 0.035,
+  "acutance_band_mode": "mean",
+  "noise_psd_model": "empirical",
+  "noise_psd_scale": 1.0,
+  "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+  "acutance_noise_share_band_lo": 0.36,
+  "acutance_noise_share_band_hi": 0.5,
+  "acutance_noise_share_scale_coefficients": [
+    521.08180962,
+    -26.62905791,
+    1.59615575
+  ],
+  "high_frequency_guard_start_cpp": 0.36,
+  "high_frequency_guard_stop_cpp": 0.5,
+  "mtf_compensation_mode": "sensor_aperture_sinc",
+  "sensor_fill_factor": 1.5,
+  "compensation_denominator_clip": 0.25,
+  "compensation_max_gain": 3.0,
+  "quality_loss_om_ceiling": 0.8851,
+  "quality_loss_coefficients": [
+    37.240228358776136,
+    26.54550669779819,
+    0.4538662637619741
+  ],
+  "quality_loss_preset_overrides": {
+    "Computer Monitor Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        5677361.198044325,
+        -16715685.9524707,
+        20317567.326582585,
+        -13046703.33912079,
+        4667794.619228022,
+        -882296.9160375095,
+        68863.59709647154
+      ]
+    },
+    "5.5\" Phone Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        -110912321.41149135,
+        50461107.51563171,
+        -9079490.127807735,
+        815148.8697247265,
+        -37712.984407641874,
+        854.6941149036079,
+        -6.261149027919645
+      ]
+    },
+    "UHDTV Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        1783462.6221675149,
+        -3813432.5606394163,
+        3326218.4642961356,
+        -1514886.1959663907,
+        380334.163146246,
+        -49956.87092015135,
+        2692.9566508574017
+      ]
+    },
+    "Small Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        6690980.837239251,
+        -12955277.716404187,
+        10300283.291740375,
+        -4303759.200708971,
+        996904.2653558743,
+        -121409.71509269004,
+        6084.6471373306085
+      ]
+    },
+    "Large Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        2355074.475971866,
+        -5276146.244338096,
+        4846781.143787682,
+        -2336594.295523967,
+        623766.4933095274,
+        -87476.30712136331,
+        5049.882965558553
+      ]
+    }
+  }
+}

--- a/artifacts/issue52_roi_reference_acutance_benchmark.json
+++ b/artifacts/issue52_roi_reference_acutance_benchmark.json
@@ -1,0 +1,247 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "roi_source": "reference",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.042461139101273825,
+        "0.25": 0.03438329907650581,
+        "0.4": 0.028222441215812154,
+        "0.65": 0.03228872676435854,
+        "0.8": 0.040189721146270965,
+        "ori": 0.0451547726413977
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 1.3478855541024857,
+        "0.25": 1.3065197488765725,
+        "0.4": 1.1903152267233512,
+        "0.65": 0.33169210926209886,
+        "0.8": 1.149561056616232,
+        "ori": 2.315457257974792
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.04130714367806507,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.012909940589898264,
+          "Computer Monitor Acutance": 0.053503296232802214,
+          "Large Print Acutance": 0.048029164175666376,
+          "Small Print Acutance": 0.0440934456167187,
+          "UHDTV Display Acutance": 0.047999871775239775
+        },
+        "curve_mae_mean": 0.036795670048548175,
+        "overall_quality_loss_mae_mean": 1.2635712539874173,
+        "quality_loss_focus_preset_mae_mean": 1.2635712539874173,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 0.1699187951448336,
+          "Computer Monitor Quality Loss": 2.9887158785513286,
+          "Large Print Quality Loss": 0.9753964866987435,
+          "Small Print Quality Loss": 0.6445598500524008,
+          "UHDTV Display Quality Loss": 1.5392652594897804
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json"
+    }
+  ]
+}

--- a/artifacts/issue52_roi_reference_psd_benchmark.json
+++ b/artifacts/issue52_roi_reference_psd_benchmark.json
@@ -1,0 +1,189 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "roi_source": "reference",
+        "sensor_fill_factor": 1.5,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.04393768183373263,
+        "0.25": 0.03710788456836763,
+        "0.4": 0.0329077188294806,
+        "0.65": 0.03870720063357137,
+        "0.8": 0.05002485138358607,
+        "ori": 0.05646024794455208
+      },
+      "overall": {
+        "curve_mae_mean": 0.04231237218084573,
+        "mtf_abs_signed_rel_mean": 0.0848335121245157,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.017405731949021022,
+            "mre_mean": 0.08764571042450976,
+            "signed_rel_mean": 0.04656660347357008
+          },
+          "low": {
+            "mae_mean": 0.037300268705105874,
+            "mre_mean": 0.04667271753065407,
+            "signed_rel_mean": 0.02116254166025956
+          },
+          "mid": {
+            "mae_mean": 0.03872032320276679,
+            "mre_mean": 0.12241708324324026,
+            "signed_rel_mean": 0.1059461109531886
+          },
+          "top": {
+            "mae_mean": 0.07406627402274787,
+            "mre_mean": 0.20241614420154247,
+            "signed_rel_mean": -0.16565879241104461
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.026588479385846887,
+          "mtf30": 0.029031147782014672,
+          "mtf50": 0.009210531290681506
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.013046926325952163,
+          "Computer Monitor Acutance": 0.0619057128560007,
+          "Large Print Acutance": 0.04826432657695518,
+          "Small Print Acutance": 0.055962857427902676,
+          "UHDTV Display Acutance": 0.05347209296392057
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json"
+    }
+  ]
+}

--- a/docs/issue52_direct_roi_reference_followup.md
+++ b/docs/issue52_direct_roi_reference_followup.md
@@ -1,0 +1,100 @@
+# Issue 52 Direct ROI Reference Follow-up
+
+This note records the bounded direct-method ROI-policy follow-up for issue `#52`.
+
+## Family
+
+This pass stays inside the current direct-method branch from PR `#42` and changes only the ROI policy:
+
+- start from the current anchored high-frequency direct-method profile from PR `#42`
+- remove the latent `reference_refined` texture-support refinement around the observable crop
+- use the observable Imatest `L R T B` crop directly with `roi_source = reference`
+
+This is distinct from issue `#50` because it does not change chart scale or frequency mapping. It is also distinct from issue `#41` because it does not change the chart prior, ideal PSD, or OECF family.
+
+## Comparison Set
+
+PR `#30` baseline:
+
+- PSD `curve_mae_mean = 0.04306442`
+- PSD `mtf_abs_signed_rel_mean = 0.08692956`
+- PSD `MTF20 / MTF30 / MTF50 = 0.03300903 / 0.03693524 / 0.00933262`
+- Acutance `curve_mae_mean = 0.03683438`
+- `acutance_focus_preset_mae_mean = 0.04249131`
+- `overall_quality_loss_mae_mean = 1.22214341`
+
+PR `#42` anchored high-frequency PSD follow-up:
+
+- PSD `curve_mae_mean = 0.04300089`
+- PSD `mtf_abs_signed_rel_mean = 0.08671417`
+- PSD `MTF20 / MTF30 / MTF50 = 0.03301077 / 0.03693639 / 0.00933262`
+- Acutance `curve_mae_mean = 0.03678903`
+- `acutance_focus_preset_mae_mean = 0.04248683`
+- `overall_quality_loss_mae_mean = 1.22149895`
+
+PR `#51` captured-image-size negative:
+
+- PSD `curve_mae_mean = 0.04325206`
+- PSD `mtf_abs_signed_rel_mean = 0.08726213`
+- PSD `MTF20 / MTF30 / MTF50 = 0.03310971 / 0.03698518 / 0.00940762`
+- Acutance `curve_mae_mean = 0.03692861`
+- `acutance_focus_preset_mae_mean = 0.04314809`
+- `overall_quality_loss_mae_mean = 1.23268776`
+
+Issue `#52` observable-reference ROI candidate:
+
+- PSD `curve_mae_mean = 0.04231237`
+- PSD `mtf_abs_signed_rel_mean = 0.08483351`
+- PSD `MTF20 / MTF30 / MTF50 = 0.02658848 / 0.02903115 / 0.00921053`
+- Acutance `curve_mae_mean = 0.03679567`
+- `acutance_focus_preset_mae_mean = 0.04130714`
+- `overall_quality_loss_mae_mean = 1.26357125`
+
+## Result
+
+Relative to PR `#42`, using the observable reference crop directly is a clear lower-layer improvement but a downstream Quality Loss regression:
+
+- PSD `curve_mae_mean`: `0.04300089 -> 0.04231237`
+- PSD signed-relative residual: `0.08671417 -> 0.08483351`
+- `MTF20`: `0.03301077 -> 0.02658848`
+- `MTF30`: `0.03693639 -> 0.02903115`
+- `MTF50`: `0.00933262 -> 0.00921053`
+- Acutance `curve_mae_mean`: `0.03678903 -> 0.03679567`
+- `acutance_focus_preset_mae_mean`: `0.04248683 -> 0.04130714`
+- `overall_quality_loss_mae_mean`: `1.22149895 -> 1.26357125`
+
+Relative to PR `#30`, the same pattern holds:
+
+- PSD `curve_mae_mean`: `0.04306442 -> 0.04231237`
+- PSD signed-relative residual: `0.08692956 -> 0.08483351`
+- `MTF20`: `0.03300903 -> 0.02658848`
+- `MTF30`: `0.03693524 -> 0.02903115`
+- `MTF50`: `0.00933262 -> 0.00921053`
+- Acutance `curve_mae_mean`: `0.03683438 -> 0.03679567`
+- `acutance_focus_preset_mae_mean`: `0.04249131 -> 0.04130714`
+- `overall_quality_loss_mae_mean`: `1.22214341 -> 1.26357125`
+
+Relative to PR `#51`, the observable-reference ROI candidate is better on every reported lower-layer and Acutance metric, but it still loses on overall Quality Loss:
+
+- PSD `curve_mae_mean`: `0.04325206 -> 0.04231237`
+- PSD signed-relative residual: `0.08726213 -> 0.08483351`
+- `MTF20`: `0.03310971 -> 0.02658848`
+- `MTF30`: `0.03698518 -> 0.02903115`
+- `MTF50`: `0.00940762 -> 0.00921053`
+- Acutance `curve_mae_mean`: `0.03692861 -> 0.03679567`
+- `acutance_focus_preset_mae_mean`: `0.04314809 -> 0.04130714`
+- `overall_quality_loss_mae_mean`: `1.23268776 -> 1.26357125`
+
+The Quality Loss regression is broad rather than phone-only. The candidate lands at:
+
+- `5.5" Phone Display Quality Loss` MAE `= 0.16991880`
+- `Computer Monitor Quality Loss` MAE `= 2.98871588`
+- `Large Print Quality Loss` MAE `= 0.97539649`
+- `Small Print Quality Loss` MAE `= 0.64455985`
+- `UHDTV Display Quality Loss` MAE `= 1.53926526`
+
+## Conclusion
+
+This is a bounded mixed result, not a drop-in replacement for the current direct-method branch.
+
+Using the observable Imatest crop directly removes some lower-layer error introduced by the current latent texture-support ROI refinement, and it improves focus-preset Acutance MAE. But the downstream Quality Loss fit moves materially in the wrong direction, so this candidate does not become the new canonical path by itself.


### PR DESCRIPTION
## Summary
- track one bounded direct-method ROI-policy family under issue #52 by replacing `reference_refined` with direct observable `roi_source = reference`
- add the tracked profile, benchmark artifacts, and follow-up note for the observable-reference ROI candidate
- benchmark the candidate against the current direct-method branch and prior issue #29 descendants

## Validation
- `python3 -m algo.benchmark_parity_psd_mtf 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json --output artifacts/issue52_roi_reference_psd_benchmark.json`
- `python3 -m algo.benchmark_parity_acutance_quality_loss 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json --output artifacts/issue52_roi_reference_acutance_benchmark.json`

## Result
- lower-layer PSD metrics improve versus PR #30, PR #42, and PR #51, including `curve_mae_mean 0.04300089 -> 0.04231237`, signed-relative residual `0.08671417 -> 0.08483351`, and `MTF20 / MTF30 / MTF50 = 0.02658848 / 0.02903115 / 0.00921053`
- Acutance remains mixed-positive with `curve_mae_mean 0.03678903 -> 0.03679567` and `acutance_focus_preset_mae_mean 0.04248683 -> 0.04130714`
- overall Quality Loss regresses versus PR #42 from `1.22149895 -> 1.26357125`, so this is a bounded mixed result rather than a main-line replacement

Refs #29
Refs #52
Context from #41
Context from #42
Context from #43
Context from #50
Context from #51
