### PR TITLE
Issue #58: audit chart/sensor compensation family

### DIFF
--- a/algo/deadleaf_13b10_imatest_chart_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json
+++ b/algo/deadleaf_13b10_imatest_chart_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json
@@ -1,0 +1,186 @@
+{
+  "name": "deadleaf_13b10_imatest_chart_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only",
+  "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+  "gamma": 0.5,
+  "linearization_mode": "toe_power",
+  "linearization_toe": 0.12,
+  "bayer_pattern": "RGGB",
+  "bayer_mode": "demosaic_red",
+  "roi_source": "reference",
+  "roi_width": 1655,
+  "roi_height": 1673,
+  "matched_ori_reference_anchor": true,
+  "matched_ori_correction_clip_lo": 0.5,
+  "matched_ori_correction_clip_hi": 2.0,
+  "matched_ori_anchor_mode": "acutance_only",
+  "matched_ori_strength_curve_frequencies": [
+    0.0,
+    0.12,
+    0.22,
+    0.35,
+    0.5
+  ],
+  "matched_ori_strength_curve_values": [
+    1.0,
+    1.0,
+    0.82,
+    0.95,
+    1.0
+  ],
+  "matched_ori_acutance_reference_anchor": true,
+  "matched_ori_acutance_correction_clip_lo": 0.9,
+  "matched_ori_acutance_correction_clip_hi": 1.1,
+  "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+  "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+    0.0,
+    0.25,
+    0.6,
+    0.8,
+    1.6,
+    2.5
+  ],
+  "matched_ori_acutance_curve_correction_clip_hi_values": [
+    1.02,
+    1.03,
+    0.895,
+    0.895,
+    1.05,
+    1.06
+  ],
+  "matched_ori_acutance_strength_curve_relative_scales": [
+    0.0,
+    0.2,
+    0.8,
+    1.6,
+    2.5
+  ],
+  "matched_ori_acutance_strength_curve_values": [
+    0.7,
+    0.69,
+    0.64,
+    0.62,
+    0.6
+  ],
+  "matched_ori_acutance_correction_delta_power": 1.0,
+  "matched_ori_acutance_curve_correction_delta_power": 0.95,
+  "matched_ori_acutance_preset_correction_delta_power": null,
+  "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+    0.0,
+    4.5,
+    5.8,
+    6.2
+  ],
+  "matched_ori_acutance_preset_correction_delta_power_values": [
+    1.05,
+    1.05,
+    1.85,
+    1.85
+  ],
+  "matched_ori_acutance_preset_strength_curve_relative_scales": [
+    0.0,
+    3.0,
+    4.5,
+    5.8,
+    6.2
+  ],
+  "matched_ori_acutance_preset_strength_curve_values": [
+    1.0,
+    1.0,
+    0.85,
+    0.45,
+    0.45
+  ],
+  "frequency_scale": 1.0,
+  "texture_support_scale": true,
+  "normalization_band_lo": 0.01,
+  "normalization_band_hi": 0.03,
+  "normalization_mode": "max",
+  "acutance_band_lo": 0.017,
+  "acutance_band_hi": 0.035,
+  "acutance_band_mode": "mean",
+  "noise_psd_model": "empirical",
+  "noise_psd_scale": 1.0,
+  "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+  "acutance_noise_share_band_lo": 0.36,
+  "acutance_noise_share_band_hi": 0.5,
+  "acutance_noise_share_scale_coefficients": [
+    521.08180962,
+    -26.62905791,
+    1.59615575
+  ],
+  "high_frequency_guard_start_cpp": 0.36,
+  "high_frequency_guard_stop_cpp": 0.5,
+  "mtf_compensation_mode": "chart_sensor_aperture_sinc",
+  "sensor_fill_factor": 1.5,
+  "chart_fill_factor": 0.15,
+  "compensation_denominator_clip": 0.25,
+  "compensation_max_gain": 3.0,
+  "quality_loss_om_ceiling": 0.8851,
+  "quality_loss_coefficients": [
+    37.240228358776136,
+    26.54550669779819,
+    0.4538662637619741
+  ],
+  "quality_loss_preset_overrides": {
+    "Computer Monitor Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        5677361.198044325,
+        -16715685.9524707,
+        20317567.326582585,
+        -13046703.33912079,
+        4667794.619228022,
+        -882296.9160375095,
+        68863.59709647154
+      ]
+    },
+    "5.5\" Phone Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        -110912321.41149135,
+        50461107.51563171,
+        -9079490.127807735,
+        815148.8697247265,
+        -37712.984407641874,
+        854.6941149036079,
+        -6.261149027919645
+      ]
+    },
+    "UHDTV Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        1783462.6221675149,
+        -3813432.5606394163,
+        3326218.4642961356,
+        -1514886.1959663907,
+        380334.163146246,
+        -49956.87092015135,
+        2692.9566508574017
+      ]
+    },
+    "Small Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        6690980.837239251,
+        -12955277.716404187,
+        10300283.291740375,
+        -4303759.200708971,
+        996904.2653558743,
+        -121409.71509269004,
+        6084.6471373306085
+      ]
+    },
+    "Large Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        2355074.475971866,
+        -5276146.244338096,
+        4846781.143787682,
+        -2336594.295523967,
+        623766.4933095274,
+        -87476.30712136331,
+        5049.882965558553
+      ]
+    }
+  }
+}

