### PR TITLE
Issue #56: audit empirical frequency-scale family

### DIFF
--- a/algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_freqscale_1095_profile.json
+++ b/algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_freqscale_1095_profile.json
@@ -1,0 +1,191 @@
+{
+  "name": "deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_freqscale_1095",
+  "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+  "gamma": 0.5,
+  "linearization_mode": "toe_power",
+  "linearization_toe": 0.12,
+  "bayer_pattern": "RGGB",
+  "bayer_mode": "demosaic_red",
+  "roi_source": "reference",
+  "roi_width": 1655,
+  "roi_height": 1673,
+  "roi_refine_percentile": 45.0,
+  "roi_refine_sigma": 5.0,
+  "roi_refine_min_border_margin": 8,
+  "roi_refine_search_radius": 4,
+  "roi_refine_step": 2,
+  "roi_refine_area_tolerance": 0.98,
+  "matched_ori_reference_anchor": true,
+  "matched_ori_correction_clip_lo": 0.5,
+  "matched_ori_correction_clip_hi": 2.0,
+  "matched_ori_anchor_mode": "acutance_only",
+  "matched_ori_strength_curve_frequencies": [
+    0.0,
+    0.12,
+    0.22,
+    0.35,
+    0.5
+  ],
+  "matched_ori_strength_curve_values": [
+    1.0,
+    1.0,
+    0.82,
+    0.95,
+    1.0
+  ],
+  "matched_ori_acutance_reference_anchor": true,
+  "matched_ori_acutance_correction_clip_lo": 0.9,
+  "matched_ori_acutance_correction_clip_hi": 1.1,
+  "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+  "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+    0.0,
+    0.25,
+    0.6,
+    0.8,
+    1.6,
+    2.5
+  ],
+  "matched_ori_acutance_curve_correction_clip_hi_values": [
+    1.02,
+    1.03,
+    0.895,
+    0.895,
+    1.05,
+    1.06
+  ],
+  "matched_ori_acutance_strength_curve_relative_scales": [
+    0.0,
+    0.2,
+    0.8,
+    1.6,
+    2.5
+  ],
+  "matched_ori_acutance_strength_curve_values": [
+    0.7,
+    0.69,
+    0.64,
+    0.62,
+    0.6
+  ],
+  "matched_ori_acutance_correction_delta_power": 1.0,
+  "matched_ori_acutance_curve_correction_delta_power": 0.95,
+  "matched_ori_acutance_preset_correction_delta_power": null,
+  "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+    0.0,
+    4.5,
+    5.8,
+    6.2
+  ],
+  "matched_ori_acutance_preset_correction_delta_power_values": [
+    1.05,
+    1.05,
+    1.85,
+    1.85
+  ],
+  "matched_ori_acutance_preset_strength_curve_relative_scales": [
+    0.0,
+    3.0,
+    4.5,
+    5.8,
+    6.2
+  ],
+  "matched_ori_acutance_preset_strength_curve_values": [
+    1.0,
+    1.0,
+    0.85,
+    0.45,
+    0.45
+  ],
+  "frequency_scale": 1.095,
+  "texture_support_scale": true,
+  "normalization_band_lo": 0.01,
+  "normalization_band_hi": 0.03,
+  "normalization_mode": "max",
+  "acutance_band_lo": 0.017,
+  "acutance_band_hi": 0.035,
+  "acutance_band_mode": "mean",
+  "noise_psd_model": "empirical",
+  "noise_psd_scale": 1.0,
+  "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+  "acutance_noise_share_band_lo": 0.36,
+  "acutance_noise_share_band_hi": 0.5,
+  "acutance_noise_share_scale_coefficients": [
+    521.08180962,
+    -26.62905791,
+    1.59615575
+  ],
+  "high_frequency_guard_start_cpp": 0.36,
+  "high_frequency_guard_stop_cpp": 0.5,
+  "mtf_compensation_mode": "sensor_aperture_sinc",
+  "sensor_fill_factor": 1.5,
+  "compensation_denominator_clip": 0.25,
+  "compensation_max_gain": 3.0,
+  "quality_loss_om_ceiling": 0.8851,
+  "quality_loss_coefficients": [
+    37.240228358776136,
+    26.54550669779819,
+    0.4538662637619741
+  ],
+  "quality_loss_preset_overrides": {
+    "Computer Monitor Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        5677361.198044325,
+        -16715685.9524707,
+        20317567.326582585,
+        -13046703.33912079,
+        4667794.619228022,
+        -882296.9160375095,
+        68863.59709647154
+      ]
+    },
+    "5.5\" Phone Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        -110912321.41149135,
+        50461107.51563171,
+        -9079490.127807735,
+        815148.8697247265,
+        -37712.984407641874,
+        854.6941149036079,
+        -6.261149027919645
+      ]
+    },
+    "UHDTV Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        1783462.6221675149,
+        -3813432.5606394163,
+        3326218.4642961356,
+        -1514886.1959663907,
+        380334.163146246,
+        -49956.87092015135,
+        2692.9566508574017
+      ]
+    },
+    "Small Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        6690980.837239251,
+        -12955277.716404187,
+        10300283.291740375,
+        -4303759.200708971,
+        996904.2653558743,
+        -121409.71509269004,
+        6084.6471373306085
+      ]
+    },
+    "Large Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        2355074.475971866,
+        -5276146.244338096,
+        4846781.143787682,
+        -2336594.295523967,
+        623766.4933095274,
+        -87476.30712136331,
+        5049.882965558553
+      ]
+    }
+  }
+}

