### PR TITLE
Issue #54: audit observable-bin frequency mapping

### DIFF
--- a/algo/benchmark_parity_acutance_quality_loss.py
+++ b/algo/benchmark_parity_acutance_quality_loss.py
@@ -15,7 +15,6 @@ from .dead_leaves import (
     BayerMode,
     BayerPattern,
     DEFAULT_ACUTANCE_PRESETS,
-    IMATEST_REFERENCE_BINS,
     MTF_SHAPE_CORRECTION_SHARE_GATE,
     RoiBounds,
     acutance_curve_from_mtf,
@@ -45,6 +44,7 @@ from .parity_benchmark_common import (
     derive_reference_acutance_correction_curve,
     derive_reference_correction_curve,
     derive_intrinsic_transfer_curve,
+    resolve_frequency_bin_centers,
 )
 
 FOCUS_ACUTANCE_PRESETS = (
@@ -131,6 +131,7 @@ class Profile:
     matched_ori_acutance_preset_correction_delta_power_values: tuple[float, ...] | None = None
     matched_ori_acutance_preset_strength_curve_relative_scales: tuple[float, ...] | None = None
     matched_ori_acutance_preset_strength_curve_values: tuple[float, ...] | None = None
+    frequency_bin_source: str = "reference_bins"
     frequency_scale: float = 1.0
     normalization_band_lo: float = 0.01
     normalization_band_hi: float = 0.03
@@ -350,10 +351,18 @@ def summarize_profile(
             ori_roi = choose_roi(profile, ori_reference, ori_image)
             ori_estimate = estimate_dead_leaves_mtf(
                 ori_image,
-                num_bins=len(IMATEST_REFERENCE_BINS),
+                num_bins=len(
+                    resolve_frequency_bin_centers(
+                        ori_reference.frequencies_cpp,
+                        source=profile.frequency_bin_source,
+                    )
+                ),
                 ideal_psd_mode="calibrated_log",
                 ideal_psd_calibration=calibration,
-                bin_centers=IMATEST_REFERENCE_BINS,
+                bin_centers=resolve_frequency_bin_centers(
+                    ori_reference.frequencies_cpp,
+                    source=profile.frequency_bin_source,
+                ),
                 roi_override=ori_roi,
                 normalization_band=(profile.normalization_band_lo, profile.normalization_band_hi),
                 normalization_mode=profile.normalization_mode,
@@ -590,10 +599,18 @@ def summarize_profile(
             ).astype(np.float32)
         estimate = estimate_dead_leaves_mtf(
             image,
-            num_bins=len(IMATEST_REFERENCE_BINS),
+            num_bins=len(
+                resolve_frequency_bin_centers(
+                    reference.frequencies_cpp,
+                    source=profile.frequency_bin_source,
+                )
+            ),
             ideal_psd_mode="calibrated_log",
             ideal_psd_calibration=calibration,
-            bin_centers=IMATEST_REFERENCE_BINS,
+            bin_centers=resolve_frequency_bin_centers(
+                reference.frequencies_cpp,
+                source=profile.frequency_bin_source,
+            ),
             roi_override=roi,
             normalization_band=(profile.normalization_band_lo, profile.normalization_band_hi),
             normalization_mode=profile.normalization_mode,
@@ -724,10 +741,18 @@ def summarize_profile(
                     ori_roi = choose_roi(profile, ori_reference, ori_image)
                     ori_estimate = estimate_dead_leaves_mtf(
                         ori_image,
-                        num_bins=len(IMATEST_REFERENCE_BINS),
+                        num_bins=len(
+                            resolve_frequency_bin_centers(
+                                ori_reference.frequencies_cpp,
+                                source=profile.frequency_bin_source,
+                            )
+                        ),
                         ideal_psd_mode="calibrated_log",
                         ideal_psd_calibration=calibration,
-                        bin_centers=IMATEST_REFERENCE_BINS,
+                        bin_centers=resolve_frequency_bin_centers(
+                            ori_reference.frequencies_cpp,
+                            source=profile.frequency_bin_source,
+                        ),
                         roi_override=ori_roi,
                         normalization_band=(profile.normalization_band_lo, profile.normalization_band_hi),
                         normalization_mode=profile.normalization_mode,

--- a/algo/benchmark_parity_psd_mtf.py
+++ b/algo/benchmark_parity_psd_mtf.py
@@ -11,7 +11,6 @@ import numpy as np
 from .dead_leaves import (
     BayerMode,
     BayerPattern,
-    IMATEST_REFERENCE_BINS,
     MTF_SHAPE_CORRECTION_SHARE_GATE,
     RoiBounds,
     acutance_curve_from_mtf,
@@ -40,6 +39,7 @@ from .parity_benchmark_common import (
     derive_quantile_transfer_curve,
     derive_reference_correction_curve,
     derive_intrinsic_transfer_curve,
+    resolve_frequency_bin_centers,
 )
 
 BANDS = (
@@ -117,6 +117,7 @@ class Profile:
     matched_ori_acutance_preset_correction_delta_power_values: tuple[float, ...] | None = None
     matched_ori_acutance_preset_strength_curve_relative_scales: tuple[float, ...] | None = None
     matched_ori_acutance_preset_strength_curve_values: tuple[float, ...] | None = None
+    frequency_bin_source: str = "reference_bins"
     frequency_scale: float = 1.0
     normalization_band_lo: float = 0.01
     normalization_band_hi: float = 0.03
@@ -361,10 +362,18 @@ def profile_payload(
             ).astype(np.float32)
         estimate = estimate_dead_leaves_mtf(
             image,
-            num_bins=len(IMATEST_REFERENCE_BINS),
+            num_bins=len(
+                resolve_frequency_bin_centers(
+                    reference.frequencies_cpp,
+                    source=profile.frequency_bin_source,
+                )
+            ),
             ideal_psd_mode="calibrated_log",
             ideal_psd_calibration=calibration,
-            bin_centers=IMATEST_REFERENCE_BINS,
+            bin_centers=resolve_frequency_bin_centers(
+                reference.frequencies_cpp,
+                source=profile.frequency_bin_source,
+            ),
             roi_override=roi,
             normalization_band=(profile.normalization_band_lo, profile.normalization_band_hi),
             normalization_mode=profile.normalization_mode,
@@ -497,10 +506,18 @@ def profile_payload(
                     ori_roi = choose_roi(profile, ori_reference, ori_image)
                     ori_estimate = estimate_dead_leaves_mtf(
                         ori_image,
-                        num_bins=len(IMATEST_REFERENCE_BINS),
+                        num_bins=len(
+                            resolve_frequency_bin_centers(
+                                ori_reference.frequencies_cpp,
+                                source=profile.frequency_bin_source,
+                            )
+                        ),
                         ideal_psd_mode="calibrated_log",
                         ideal_psd_calibration=calibration,
-                        bin_centers=IMATEST_REFERENCE_BINS,
+                        bin_centers=resolve_frequency_bin_centers(
+                            ori_reference.frequencies_cpp,
+                            source=profile.frequency_bin_source,
+                        ),
                         roi_override=ori_roi,
                         normalization_band=(profile.normalization_band_lo, profile.normalization_band_hi),
                         normalization_mode=profile.normalization_mode,

--- a/algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_observable_bins_profile.json
+++ b/algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_observable_bins_profile.json
@@ -1,0 +1,192 @@
+{
+  "name": "deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_observable_bins",
+  "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+  "gamma": 0.5,
+  "linearization_mode": "toe_power",
+  "linearization_toe": 0.12,
+  "bayer_pattern": "RGGB",
+  "bayer_mode": "demosaic_red",
+  "roi_source": "reference",
+  "roi_width": 1655,
+  "roi_height": 1673,
+  "roi_refine_percentile": 45.0,
+  "roi_refine_sigma": 5.0,
+  "roi_refine_min_border_margin": 8,
+  "roi_refine_search_radius": 4,
+  "roi_refine_step": 2,
+  "roi_refine_area_tolerance": 0.98,
+  "matched_ori_reference_anchor": true,
+  "matched_ori_correction_clip_lo": 0.5,
+  "matched_ori_correction_clip_hi": 2.0,
+  "matched_ori_anchor_mode": "acutance_only",
+  "matched_ori_strength_curve_frequencies": [
+    0.0,
+    0.12,
+    0.22,
+    0.35,
+    0.5
+  ],
+  "matched_ori_strength_curve_values": [
+    1.0,
+    1.0,
+    0.82,
+    0.95,
+    1.0
+  ],
+  "matched_ori_acutance_reference_anchor": true,
+  "matched_ori_acutance_correction_clip_lo": 0.9,
+  "matched_ori_acutance_correction_clip_hi": 1.1,
+  "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+  "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+    0.0,
+    0.25,
+    0.6,
+    0.8,
+    1.6,
+    2.5
+  ],
+  "matched_ori_acutance_curve_correction_clip_hi_values": [
+    1.02,
+    1.03,
+    0.895,
+    0.895,
+    1.05,
+    1.06
+  ],
+  "matched_ori_acutance_strength_curve_relative_scales": [
+    0.0,
+    0.2,
+    0.8,
+    1.6,
+    2.5
+  ],
+  "matched_ori_acutance_strength_curve_values": [
+    0.7,
+    0.69,
+    0.64,
+    0.62,
+    0.6
+  ],
+  "matched_ori_acutance_correction_delta_power": 1.0,
+  "matched_ori_acutance_curve_correction_delta_power": 0.95,
+  "matched_ori_acutance_preset_correction_delta_power": null,
+  "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+    0.0,
+    4.5,
+    5.8,
+    6.2
+  ],
+  "matched_ori_acutance_preset_correction_delta_power_values": [
+    1.05,
+    1.05,
+    1.85,
+    1.85
+  ],
+  "matched_ori_acutance_preset_strength_curve_relative_scales": [
+    0.0,
+    3.0,
+    4.5,
+    5.8,
+    6.2
+  ],
+  "matched_ori_acutance_preset_strength_curve_values": [
+    1.0,
+    1.0,
+    0.85,
+    0.45,
+    0.45
+  ],
+  "frequency_scale": 1.0,
+  "texture_support_scale": true,
+  "normalization_band_lo": 0.01,
+  "normalization_band_hi": 0.03,
+  "normalization_mode": "max",
+  "acutance_band_lo": 0.017,
+  "acutance_band_hi": 0.035,
+  "acutance_band_mode": "mean",
+  "noise_psd_model": "empirical",
+  "noise_psd_scale": 1.0,
+  "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+  "acutance_noise_share_band_lo": 0.36,
+  "acutance_noise_share_band_hi": 0.5,
+  "acutance_noise_share_scale_coefficients": [
+    521.08180962,
+    -26.62905791,
+    1.59615575
+  ],
+  "high_frequency_guard_start_cpp": 0.36,
+  "high_frequency_guard_stop_cpp": 0.5,
+  "mtf_compensation_mode": "sensor_aperture_sinc",
+  "sensor_fill_factor": 1.5,
+  "compensation_denominator_clip": 0.25,
+  "compensation_max_gain": 3.0,
+  "quality_loss_om_ceiling": 0.8851,
+  "quality_loss_coefficients": [
+    37.240228358776136,
+    26.54550669779819,
+    0.4538662637619741
+  ],
+  "quality_loss_preset_overrides": {
+    "Computer Monitor Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        5677361.198044325,
+        -16715685.9524707,
+        20317567.326582585,
+        -13046703.33912079,
+        4667794.619228022,
+        -882296.9160375095,
+        68863.59709647154
+      ]
+    },
+    "5.5\" Phone Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        -110912321.41149135,
+        50461107.51563171,
+        -9079490.127807735,
+        815148.8697247265,
+        -37712.984407641874,
+        854.6941149036079,
+        -6.261149027919645
+      ]
+    },
+    "UHDTV Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        1783462.6221675149,
+        -3813432.5606394163,
+        3326218.4642961356,
+        -1514886.1959663907,
+        380334.163146246,
+        -49956.87092015135,
+        2692.9566508574017
+      ]
+    },
+    "Small Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        6690980.837239251,
+        -12955277.716404187,
+        10300283.291740375,
+        -4303759.200708971,
+        996904.2653558743,
+        -121409.71509269004,
+        6084.6471373306085
+      ]
+    },
+    "Large Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        2355074.475971866,
+        -5276146.244338096,
+        4846781.143787682,
+        -2336594.295523967,
+        623766.4933095274,
+        -87476.30712136331,
+        5049.882965558553
+      ]
+    }
+  },
+  "frequency_bin_source": "observable_table"
+}