--- a/artifacts/issue58_chart_sensor_compensation_acutance_benchmark.json
+++ b/artifacts/issue58_chart_sensor_compensation_acutance_benchmark.json
@@ -1,0 +1,495 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "roi_source": "reference",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.042461139101273825,
+        "0.25": 0.03438329907650581,
+        "0.4": 0.028222441215812154,
+        "0.65": 0.03228872676435854,
+        "0.8": 0.040189721146270965,
+        "ori": 0.0451547726413977
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 1.3478855541024857,
+        "0.25": 1.3065197488765725,
+        "0.4": 1.1903152267233512,
+        "0.65": 0.33169210926209886,
+        "0.8": 1.149561056616232,
+        "ori": 2.315457257974792
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.04130714367806507,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.012909940589898264,
+          "Computer Monitor Acutance": 0.053503296232802214,
+          "Large Print Acutance": 0.048029164175666376,
+          "Small Print Acutance": 0.0440934456167187,
+          "UHDTV Display Acutance": 0.047999871775239775
+        },
+        "curve_mae_mean": 0.036795670048548175,
+        "overall_quality_loss_mae_mean": 1.2635712539874173,
+        "quality_loss_focus_preset_mae_mean": 1.2635712539874173,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 0.1699187951448336,
+          "Computer Monitor Quality Loss": 2.9887158785513286,
+          "Large Print Quality Loss": 0.9753964866987435,
+          "Small Print Quality Loss": 0.6445598500524008,
+          "UHDTV Display Quality Loss": 1.5392652594897804
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json"
+    },
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 0.15,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "chart_sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "roi_source": "reference",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.04256394007352871,
+        "0.25": 0.034450111959957265,
+        "0.4": 0.028255112794437903,
+        "0.65": 0.0322983456769208,
+        "0.8": 0.0401999805252536,
+        "ori": 0.045151456094827236
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 1.3388821342474864,
+        "0.25": 1.3071898635259462,
+        "0.4": 1.1922925554127168,
+        "0.65": 0.33320646737195564,
+        "0.8": 1.1503677191759287,
+        "ori": 2.3159757761922948
+      },
+      "delta_vs_first_profile": {
+        "acutance_focus_preset_mae_mean": -4.571416857422628e-05,
+        "curve_mae_mean": 4.313919926212523e-05,
+        "overall_quality_loss_mae_mean": -0.0009065751585766169,
+        "quality_loss_focus_preset_mae_mean": -0.0009065751585766169
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.04126142950949084,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.012904952445893157,
+          "Computer Monitor Acutance": 0.053520742514481544,
+          "Large Print Acutance": 0.047952708317223675,
+          "Small Print Acutance": 0.043974804440237894,
+          "UHDTV Display Acutance": 0.04795393982961792
+        },
+        "curve_mae_mean": 0.0368388092478103,
+        "overall_quality_loss_mae_mean": 1.2626646788288407,
+        "quality_loss_focus_preset_mae_mean": 1.2626646788288407,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 0.16998827003204747,
+          "Computer Monitor Quality Loss": 2.9822377122465236,
+          "Large Print Quality Loss": 0.9752058029182098,
+          "Small Print Quality Loss": 0.6442552253418805,
+          "UHDTV Display Quality Loss": 1.5416363836055424
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_chart_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json"
+    }
+  ]
+}