--- a/artifacts/issue56_empirical_frequency_scale_acutance_benchmark.json
+++ b/artifacts/issue56_empirical_frequency_scale_acutance_benchmark.json
@@ -1,0 +1,247 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.095,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "roi_source": "reference",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.043790155273663235,
+        "0.25": 0.03484455046554374,
+        "0.4": 0.028609763518182434,
+        "0.65": 0.033115979173191736,
+        "0.8": 0.03884737418763598,
+        "ori": 0.04130848862768817
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 2.1205628551010727,
+        "0.25": 1.288170870640523,
+        "0.4": 1.0817525798285823,
+        "0.65": 0.5272556549385113,
+        "0.8": 1.2037576524966158,
+        "ori": 2.6665350652214452
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.03699264118492546,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.016810511427410642,
+          "Computer Monitor Acutance": 0.054237735168271614,
+          "Large Print Acutance": 0.03862844832111008,
+          "Small Print Acutance": 0.030348558063282082,
+          "UHDTV Display Acutance": 0.04493795294455284
+        },
+        "curve_mae_mean": 0.03666081546909307,
+        "overall_quality_loss_mae_mean": 1.4582278636293544,
+        "quality_loss_focus_preset_mae_mean": 1.4582278636293544,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 0.2023238841227169,
+          "Computer Monitor Quality Loss": 3.6376862499825835,
+          "Large Print Quality Loss": 0.9626965715082461,
+          "Small Print Quality Loss": 0.7457710410703663,
+          "UHDTV Display Quality Loss": 1.7426615714628597
+        }
+      },
+      "profile_path": "/tmp/issue56_freqscale_1095.json"
+    }
+  ]
+}

--- a/artifacts/issue56_empirical_frequency_scale_psd_benchmark.json
+++ b/artifacts/issue56_empirical_frequency_scale_psd_benchmark.json
@@ -1,0 +1,189 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.095,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "roi_source": "reference",
+        "sensor_fill_factor": 1.5,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.05293532674025513,
+        "0.25": 0.04517291785820425,
+        "0.4": 0.04025985581138145,
+        "0.65": 0.046175097390007476,
+        "0.8": 0.05086131396727281,
+        "ori": 0.056407292574943
+      },
+      "overall": {
+        "curve_mae_mean": 0.048104121871917774,
+        "mtf_abs_signed_rel_mean": 0.14593603627453947,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.03935916762317556,
+            "mre_mean": 0.1905589728186529,
+            "signed_rel_mean": 0.17845932646695462
+          },
+          "low": {
+            "mae_mean": 0.04782764538868513,
+            "mre_mean": 0.062216203864202346,
+            "signed_rel_mean": 0.05447743541250831
+          },
+          "mid": {
+            "mae_mean": 0.07100200595215347,
+            "mre_mean": 0.23128756658999317,
+            "signed_rel_mean": 0.22947830256044605
+          },
+          "top": {
+            "mae_mean": 0.07149723101533038,
+            "mre_mean": 0.2034524498275106,
+            "signed_rel_mean": -0.12132908065824888
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.031580123999406,
+          "mtf30": 0.047830649248861,
+          "mtf50": 0.021573538079002308
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.01821327283750133,
+          "Computer Monitor Acutance": 0.06637708668537426,
+          "Large Print Acutance": 0.06393791007456333,
+          "Small Print Acutance": 0.06790673479726608,
+          "UHDTV Display Acutance": 0.06338649576934968
+        }
+      },
+      "profile_path": "/tmp/issue56_freqscale_1095.json"
+    }
+  ]
+}