--- a/algo/parity_benchmark_common.py
+++ b/algo/parity_benchmark_common.py
@@ -7,7 +7,7 @@ from typing import Sequence
 import cv2
 import numpy as np
 
-from .dead_leaves import AcutancePoint
+from .dead_leaves import AcutancePoint, IMATEST_REFERENCE_BINS
 
 
 EPS = 1e-12
@@ -21,6 +21,21 @@ def capture_key_from_stem(stem: str) -> str:
     if stem.endswith("_R_Random"):
         return stem[: -len("_R_Random")]
     return stem
+
+
+def resolve_frequency_bin_centers(
+    reference_frequencies_cpp: Sequence[float],
+    *,
+    source: str = "reference_bins",
+) -> np.ndarray:
+    if source == "reference_bins":
+        return np.asarray(IMATEST_REFERENCE_BINS, dtype=np.float64).copy()
+    if source == "observable_table":
+        centers = np.asarray(reference_frequencies_cpp, dtype=np.float64)
+        if centers.ndim != 1 or centers.size == 0:
+            raise ValueError("Observable-table frequency bins must be a non-empty 1D series")
+        return centers.copy()
+    raise ValueError(f"Unsupported frequency bin source: {source}")
 
 
 def build_ori_reference_map(dataset_root: Path) -> dict[str, tuple[Path, Path]]:

--- a/artifacts/issue54_observable_frequency_bins_acutance_benchmark.json
+++ b/artifacts/issue54_observable_frequency_bins_acutance_benchmark.json
@@ -1,0 +1,247 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "roi_source": "reference",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.04247868626715585,
+        "0.25": 0.034408668452146865,
+        "0.4": 0.028485972388305438,
+        "0.65": 0.032158641470711395,
+        "0.8": 0.040314751310171607,
+        "ori": 0.045532639019301636
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 1.3611449961356383,
+        "0.25": 1.3098765289947367,
+        "0.4": 1.2072354638002412,
+        "0.65": 0.3443181340407375,
+        "0.8": 1.1502456330410205,
+        "ori": 2.3215770033729197
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.04092806011880924,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.012632859545328204,
+          "Computer Monitor Acutance": 0.05327084155351432,
+          "Large Print Acutance": 0.04762663123263737,
+          "Small Print Acutance": 0.043478956082953275,
+          "UHDTV Display Acutance": 0.04763101217961305
+        },
+        "curve_mae_mean": 0.03690674373255725,
+        "overall_quality_loss_mae_mean": 1.272290038135693,
+        "quality_loss_focus_preset_mae_mean": 1.272290038135693,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 0.17403968250594493,
+          "Computer Monitor Quality Loss": 3.005541718007179,
+          "Large Print Quality Loss": 0.9797306535035449,
+          "Small Print Quality Loss": 0.6463902403067138,
+          "UHDTV Display Quality Loss": 1.5557478963550824
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_observable_bins_profile.json"
+    }
+  ]
+}