--- a/artifacts/issue58_chart_sensor_compensation_psd_benchmark.json
+++ b/artifacts/issue58_chart_sensor_compensation_psd_benchmark.json
@@ -1,0 +1,373 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "roi_source": "reference",
+        "sensor_fill_factor": 1.5,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.04393768183373263,
+        "0.25": 0.03710788456836763,
+        "0.4": 0.0329077188294806,
+        "0.65": 0.03870720063357137,
+        "0.8": 0.05002485138358607,
+        "ori": 0.05646024794455208
+      },
+      "overall": {
+        "curve_mae_mean": 0.04231237218084573,
+        "mtf_abs_signed_rel_mean": 0.0848335121245157,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.017405731949021022,
+            "mre_mean": 0.08764571042450976,
+            "signed_rel_mean": 0.04656660347357008
+          },
+          "low": {
+            "mae_mean": 0.037300268705105874,
+            "mre_mean": 0.04667271753065407,
+            "signed_rel_mean": 0.02116254166025956
+          },
+          "mid": {
+            "mae_mean": 0.03872032320276679,
+            "mre_mean": 0.12241708324324026,
+            "signed_rel_mean": 0.1059461109531886
+          },
+          "top": {
+            "mae_mean": 0.07406627402274787,
+            "mre_mean": 0.20241614420154247,
+            "signed_rel_mean": -0.16565879241104461
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.026588479385846887,
+          "mtf30": 0.029031147782014672,
+          "mtf50": 0.009210531290681506
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.013046926325952163,
+          "Computer Monitor Acutance": 0.0619057128560007,
+          "Large Print Acutance": 0.04826432657695518,
+          "Small Print Acutance": 0.055962857427902676,
+          "UHDTV Display Acutance": 0.05347209296392057
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json"
+    },
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 0.15,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "chart_sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "roi_source": "reference",
+        "sensor_fill_factor": 1.5,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.04405293059200651,
+        "0.25": 0.037187427544492044,
+        "0.4": 0.03295544682458741,
+        "0.65": 0.03874838537855583,
+        "0.8": 0.05005803543237715,
+        "ori": 0.05649237008247376
+      },
+      "overall": {
+        "curve_mae_mean": 0.042374843624795586,
+        "mtf_abs_signed_rel_mean": 0.08462896980231628,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.017701683916424737,
+            "mre_mean": 0.08881222879441157,
+            "signed_rel_mean": 0.04958447985199538
+          },
+          "low": {
+            "mae_mean": 0.037295490505837414,
+            "mre_mean": 0.04667556789701297,
+            "signed_rel_mean": 0.02125218518475647
+          },
+          "mid": {
+            "mae_mean": 0.03884532674350729,
+            "mre_mean": 0.12294790247764889,
+            "signed_rel_mean": 0.10680721174072132
+          },
+          "top": {
+            "mae_mean": 0.07334526373949427,
+            "mre_mean": 0.2002031008068422,
+            "signed_rel_mean": -0.16087200243179195
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.026782180896081077,
+          "mtf30": 0.029131186223176352,
+          "mtf50": 0.009228613371601612
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.013047621017254572,
+          "Computer Monitor Acutance": 0.061965613720666265,
+          "Large Print Acutance": 0.04829399788676143,
+          "Small Print Acutance": 0.055981620490213845,
+          "UHDTV Display Acutance": 0.0535090317686734
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_chart_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json"
+    }
+  ]
+}