--- a/artifacts/issue56_empirical_frequency_scale_search_summary.json
+++ b/artifacts/issue56_empirical_frequency_scale_search_summary.json
@@ -1,0 +1,129 @@
+{
+  "calibration_sweep": {
+    "best_scale": 1.15,
+    "total_error": 10.7989294439512,
+    "source_count": 40,
+    "analysis_pipeline": {
+      "gamma": 0.5,
+      "bayer_pattern": "RGGB",
+      "bayer_mode": "demosaic_red"
+    }
+  },
+  "candidate_psd_summary": {
+    "1.095": {
+      "curve_mae_mean": 0.048104121871917774,
+      "mtf_abs_signed_rel_mean": 0.14593603627453947,
+      "mtf_bands": {
+        "high": {
+          "mae_mean": 0.03935916762317556,
+          "mre_mean": 0.1905589728186529,
+          "signed_rel_mean": 0.17845932646695462
+        },
+        "low": {
+          "mae_mean": 0.04782764538868513,
+          "mre_mean": 0.062216203864202346,
+          "signed_rel_mean": 0.05447743541250831
+        },
+        "mid": {
+          "mae_mean": 0.07100200595215347,
+          "mre_mean": 0.23128756658999317,
+          "signed_rel_mean": 0.22947830256044605
+        },
+        "top": {
+          "mae_mean": 0.07149723101533038,
+          "mre_mean": 0.2034524498275106,
+          "signed_rel_mean": -0.12132908065824888
+        }
+      },
+      "mtf_threshold_mae": {
+        "mtf20": 0.031580123999406,
+        "mtf30": 0.047830649248861,
+        "mtf50": 0.021573538079002308
+      },
+      "preset_mae": {
+        "5.5\" Phone Display Acutance": 0.01821327283750133,
+        "Computer Monitor Acutance": 0.06637708668537426,
+        "Large Print Acutance": 0.06393791007456333,
+        "Small Print Acutance": 0.06790673479726608,
+        "UHDTV Display Acutance": 0.06338649576934968
+      }
+    },
+    "1.135": {
+      "curve_mae_mean": 0.05150719846131648,
+      "mtf_abs_signed_rel_mean": 0.17177130292834428,
+      "mtf_bands": {
+        "high": {
+          "mae_mean": 0.05076559033312937,
+          "mre_mean": 0.24596789697385027,
+          "signed_rel_mean": 0.24004369376935294
+        },
+        "low": {
+          "mae_mean": 0.05447930159726615,
+          "mre_mean": 0.07101644423111948,
+          "signed_rel_mean": 0.06632912506667055
+        },
+        "mid": {
+          "mae_mean": 0.08690490947192038,
+          "mre_mean": 0.2807193685351911,
+          "signed_rel_mean": 0.279936539058256
+        },
+        "top": {
+          "mae_mean": 0.07166260423163397,
+          "mre_mean": 0.20617892134937735,
+          "signed_rel_mean": -0.10077585381909762
+        }
+      },
+      "mtf_threshold_mae": {
+        "mtf20": 0.044691280481607684,
+        "mtf30": 0.05379348202121811,
+        "mtf50": 0.03229322127064498
+      },
+      "preset_mae": {
+        "5.5\" Phone Display Acutance": 0.021378899254289437,
+        "Computer Monitor Acutance": 0.06861147140866179,
+        "Large Print Acutance": 0.07030979044463717,
+        "Small Print Acutance": 0.07484918621757386,
+        "UHDTV Display Acutance": 0.06804903571201891
+      }
+    },
+    "1.15": {
+      "curve_mae_mean": 0.05308857338679508,
+      "mtf_abs_signed_rel_mean": 0.18150411057590965,
+      "mtf_bands": {
+        "high": {
+          "mae_mean": 0.05535549811711371,
+          "mre_mean": 0.26838332046828367,
+          "signed_rel_mean": 0.264075713852754
+        },
+        "low": {
+          "mae_mean": 0.05688132792216418,
+          "mre_mean": 0.07412949609843092,
+          "signed_rel_mean": 0.07024922741521525
+        },
+        "mid": {
+          "mae_mean": 0.0929405296596524,
+          "mre_mean": 0.29936748767064447,
+          "signed_rel_mean": 0.2988421069390708
+        },
+        "top": {
+          "mae_mean": 0.07188418659272403,
+          "mre_mean": 0.20738299621083184,
+          "signed_rel_mean": -0.09284939409659845
+        }
+      },
+      "mtf_threshold_mae": {
+        "mtf20": 0.04650188323113688,
+        "mtf30": 0.05913432470861728,
+        "mtf50": 0.03859439021706691
+      },
+      "preset_mae": {
+        "5.5\" Phone Display Acutance": 0.022887794832821766,
+        "Computer Monitor Acutance": 0.06962956715013482,
+        "Large Print Acutance": 0.07292005142475391,
+        "Small Print Acutance": 0.07489396696538797,
+        "UHDTV Display Acutance": 0.06997797658437958
+      }
+    }
+  },
+  "selected_candidate": "1.095"
+}