--- a/artifacts/issue54_observable_frequency_bins_psd_benchmark.json
+++ b/artifacts/issue54_observable_frequency_bins_psd_benchmark.json
@@ -1,0 +1,189 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "roi_source": "reference",
+        "sensor_fill_factor": 1.5,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.0439783236117057,
+        "0.25": 0.03704518139883028,
+        "0.4": 0.03308132359721401,
+        "0.65": 0.038575751211670006,
+        "0.8": 0.05023503411043351,
+        "ori": 0.05690093596815642
+      },
+      "overall": {
+        "curve_mae_mean": 0.04241564126161934,
+        "mtf_abs_signed_rel_mean": 0.08641068164960827,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.01786238437837319,
+            "mre_mean": 0.08953425387039934,
+            "signed_rel_mean": 0.04890055201375894
+          },
+          "low": {
+            "mae_mean": 0.03723708892057649,
+            "mre_mean": 0.046709382461667906,
+            "signed_rel_mean": 0.024022337650985572
+          },
+          "mid": {
+            "mae_mean": 0.03915569171038953,
+            "mre_mean": 0.12417735473646874,
+            "signed_rel_mean": 0.10932301602280918
+          },
+          "top": {
+            "mae_mean": 0.07370374938194174,
+            "mre_mean": 0.2016215757088485,
+            "signed_rel_mean": -0.16339682091087945
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.021093664116902187,
+          "mtf30": 0.02920595943030816,
+          "mtf50": 0.009428579810416034
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.012788283015639904,
+          "Computer Monitor Acutance": 0.06177817679462536,
+          "Large Print Acutance": 0.047938875128194704,
+          "Small Print Acutance": 0.05549901119656311,
+          "UHDTV Display Acutance": 0.053333805924793774
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_observable_bins_profile.json"
+    }
+  ]
+}