--- a/docs/issue58_chart_sensor_compensation_followup.md
+++ b/docs/issue58_chart_sensor_compensation_followup.md
@@ -1,0 +1,133 @@
+# Issue 58 Chart And Sensor Compensation Follow-up
+
+This note records the bounded chart/sensor compensation refresh for issue `#58`.
+
+## Family
+
+This pass revisits the chart/sensor compensation family from issue `#39` on top of the newer post-PR-`#57` direct-method branch.
+
+It keeps the current reduced direct-method line from PR `#55` intact:
+
+- anchored high-frequency PSD calibration
+- `roi_source = reference`
+- static inferred reference-bin centers
+- `frequency_scale = 1.0`
+- unchanged matched-ORI, Acutance, and Quality Loss correction stack
+
+The only family change is the same source-backed lower-layer chart aperture term that issue `#39` introduced on the older branch:
+
+- `mtf_compensation_mode: sensor_aperture_sinc -> chart_sensor_aperture_sinc`
+- `chart_fill_factor: 0.15`
+
+## Source Basis
+
+This remains the same documented family identified in [dead_leaves_black_box_research.md](./dead_leaves_black_box_research.md):
+
+- Imatest documentation decomposes measured MTF into chart, lens, sensor, and processing terms
+- the repo already models the sensor aperture term
+- this bounded refresh adds one chart-medium aperture term without reopening ROI policy, observable-bin frequency mapping, or empirical `frequency_scale`
+
+## Profiles Compared
+
+Current direct-method baseline from PR `#55`:
+
+- [../algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json](../algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json)
+
+Issue `#58` refreshed chart/sensor candidate:
+
+- [../algo/deadleaf_13b10_imatest_chart_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json](../algo/deadleaf_13b10_imatest_chart_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json)
+
+Artifacts:
+
+- [../artifacts/issue58_chart_sensor_compensation_psd_benchmark.json](../artifacts/issue58_chart_sensor_compensation_psd_benchmark.json)
+- [../artifacts/issue58_chart_sensor_compensation_acutance_benchmark.json](../artifacts/issue58_chart_sensor_compensation_acutance_benchmark.json)
+
+## Comparison Set
+
+This pass compares against:
+
+- PR `#30` current best merged canonical-target branch
+- PR `#40` older-branch chart/sensor compensation result
+- PR `#53` ROI-policy follow-up
+- PR `#55` observable-bin frequency-mapping follow-up
+- PR `#57` empirical `frequency_scale` follow-up
+
+| Path | PSD `curve_mae_mean` | PSD signed-relative residual | `MTF20` | `MTF30` | `MTF50` | Acutance `curve_mae_mean` | `acutance_focus_preset_mae_mean` | `overall_quality_loss_mae_mean` |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| PR `#30` | `0.04497615` | `0.33019613` | `0.11418549` | `0.07118338` | `0.03341906` | `0.04497615` | `0.03479546` | `2.19874216` |
+| PR `#40` | `0.04313186` | `0.08672250` | `0.03317034` | `0.03705447` | `0.00938074` | `0.05521880` | `0.06881027` | `3.37730101` |
+| PR `#53` | `0.04231237` | `0.08483351` | `0.02658848` | `0.02903115` | `0.00921053` | `0.03679567` | `0.04130714` | `1.26357125` |
+| PR `#55` | `0.04241564` | `0.08641068` | `0.02109366` | `0.02920596` | `0.00942858` | `0.03690674` | `0.04092806` | `1.27229004` |
+| PR `#57` | `0.04810412` | `0.14593604` | `0.03158012` | `0.04783065` | `0.02157354` | `0.03666082` | `0.03699264` | `1.45822786` |
+| issue `#58` refreshed chart/sensor candidate | `0.04237484` | `0.08462897` | `0.02678218` | `0.02913119` | `0.00922861` | `0.03683881` | `0.04126143` | `1.26266468` |
+
+## Result
+
+Relative to PR `#55`, the refreshed chart/sensor candidate is mixed:
+
+- PSD `curve_mae_mean`: `0.04241564 -> 0.04237484`
+- PSD signed-relative residual: `0.08641068 -> 0.08462897`
+- `MTF20`: `0.02109366 -> 0.02678218`
+- `MTF30`: `0.02920596 -> 0.02913119`
+- `MTF50`: `0.00942858 -> 0.00922861`
+- Acutance `curve_mae_mean`: `0.03690674 -> 0.03683881`
+- `acutance_focus_preset_mae_mean`: `0.04092806 -> 0.04126143`
+- `overall_quality_loss_mae_mean`: `1.27229004 -> 1.26266468`
+
+Relative to PR `#53`, the same family is still nearly neutral but not a lower-layer win:
+
+- PSD `curve_mae_mean`: `0.04231237 -> 0.04237484`
+- PSD signed-relative residual: `0.08483351 -> 0.08462897`
+- `MTF20`: `0.02658848 -> 0.02678218`
+- `MTF30`: `0.02903115 -> 0.02913119`
+- `MTF50`: `0.00921053 -> 0.00922861`
+- Acutance `curve_mae_mean`: `0.03679567 -> 0.03683881`
+- `acutance_focus_preset_mae_mean`: `0.04130714 -> 0.04126143`
+- `overall_quality_loss_mae_mean`: `1.26357125 -> 1.26266468`
+
+Relative to PR `#40`, the same chart/sensor family is much better on the newer direct-method branch:
+
+- PSD `curve_mae_mean`: `0.04313186 -> 0.04237484`
+- PSD signed-relative residual: `0.08672250 -> 0.08462897`
+- `MTF20`: `0.03317034 -> 0.02678218`
+- `MTF30`: `0.03705447 -> 0.02913119`
+- `MTF50`: `0.00938074 -> 0.00922861`
+- Acutance `curve_mae_mean`: `0.05521880 -> 0.03683881`
+- `acutance_focus_preset_mae_mean`: `0.06881027 -> 0.04126143`
+- `overall_quality_loss_mae_mean`: `3.37730101 -> 1.26266468`
+
+Relative to PR `#57`, the refreshed chart/sensor candidate restores the lower-layer and Quality Loss behavior that the empirical `frequency_scale` candidate lost:
+
+- PSD `curve_mae_mean`: `0.04810412 -> 0.04237484`
+- PSD signed-relative residual: `0.14593604 -> 0.08462897`
+- `MTF20`: `0.03158012 -> 0.02678218`
+- `MTF30`: `0.04783065 -> 0.02913119`
+- `MTF50`: `0.02157354 -> 0.00922861`
+- Acutance `curve_mae_mean`: `0.03666082 -> 0.03683881`
+- `acutance_focus_preset_mae_mean`: `0.03699264 -> 0.04126143`
+- `overall_quality_loss_mae_mean`: `1.45822786 -> 1.26266468`
+
+Relative to PR `#30`, the refreshed candidate is still far better on lower-layer residuals and downstream Quality Loss, but it still does not beat the older focus-preset Acutance aggregate:
+
+- PSD `curve_mae_mean`: `0.04497615 -> 0.04237484`
+- PSD signed-relative residual: `0.33019613 -> 0.08462897`
+- `MTF20`: `0.11418549 -> 0.02678218`
+- `MTF30`: `0.07118338 -> 0.02913119`
+- `MTF50`: `0.03341906 -> 0.00922861`
+- Acutance `curve_mae_mean`: `0.04497615 -> 0.03683881`
+- `acutance_focus_preset_mae_mean`: `0.03479546 -> 0.04126143`
+- `overall_quality_loss_mae_mean`: `2.19874216 -> 1.26266468`
+
+## Conclusion
+
+This is another bounded mixed result, not a new default direct-method path.
+
+The newer direct-method branch does make the old chart/sensor compensation family look meaningfully healthier than it did in PR `#40`: the refreshed candidate materially improves the older chart/sensor result and slightly improves several PSD and Quality Loss metrics relative to PR `#55`. But it still fails the stricter lower-layer gate because the primary PSD curve is slightly worse than PR `#53`, and `MTF20` regresses against both PR `#53` and PR `#55`.
+
+That means the updated chart-medium aperture term is no longer the clearly negative family it looked like in issue `#39`, but it is still not strong enough to replace the current direct-method baseline. The result is useful because it narrows the remaining gap further: later ROI and frequency-mapping refinements made this family less harmful, yet one fixed chart-aperture factor still does not produce a clean lower-layer win on the current dataset.
+
+## Validation
+
+- `python3 -m algo.benchmark_parity_psd_mtf 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json algo/deadleaf_13b10_imatest_chart_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json --output artifacts/issue58_chart_sensor_compensation_psd_benchmark.json`
+- `python3 -m algo.benchmark_parity_acutance_quality_loss 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json algo/deadleaf_13b10_imatest_chart_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json --output artifacts/issue58_chart_sensor_compensation_acutance_benchmark.json`
+- `python3 -m pytest tests/test_dead_leaves_mtf_compensation.py tests/test_benchmark_parity_psd_mtf.py tests/test_benchmark_parity_acutance_quality_loss.py`