--- a/docs/issue56_empirical_frequency_scale_followup.md
+++ b/docs/issue56_empirical_frequency_scale_followup.md
@@ -1,0 +1,133 @@
+# Issue 56 Empirical Frequency-Scale Follow-up
+
+This note records the bounded direct-method empirical `frequency_scale` follow-up for issue `#56`.
+
+## Family
+
+This pass stays inside the current direct-method branch from PR `#55` and changes only the global empirical frequency scale:
+
+- start from the current anchored high-frequency direct-method profile with `roi_source = reference`
+- keep the better static inferred reference-bin centers from PR `#53`
+- keep the observable ROI policy from PR `#53` and the matched-ORI / Acutance / Quality Loss correction stack unchanged
+- replace `frequency_scale = 1.0` with one README-backed empirical global scale candidate
+
+This is distinct from issue `#50` because it does not reuse captured-image-size correction. It is distinct from issue `#52` because it leaves ROI policy unchanged. It is distinct from issue `#54` because it keeps the static inferred reference-bin centers instead of switching to per-capture observable-bin centers.
+
+## Calibration Slice
+
+The current repo already documents stable empirical dataset-scale ranges around `1.095` to `1.135`. A fresh lower-layer sweep on the current ROI-reference / static-bin path pushed the threshold-only objective to the top of the tested range:
+
+- `best_scale = 1.15`
+- `source_count = 40`
+
+That threshold-only sweep did not become the committed candidate by itself. Full direct-method parity benchmarks were then run at three bounded empirical values:
+
+- `1.095`
+- `1.135`
+- `1.15`
+
+Among those three, `1.095` was the least-bad full-pipeline candidate, so this note records that one as the bounded issue-56 result.
+
+## Comparison Set
+
+PR `#30` baseline:
+
+- PSD `curve_mae_mean = 0.04497615`
+- PSD `mtf_abs_signed_rel_mean = 0.33019613`
+- PSD `MTF20 / MTF30 / MTF50 = 0.11418549 / 0.07118338 / 0.03341906`
+- Acutance `curve_mae_mean = 0.04497615`
+- `acutance_focus_preset_mae_mean = 0.03479546`
+- `overall_quality_loss_mae_mean = 2.19874216`
+
+PR `#42` anchored high-frequency PSD follow-up:
+
+- PSD `curve_mae_mean = 0.04306442`
+- PSD `mtf_abs_signed_rel_mean = 0.08692956`
+- PSD `MTF20 / MTF30 / MTF50 = 0.03300903 / 0.03693524 / 0.00933262`
+- Acutance `curve_mae_mean = 0.03683438`
+- `acutance_focus_preset_mae_mean = 0.04249131`
+- `overall_quality_loss_mae_mean = 1.22214341`
+
+PR `#53` observable-reference ROI follow-up:
+
+- PSD `curve_mae_mean = 0.04231237`
+- PSD `mtf_abs_signed_rel_mean = 0.08483351`
+- PSD `MTF20 / MTF30 / MTF50 = 0.02658848 / 0.02903115 / 0.00921053`
+- Acutance `curve_mae_mean = 0.03679567`
+- `acutance_focus_preset_mae_mean = 0.04130714`
+- `overall_quality_loss_mae_mean = 1.26357125`
+
+PR `#55` observable-bin frequency-mapping follow-up:
+
+- PSD `curve_mae_mean = 0.04241564`
+- PSD `mtf_abs_signed_rel_mean = 0.08641068`
+- PSD `MTF20 / MTF30 / MTF50 = 0.02109366 / 0.02920596 / 0.00942858`
+- Acutance `curve_mae_mean = 0.03690674`
+- `acutance_focus_preset_mae_mean = 0.04092806`
+- `overall_quality_loss_mae_mean = 1.27229004`
+
+Issue `#56` empirical `frequency_scale = 1.095` candidate:
+
+- PSD `curve_mae_mean = 0.04810412`
+- PSD `mtf_abs_signed_rel_mean = 0.14593604`
+- PSD `MTF20 / MTF30 / MTF50 = 0.03158012 / 0.04783065 / 0.02157354`
+- Acutance `curve_mae_mean = 0.03666082`
+- `acutance_focus_preset_mae_mean = 0.03699264`
+- `overall_quality_loss_mae_mean = 1.45822786`
+
+## Result
+
+Relative to PR `#55`, the `frequency_scale = 1.095` candidate is a mixed result with a clear lower-layer and Quality Loss regression:
+
+- PSD `curve_mae_mean`: `0.04241564 -> 0.04810412`
+- PSD signed-relative residual: `0.08641068 -> 0.14593604`
+- `MTF20`: `0.02109366 -> 0.03158012`
+- `MTF30`: `0.02920596 -> 0.04783065`
+- `MTF50`: `0.00942858 -> 0.02157354`
+- Acutance `curve_mae_mean`: `0.03690674 -> 0.03666082`
+- `acutance_focus_preset_mae_mean`: `0.04092806 -> 0.03699264`
+- `overall_quality_loss_mae_mean`: `1.27229004 -> 1.45822786`
+
+Relative to PR `#53`, the same pattern holds:
+
+- PSD `curve_mae_mean`: `0.04231237 -> 0.04810412`
+- PSD signed-relative residual: `0.08483351 -> 0.14593604`
+- `MTF20`: `0.02658848 -> 0.03158012`
+- `MTF30`: `0.02903115 -> 0.04783065`
+- `MTF50`: `0.00921053 -> 0.02157354`
+- Acutance `curve_mae_mean`: `0.03679567 -> 0.03666082`
+- `acutance_focus_preset_mae_mean`: `0.04130714 -> 0.03699264`
+- `overall_quality_loss_mae_mean`: `1.26357125 -> 1.45822786`
+
+Relative to PR `#42`, the empirical-scale candidate keeps only the narrower Acutance-side gains while losing the earlier lower-layer and Quality Loss behavior:
+
+- PSD `curve_mae_mean`: `0.04306442 -> 0.04810412`
+- PSD signed-relative residual: `0.08692956 -> 0.14593604`
+- `MTF20`: `0.03300903 -> 0.03158012`
+- `MTF30`: `0.03693524 -> 0.04783065`
+- `MTF50`: `0.00933262 -> 0.02157354`
+- Acutance `curve_mae_mean`: `0.03683438 -> 0.03666082`
+- `acutance_focus_preset_mae_mean`: `0.04249131 -> 0.03699264`
+- `overall_quality_loss_mae_mean`: `1.22214341 -> 1.45822786`
+
+Relative to PR `#30`, the empirical-scale candidate is still much better on total Quality Loss and on the overall PSD curve, but it does not beat the earlier focus-preset Acutance aggregate:
+
+- PSD `curve_mae_mean`: `0.04497615 -> 0.04810412`
+- PSD signed-relative residual: `0.33019613 -> 0.14593604`
+- `MTF20`: `0.11418549 -> 0.03158012`
+- `MTF30`: `0.07118338 -> 0.04783065`
+- `MTF50`: `0.03341906 -> 0.02157354`
+- Acutance `curve_mae_mean`: `0.04497615 -> 0.03666082`
+- `acutance_focus_preset_mae_mean`: `0.03479546 -> 0.03699264`
+- `overall_quality_loss_mae_mean`: `2.19874216 -> 1.45822786`
+
+The broader empirical-scale sweep also did not uncover a better nearby full-pipeline candidate. The higher values backed by the lower-layer threshold-only sweep were worse on the PSD benchmark:
+
+- `frequency_scale = 1.135`: PSD `curve_mae_mean = 0.05150720`, signed-relative residual `= 0.17177130`
+- `frequency_scale = 1.15`: PSD `curve_mae_mean = 0.05308857`, signed-relative residual `= 0.18150411`
+
+## Conclusion
+
+This is another bounded mixed result, not a new default direct-method path.
+
+Applying a global empirical `frequency_scale` around the repo's documented dataset-level range can improve the Acutance curve and focus-preset Acutance metrics on the current ROI-reference / static-bin path. But the same family materially worsens the lower-layer PSD summary and pushes overall Quality Loss farther away from the current best direct-method branch. The threshold-only calibration sweep therefore does not transfer cleanly to the full direct-method benchmark objective, and `frequency_scale = 1.0` remains the better default on the current direct-method line.