--- a/docs/issue54_observable_frequency_bins_followup.md
+++ b/docs/issue54_observable_frequency_bins_followup.md
@@ -1,0 +1,100 @@
+# Issue 54 Observable Frequency-Bin Follow-up
+
+This note records the bounded direct-method frequency-mapping follow-up for issue `#54`.
+
+## Family
+
+This pass stays inside the current direct-method branch from PR `#53` and changes only the frequency-axis formulation:
+
+- start from the current anchored high-frequency direct-method profile with observable ROI from PR `#53`
+- keep the current ROI policy, texture-support scaling, and matched-ORI anchor behavior
+- replace the inferred static `IMATEST_REFERENCE_BINS` centers with the directly observed per-capture `Table of MTF` frequency bins from each golden CSV via `frequency_bin_source = observable_table`
+
+This is distinct from issue `#50` because it does not alter captured-image-size or chart-scale assumptions. It is also distinct from issue `#52` because it keeps `roi_source = reference` fixed and changes only the frequency-bin mapping.
+
+## Comparison Set
+
+PR `#30` baseline:
+
+- PSD `curve_mae_mean = 0.04497615`
+- PSD `mtf_abs_signed_rel_mean = 0.33019613`
+- PSD `MTF20 / MTF30 / MTF50 = 0.11418549 / 0.07118338 / 0.03341906`
+- Acutance `curve_mae_mean = 0.04497615`
+- `acutance_focus_preset_mae_mean = 0.03479546`
+- `overall_quality_loss_mae_mean = 2.19874216`
+
+PR `#42` anchored high-frequency PSD follow-up:
+
+- PSD `curve_mae_mean = 0.04306442`
+- PSD `mtf_abs_signed_rel_mean = 0.08692956`
+- PSD `MTF20 / MTF30 / MTF50 = 0.03300903 / 0.03693524 / 0.00933262`
+- Acutance `curve_mae_mean = 0.03683438`
+- `acutance_focus_preset_mae_mean = 0.04249131`
+- `overall_quality_loss_mae_mean = 1.22214341`
+
+PR `#53` observable-reference ROI follow-up:
+
+- PSD `curve_mae_mean = 0.04231237`
+- PSD `mtf_abs_signed_rel_mean = 0.08483351`
+- PSD `MTF20 / MTF30 / MTF50 = 0.02658848 / 0.02903115 / 0.00921053`
+- Acutance `curve_mae_mean = 0.03679567`
+- `acutance_focus_preset_mae_mean = 0.04130714`
+- `overall_quality_loss_mae_mean = 1.26357125`
+
+Issue `#54` observable-bin frequency candidate:
+
+- PSD `curve_mae_mean = 0.04241564`
+- PSD `mtf_abs_signed_rel_mean = 0.08641068`
+- PSD `MTF20 / MTF30 / MTF50 = 0.02109366 / 0.02920596 / 0.00942858`
+- Acutance `curve_mae_mean = 0.03690674`
+- `acutance_focus_preset_mae_mean = 0.04092806`
+- `overall_quality_loss_mae_mean = 1.27229004`
+
+## Result
+
+Relative to PR `#53`, switching from inferred static bin centers to the observable per-capture table is a narrow lower-layer tradeoff, not a clear net win:
+
+- PSD `curve_mae_mean`: `0.04231237 -> 0.04241564`
+- PSD signed-relative residual: `0.08483351 -> 0.08641068`
+- `MTF20`: `0.02658848 -> 0.02109366`
+- `MTF30`: `0.02903115 -> 0.02920596`
+- `MTF50`: `0.00921053 -> 0.00942858`
+- Acutance `curve_mae_mean`: `0.03679567 -> 0.03690674`
+- `acutance_focus_preset_mae_mean`: `0.04130714 -> 0.04092806`
+- `overall_quality_loss_mae_mean`: `1.26357125 -> 1.27229004`
+
+Relative to PR `#42`, the observable-bin candidate still keeps most of the later direct-method gains, but it does not recover the top-line Quality Loss baseline:
+
+- PSD `curve_mae_mean`: `0.04306442 -> 0.04241564`
+- PSD signed-relative residual: `0.08692956 -> 0.08641068`
+- `MTF20`: `0.03300903 -> 0.02109366`
+- `MTF30`: `0.03693524 -> 0.02920596`
+- `MTF50`: `0.00933262 -> 0.00942858`
+- Acutance `curve_mae_mean`: `0.03683438 -> 0.03690674`
+- `acutance_focus_preset_mae_mean`: `0.04249131 -> 0.04092806`
+- `overall_quality_loss_mae_mean`: `1.22214341 -> 1.27229004`
+
+Relative to PR `#30`, the candidate remains much better on PSD and overall Quality Loss, but it still does not beat the early focus-preset Acutance aggregate:
+
+- PSD `curve_mae_mean`: `0.04497615 -> 0.04241564`
+- PSD signed-relative residual: `0.33019613 -> 0.08641068`
+- `MTF20`: `0.11418549 -> 0.02109366`
+- `MTF30`: `0.07118338 -> 0.02920596`
+- `MTF50`: `0.03341906 -> 0.00942858`
+- Acutance `curve_mae_mean`: `0.04497615 -> 0.03690674`
+- `acutance_focus_preset_mae_mean`: `0.03479546 -> 0.04092806`
+- `overall_quality_loss_mae_mean`: `2.19874216 -> 1.27229004`
+
+The Quality Loss regression versus PR `#53` is broad rather than concentrated in one preset:
+
+- `5.5" Phone Display Quality Loss` MAE `= 0.17403968`
+- `Computer Monitor Quality Loss` MAE `= 3.00554172`
+- `Large Print Quality Loss` MAE `= 0.97973065`
+- `Small Print Quality Loss` MAE `= 0.64639024`
+- `UHDTV Display Quality Loss` MAE `= 1.55574790`
+
+## Conclusion
+
+This is a bounded mixed result, not a new default frequency-mapping path.
+
+Using the observable frequency table directly is source-backed and it improves the `MTF20` threshold error while preserving the general post-PR-42 direct-method gains. But the rest of the lower-layer PSD summary slips versus PR `#53`, the Acutance curve regresses slightly, and overall Quality Loss moves further away from the current best direct-method path. The static inferred reference-bin centers therefore remain the better default on the current dataset.