### PR DESCRIPTION
## Summary

- refresh the chart/sensor aperture compensation family from issue #39 on top of the newer post-PR-57 direct-method branch
- add a bounded candidate profile that keeps the current anchored ROI-reference direct-method path fixed and changes only `mtf_compensation_mode` plus `chart_fill_factor = 0.15`
- check in focused PSD and Acutance/Quality Loss benchmark artifacts plus the issue-58 follow-up note

## Result

This lands as another bounded mixed result, not a new default direct-method path.

Compared with PR #55, the refreshed chart/sensor candidate slightly improves PSD `curve_mae_mean` (`0.04241564 -> 0.04237484`), PSD signed-relative residual (`0.08641068 -> 0.08462897`), `MTF30` (`0.02920596 -> 0.02913119`), `MTF50` (`0.00942858 -> 0.00922861`), Acutance `curve_mae_mean` (`0.03690674 -> 0.03683881`), and `overall_quality_loss_mae_mean` (`1.27229004 -> 1.26266468`).

But it still regresses `MTF20` (`0.02109366 -> 0.02678218`) and `acutance_focus_preset_mae_mean` (`0.04092806 -> 0.04126143`). Relative to PR #53, it is still not a lower-layer win because the primary PSD curve and all three threshold readouts are slightly worse, even though signed-relative residual, focus-preset Acutance, and overall Quality Loss improve slightly.

Compared with PR #40, the same family looks much healthier on the newer direct-method branch, but it still does not beat the current direct-method baseline cleanly enough to replace it.

## Validation

- `python3 -m algo.benchmark_parity_psd_mtf 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json algo/deadleaf_13b10_imatest_chart_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json --output artifacts/issue58_chart_sensor_compensation_psd_benchmark.json`
- `python3 -m algo.benchmark_parity_acutance_quality_loss 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json algo/deadleaf_13b10_imatest_chart_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json --output artifacts/issue58_chart_sensor_compensation_acutance_benchmark.json`
- `python3 -m pytest tests/test_dead_leaves_mtf_compensation.py tests/test_benchmark_parity_psd_mtf.py tests/test_benchmark_parity_acutance_quality_loss.py`

Refs #29
Refs #58
Context from #39
Context from #52
Context from #54
Context from #56
Context from #40
Context from #53
Context from #55
Context from #57