### PR DESCRIPTION
## Summary
- add a bounded issue-56 profile that keeps the merged ROI-reference/static-bin direct-method path and tests one README-backed empirical `frequency_scale` candidate at `1.095`
- add generated issue-56 benchmark artifacts plus a small search-summary artifact that records the threshold-only sweep and the nearby PSD candidate checks at `1.095`, `1.135`, and `1.15`
- document the outcome in the issue-56 follow-up note and record that this empirical frequency-scale family is another bounded mixed result rather than a new default path

## Validation
- `python3 -m algo.calibrate_frequency_scale 20260318_deadleaf_13b10 --calibration-file algo/deadleaf_13b10_psd_calibration_anchored.json --gamma 0.5 --bayer-pattern RGGB --bayer-mode demosaic_red --scale-min 1.00 --scale-max 1.15 --steps 31`
- `python3 -m algo.benchmark_parity_psd_mtf 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_freqscale_1095_profile.json --output artifacts/issue56_empirical_frequency_scale_psd_benchmark.json`
- `python3 -m algo.benchmark_parity_acutance_quality_loss 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_freqscale_1095_profile.json --output artifacts/issue56_empirical_frequency_scale_acutance_benchmark.json`
- `python3 -m pytest tests/test_benchmark_parity_psd_mtf.py tests/test_benchmark_parity_acutance_quality_loss.py`