--- a/tests/test_benchmark_parity_acutance_quality_loss.py
+++ b/tests/test_benchmark_parity_acutance_quality_loss.py
@@ -80,6 +80,133 @@ class BenchmarkParityAcutanceQualityLossTest(unittest.TestCase):
         self.assertEqual(actual, expected)
         self.assertEqual(refine.call_args.kwargs["seed_roi"], reference.lrtb)
 
+    def test_summarize_profile_uses_observable_table_frequency_bins(self) -> None:
+        capture_key = "OV13b10_AG8_ET5500_deadleaf_12M_40"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dataset_root = Path(tmpdir)
+            variant_root = dataset_root / "OV13B10_AI_NR_OV13B10_ppqpkl_0.10"
+            results_dir = variant_root / "Results"
+            results_dir.mkdir(parents=True)
+            stem = f"{capture_key}_variantA"
+            (results_dir / f"{stem}_R_Random.csv").write_text("", encoding="utf-8")
+            (variant_root / f"{stem}.raw").write_bytes(b"")
+
+            reference = SimpleNamespace(
+                lrtb=RoiBounds(left=0, right=1, top=0, bottom=1),
+                frequencies_cpp=np.array([0.02, 0.1, 0.25, 0.4], dtype=np.float64),
+                mtf=np.array([1.0, 0.9, 0.8, 0.7], dtype=np.float64),
+                acutance_table=[
+                    AcutancePoint(print_height_cm=40.0, viewing_distance_cm=10.0, acutance=1.0)
+                ],
+                reported_acutance={
+                    '5.5" Phone Display Acutance': 1.0,
+                    "Computer Monitor Acutance": 1.0,
+                    "UHDTV Display Acutance": 1.0,
+                    "Small Print Acutance": 1.0,
+                    "Large Print Acutance": 1.0,
+                },
+                reported_quality_loss={
+                    '5.5" Phone Display Quality Loss': 1.0,
+                    "Computer Monitor Quality Loss": 1.0,
+                    "UHDTV Display Quality Loss": 1.0,
+                    "Small Print Quality Loss": 1.0,
+                    "Large Print Quality Loss": 1.0,
+                },
+            )
+            estimate = SimpleNamespace(
+                roi=RoiBounds(left=0, right=1, top=0, bottom=1),
+                frequencies_cpp=reference.frequencies_cpp,
+                mtf_for_acutance=np.array([1.0, 0.9, 0.8, 0.7], dtype=np.float64),
+                acutance_high_frequency_noise_share=0.0,
+            )
+            profile = Profile(
+                name="test",
+                calibration_file="calibration.json",
+                roi_source="reference",
+                frequency_bin_source="observable_table",
+            )
+
+            with (
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.load_ideal_psd_calibration",
+                    return_value=None,
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.parse_imatest_random_csv",
+                    return_value=reference,
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.load_raw_u16",
+                    side_effect=lambda path, width, height: np.zeros((height, width), dtype=np.uint16),
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.extract_analysis_plane",
+                    side_effect=lambda raw, **_: raw,
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.normalize_for_analysis",
+                    side_effect=lambda plane, **_: plane,
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.estimate_dead_leaves_mtf",
+                    return_value=estimate,
+                ) as estimate_mtf,
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.apply_mtf_compensation",
+                    side_effect=lambda mtf, freqs, **_: (
+                        np.asarray(mtf, dtype=np.float64),
+                        np.asarray(freqs, dtype=np.float64),
+                    ),
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.apply_mtf_shape_correction",
+                    side_effect=lambda mtf, freqs, **_: (
+                        np.asarray(mtf, dtype=np.float64),
+                        np.asarray(freqs, dtype=np.float64),
+                    ),
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.acutance_curve_from_mtf",
+                    return_value=reference.acutance_table,
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.acutance_presets_from_mtf",
+                    return_value=reference.reported_acutance,
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.quality_loss_presets_from_acutance",
+                    return_value=reference.reported_quality_loss,
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.compare_acutance_curves",
+                    return_value={"count": 1, "mae": 0.0},
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.compare_acutance_presets",
+                    side_effect=[
+                        {name: {"abs_error": 0.0} for name in reference.reported_acutance},
+                        {name: {"abs_error": 0.0} for name in reference.reported_quality_loss},
+                    ],
+                ),
+            ):
+                summarize_profile(
+                    dataset_root=dataset_root,
+                    profile_path=dataset_root / "profile.json",
+                    profile=profile,
+                    width=2,
+                    height=2,
+                )
+
+            self.assertEqual(estimate_mtf.call_count, 1)
+            np.testing.assert_allclose(
+                estimate_mtf.call_args.kwargs["bin_centers"],
+                reference.frequencies_cpp,
+            )
+            self.assertEqual(
+                estimate_mtf.call_args.kwargs["num_bins"],
+                len(reference.frequencies_cpp),
+            )
+
     def test_reference_correction_curve_is_clipped(self) -> None:
         correction = derive_reference_correction_curve(
             np.array([0.1, 0.2], dtype=np.float64),
@@ -140,6 +267,14 @@ class BenchmarkParityAcutanceQualityLossTest(unittest.TestCase):
         self.assertEqual(target_values[-1], 1.0)
         self.assertTrue(np.all(np.diff(source_values) > 0.0))
         self.assertTrue(np.all(np.diff(target_values) >= 0.0))
+
+    def test_profile_allows_observable_table_frequency_bins(self) -> None:
+        profile = Profile(
+            name="test",
+            calibration_file="algo/deadleaf_13b10_psd_calibration.json",
+            frequency_bin_source="observable_table",
+        )
+        self.assertEqual(profile.frequency_bin_source, "observable_table")
 
     def test_quantile_transfer_curve_blends_by_strength(self) -> None:
         corrected = apply_quantile_transfer_curve(
@@ -587,6 +722,7 @@ class BenchmarkParityAcutanceQualityLossTest(unittest.TestCase):
             }
             reference = SimpleNamespace(
                 lrtb=RoiBounds(left=0, right=1, top=0, bottom=1),
+                frequencies_cpp=np.array([0.1, 0.2], dtype=np.float64),
                 acutance_table=acutance_table,
                 reported_acutance=reported_acutance,
                 reported_quality_loss=reported_quality_loss,
@@ -712,6 +848,7 @@ class BenchmarkParityAcutanceQualityLossTest(unittest.TestCase):
 
             reference = SimpleNamespace(
                 lrtb=RoiBounds(left=0, right=1, top=0, bottom=1),
+                frequencies_cpp=np.array([0.1, 0.2], dtype=np.float64),
                 acutance_table=[
                     AcutancePoint(print_height_cm=40.0, viewing_distance_cm=10.0, acutance=1.0)
                 ],

--- a/tests/test_benchmark_parity_psd_mtf.py
+++ b/tests/test_benchmark_parity_psd_mtf.py
@@ -46,6 +46,87 @@ class BenchmarkParityPsdMtfTest(unittest.TestCase):
         self.assertEqual(actual, expected)
         self.assertEqual(refine.call_args.kwargs["seed_roi"], reference.lrtb)
 
+    def test_profile_payload_uses_observable_table_frequency_bins(self) -> None:
+        capture_key = "OV13b10_AG8_ET5500_deadleaf_12M_40"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dataset_root = Path(tmpdir)
+            variant_root = dataset_root / "OV13B10_AI_NR_OV13B10_ppqpkl_0.10"
+            results_dir = variant_root / "Results"
+            results_dir.mkdir(parents=True)
+            stem = f"{capture_key}_variantA"
+            (results_dir / f"{stem}_R_Random.csv").write_text("", encoding="utf-8")
+            (variant_root / f"{stem}.raw").write_bytes(b"")
+
+            reference = SimpleNamespace(
+                lrtb=RoiBounds(left=0, right=1, top=0, bottom=1),
+                frequencies_cpp=np.array([0.02, 0.1, 0.25, 0.4], dtype=np.float64),
+                mtf=np.array([1.0, 0.9, 0.8, 0.7], dtype=np.float64),
+                acutance_table=[
+                    AcutancePoint(print_height_cm=40.0, viewing_distance_cm=10.0, acutance=1.0)
+                ],
+                reported_acutance={'5.5" Phone Display Acutance': 1.0},
+            )
+            estimate = SimpleNamespace(
+                roi=RoiBounds(left=0, right=1, top=0, bottom=1),
+                frequencies_cpp=reference.frequencies_cpp,
+                mtf=np.array([1.0, 0.9, 0.8, 0.7], dtype=np.float64),
+                mtf_for_acutance=np.array([1.0, 0.9, 0.8, 0.7], dtype=np.float64),
+            )
+            profile = Profile(
+                name="test",
+                calibration_file="calibration.json",
+                roi_source="reference",
+                frequency_bin_source="observable_table",
+            )
+
+            with (
+                patch("algo.benchmark_parity_psd_mtf.load_ideal_psd_calibration", return_value=None),
+                patch("algo.benchmark_parity_psd_mtf.parse_imatest_random_csv", return_value=reference),
+                patch(
+                    "algo.benchmark_parity_psd_mtf.load_raw_u16",
+                    side_effect=lambda path, width, height: np.zeros((height, width), dtype=np.uint16),
+                ),
+                patch("algo.benchmark_parity_psd_mtf.extract_analysis_plane", side_effect=lambda raw, **_: raw),
+                patch("algo.benchmark_parity_psd_mtf.normalize_for_analysis", side_effect=lambda plane, **_: plane),
+                patch("algo.benchmark_parity_psd_mtf.estimate_dead_leaves_mtf", return_value=estimate) as estimate_mtf,
+                patch(
+                    "algo.benchmark_parity_psd_mtf.apply_mtf_compensation",
+                    side_effect=lambda mtf, freqs, **_: (
+                        np.asarray(mtf, dtype=np.float64),
+                        np.asarray(freqs, dtype=np.float64),
+                    ),
+                ),
+                patch(
+                    "algo.benchmark_parity_psd_mtf.compute_mtf_metrics",
+                    return_value=SimpleNamespace(mtf50=0.1, mtf30=0.1, mtf20=0.1),
+                ),
+                patch("algo.benchmark_parity_psd_mtf.interpolate_threshold", return_value=0.1),
+                patch("algo.benchmark_parity_psd_mtf.acutance_curve_from_mtf", return_value=reference.acutance_table),
+                patch("algo.benchmark_parity_psd_mtf.compare_acutance_curves", return_value={"count": 1, "mae": 0.0}),
+                patch("algo.benchmark_parity_psd_mtf.acutance_presets_from_mtf", return_value=reference.reported_acutance),
+                patch(
+                    "algo.benchmark_parity_psd_mtf.compare_acutance_presets",
+                    return_value={'5.5" Phone Display Acutance': {"abs_error": 0.0}},
+                ),
+            ):
+                profile_payload(
+                    dataset_root=dataset_root,
+                    profile_path=dataset_root / "profile.json",
+                    profile=profile,
+                    width=2,
+                    height=2,
+                )
+
+            self.assertEqual(estimate_mtf.call_count, 1)
+            np.testing.assert_allclose(
+                estimate_mtf.call_args.kwargs["bin_centers"],
+                reference.frequencies_cpp,
+            )
+            self.assertEqual(
+                estimate_mtf.call_args.kwargs["num_bins"],
+                len(reference.frequencies_cpp),
+            )
+
     def test_capture_key_from_stem_strips_denoise_suffix(self) -> None:
         self.assertEqual(
             capture_key_from_stem("OV13b10_AG8_ET5500_deadleaf_12M_40_denoised_A_model_mixup04"),
@@ -167,6 +248,14 @@ class BenchmarkParityPsdMtfTest(unittest.TestCase):
         )
         self.assertEqual(profile.acutance_noise_scale_mode, "high_frequency_noise_share_quadratic")
         self.assertEqual(profile.mtf_shape_correction_mode, "hf_noise_share_gated_bump")
+
+    def test_profile_allows_observable_table_frequency_bins(self) -> None:
+        profile = Profile(
+            name="test",
+            calibration_file="algo/deadleaf_13b10_psd_calibration.json",
+            frequency_bin_source="observable_table",
+        )
+        self.assertEqual(profile.frequency_bin_source, "observable_table")
 
     def test_profile_allows_chart_fill_factor_for_compensation_family(self) -> None:
         profile = Profile(


### PR DESCRIPTION
## Summary
- add `frequency_bin_source` support so the parity benchmarks can choose between the inferred static reference-bin centers and the directly observed per-capture `Table of MTF` bin centers
- add focused tests, the issue-54 observable-bin profile, regenerated benchmark artifacts, and a follow-up note for this bounded direct-method frequency-mapping family
- benchmark the observable-table candidate against PR #30, PR #42, and PR #53 without reopening the ROI-policy or captured-image-size families

## Validation
- `python3 -m pytest tests/test_benchmark_parity_psd_mtf.py tests/test_benchmark_parity_acutance_quality_loss.py`
- `python3 -m algo.benchmark_parity_psd_mtf 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_observable_bins_profile.json --output artifacts/issue54_observable_frequency_bins_psd_benchmark.json`
- `python3 -m algo.benchmark_parity_acutance_quality_loss 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_observable_bins_profile.json --output artifacts/issue54_observable_frequency_bins_acutance_benchmark.json`

## Result
- versus PR #53, the observable-bin candidate improves only `MTF20` (`0.02658848 -> 0.02109366`) while PSD `curve_mae_mean` (`0.04231237 -> 0.04241564`), PSD signed-relative residual (`0.08483351 -> 0.08641068`), Acutance `curve_mae_mean` (`0.03679567 -> 0.03690674`), and `overall_quality_loss_mae_mean` (`1.26357125 -> 1.27229004`) all regress
- versus PR #42, it keeps most of the later direct-method PSD gains but still loses the prior Quality Loss baseline (`1.22214341 -> 1.27229004`)
- versus PR #30, PSD and overall Quality Loss remain much better, but the focus-preset Acutance aggregate is still worse (`0.03479546 -> 0.04092806`)
- this lands as another bounded mixed result, so the static inferred reference-bin centers remain the better default on the current dataset

Refs #29
Refs #54
Context from #42
Context from #52
Context from #53