## Result
- versus PR #55, `frequency_scale = 1.095` improves Acutance `curve_mae_mean` (`0.03690674 -> 0.03666082`) and `acutance_focus_preset_mae_mean` (`0.04092806 -> 0.03699264`) but regresses PSD `curve_mae_mean` (`0.04241564 -> 0.04810412`), PSD signed-relative residual (`0.08641068 -> 0.14593604`), `MTF20 / MTF30 / MTF50` (`0.02109366 / 0.02920596 / 0.00942858 -> 0.03158012 / 0.04783065 / 0.02157354`), and `overall_quality_loss_mae_mean` (`1.27229004 -> 1.45822786`)
- versus PR #53, the same empirical-scale candidate still improves the Acutance-side metrics but pushes Quality Loss and lower-layer PSD further away from the current direct-method line
- the lower-layer threshold-only sweep pushed to `best_scale = 1.15`, but full-pipeline PSD checks at `1.135` and `1.15` were worse than `1.095`, so that sweep objective does not transfer cleanly to the current full direct-method benchmark target
- this closes as another bounded mixed result, and `frequency_scale = 1.0` remains the better default on the current ROI-reference/static-bin branch

Refs #29
Refs #56
Context from #50
Context from #52
Context from #54
Context from #42
Context from #53
Context from #55