### PR TITLE
Issue #61: audit direct-method ISP proxy family

### DIFF
--- a/algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_hf_noise_share_shape_profile.json
+++ b/algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_hf_noise_share_shape_profile.json
@@ -1,0 +1,202 @@
+{
+  "name": "deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_hf_noise_share_shape",
+  "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+  "gamma": 0.5,
+  "linearization_mode": "toe_power",
+  "linearization_toe": 0.12,
+  "bayer_pattern": "RGGB",
+  "bayer_mode": "demosaic_red",
+  "roi_source": "reference",
+  "roi_width": 1655,
+  "roi_height": 1673,
+  "roi_refine_percentile": 45.0,
+  "roi_refine_sigma": 5.0,
+  "roi_refine_min_border_margin": 8,
+  "roi_refine_search_radius": 4,
+  "roi_refine_step": 2,
+  "roi_refine_area_tolerance": 0.98,
+  "matched_ori_reference_anchor": true,
+  "matched_ori_correction_clip_lo": 0.5,
+  "matched_ori_correction_clip_hi": 2.0,
+  "matched_ori_anchor_mode": "acutance_only",
+  "matched_ori_strength_curve_frequencies": [
+    0.0,
+    0.12,
+    0.22,
+    0.35,
+    0.5
+  ],
+  "matched_ori_strength_curve_values": [
+    1.0,
+    1.0,
+    0.82,
+    0.95,
+    1.0
+  ],
+  "matched_ori_acutance_reference_anchor": true,
+  "matched_ori_acutance_correction_clip_lo": 0.9,
+  "matched_ori_acutance_correction_clip_hi": 1.1,
+  "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+  "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+    0.0,
+    0.25,
+    0.6,
+    0.8,
+    1.6,
+    2.5
+  ],
+  "matched_ori_acutance_curve_correction_clip_hi_values": [
+    1.02,
+    1.03,
+    0.895,
+    0.895,
+    1.05,
+    1.06
+  ],
+  "matched_ori_acutance_strength_curve_relative_scales": [
+    0.0,
+    0.2,
+    0.8,
+    1.6,
+    2.5
+  ],
+  "matched_ori_acutance_strength_curve_values": [
+    0.7,
+    0.69,
+    0.64,
+    0.62,
+    0.6
+  ],
+  "matched_ori_acutance_correction_delta_power": 1.0,
+  "matched_ori_acutance_curve_correction_delta_power": 0.95,
+  "matched_ori_acutance_preset_correction_delta_power": null,
+  "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+    0.0,
+    4.5,
+    5.8,
+    6.2
+  ],
+  "matched_ori_acutance_preset_correction_delta_power_values": [
+    1.05,
+    1.05,
+    1.85,
+    1.85
+  ],
+  "matched_ori_acutance_preset_strength_curve_relative_scales": [
+    0.0,
+    3.0,
+    4.5,
+    5.8,
+    6.2
+  ],
+  "matched_ori_acutance_preset_strength_curve_values": [
+    1.0,
+    1.0,
+    0.85,
+    0.45,
+    0.45
+  ],
+  "frequency_scale": 1.0,
+  "texture_support_scale": true,
+  "normalization_band_lo": 0.01,
+  "normalization_band_hi": 0.03,
+  "normalization_mode": "max",
+  "acutance_band_lo": 0.017,
+  "acutance_band_hi": 0.035,
+  "acutance_band_mode": "mean",
+  "noise_psd_model": "empirical",
+  "noise_psd_scale": 1.0,
+  "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+  "acutance_noise_share_band_lo": 0.36,
+  "acutance_noise_share_band_hi": 0.5,
+  "acutance_noise_share_scale_coefficients": [
+    521.08180962,
+    -26.62905791,
+    1.59615575
+  ],
+  "high_frequency_guard_start_cpp": 0.36,
+  "high_frequency_guard_stop_cpp": 0.5,
+  "mtf_shape_correction_mode": "hf_noise_share_gated_bump",
+  "mtf_shape_correction_gain": 0.035,
+  "mtf_shape_correction_share_gate_lo": 0.05,
+  "mtf_shape_correction_share_gate_hi": 0.08,
+  "mtf_shape_correction_mid_start_cpp": 0.095,
+  "mtf_shape_correction_mid_peak_cpp": 0.145,
+  "mtf_shape_correction_mid_stop_cpp": 0.19,
+  "mtf_shape_correction_high_start_cpp": 0.36,
+  "mtf_shape_correction_high_peak_cpp": 0.4,
+  "mtf_shape_correction_high_stop_cpp": 0.49,
+  "mtf_shape_correction_high_weight": 0.25,
+  "mtf_compensation_mode": "sensor_aperture_sinc",
+  "sensor_fill_factor": 1.5,
+  "compensation_denominator_clip": 0.25,
+  "compensation_max_gain": 3.0,
+  "quality_loss_om_ceiling": 0.8851,
+  "quality_loss_coefficients": [
+    37.240228358776136,
+    26.54550669779819,
+    0.4538662637619741
+  ],
+  "quality_loss_preset_overrides": {
+    "Computer Monitor Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        5677361.198044325,
+        -16715685.9524707,
+        20317567.326582585,
+        -13046703.33912079,
+        4667794.619228022,
+        -882296.9160375095,
+        68863.59709647154
+      ]
+    },
+    "5.5\" Phone Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        -110912321.41149135,
+        50461107.51563171,
+        -9079490.127807735,
+        815148.8697247265,
+        -37712.984407641874,
+        854.6941149036079,
+        -6.261149027919645
+      ]
+    },
+    "UHDTV Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        1783462.6221675149,
+        -3813432.5606394163,
+        3326218.4642961356,
+        -1514886.1959663907,
+        380334.163146246,
+        -49956.87092015135,
+        2692.9566508574017
+      ]
+    },
+    "Small Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        6690980.837239251,
+        -12955277.716404187,
+        10300283.291740375,
+        -4303759.200708971,
+        996904.2653558743,
+        -121409.71509269004,
+        6084.6471373306085
+      ]
+    },
+    "Large Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        2355074.475971866,
+        -5276146.244338096,
+        4846781.143787682,
+        -2336594.295523967,
+        623766.4933095274,
+        -87476.30712136331,
+        5049.882965558553
+      ]
+    }
+  }
+}

--- a/artifacts/issue61_isp_family_acutance_benchmark.json
+++ b/artifacts/issue61_isp_family_acutance_benchmark.json
@@ -1,0 +1,495 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "roi_source": "reference",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.042461139101273825,
+        "0.25": 0.03438329907650581,
+        "0.4": 0.028222441215812154,
+        "0.65": 0.03228872676435854,
+        "0.8": 0.040189721146270965,
+        "ori": 0.0451547726413977
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 1.3478855541024857,
+        "0.25": 1.3065197488765725,
+        "0.4": 1.1903152267233512,
+        "0.65": 0.33169210926209886,
+        "0.8": 1.149561056616232,
+        "ori": 2.315457257974792
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.04130714367806507,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.012909940589898264,
+          "Computer Monitor Acutance": 0.053503296232802214,
+          "Large Print Acutance": 0.048029164175666376,
+          "Small Print Acutance": 0.0440934456167187,
+          "UHDTV Display Acutance": 0.047999871775239775
+        },
+        "curve_mae_mean": 0.036795670048548175,
+        "overall_quality_loss_mae_mean": 1.2635712539874173,
+        "quality_loss_focus_preset_mae_mean": 1.2635712539874173,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 0.1699187951448336,
+          "Computer Monitor Quality Loss": 2.9887158785513286,
+          "Large Print Quality Loss": 0.9753964866987435,
+          "Small Print Quality Loss": 0.6445598500524008,
+          "UHDTV Display Quality Loss": 1.5392652594897804
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json"
+    },
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "hf_noise_share_gated_bump",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "roi_source": "reference",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.042935989182242736,
+        "0.25": 0.034510309982118306,
+        "0.4": 0.028190892360762557,
+        "0.65": 0.03271952293963846,
+        "0.8": 0.04068068491192988,
+        "ori": 0.04571431189797039
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 1.350818058007133,
+        "0.25": 1.3099798855300926,
+        "0.4": 1.1786031943473692,
+        "0.65": 0.3325084465681999,
+        "0.8": 1.147206425040391,
+        "ori": 2.305771099995445
+      },
+      "delta_vs_first_profile": {
+        "acutance_focus_preset_mae_mean": 0.00028602577577808985,
+        "curve_mae_mean": 0.0003112887226234054,
+        "overall_quality_loss_mae_mean": -0.002421786746055643,
+        "quality_loss_focus_preset_mae_mean": -0.002421786746055643
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.04159316945384316,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.012887907037208319,
+          "Computer Monitor Acutance": 0.053691360633422315,
+          "Large Print Acutance": 0.048609151243059,
+          "Small Print Acutance": 0.044689945622090124,
+          "UHDTV Display Acutance": 0.048087482733436014
+        },
+        "curve_mae_mean": 0.03710695877117158,
+        "overall_quality_loss_mae_mean": 1.2611494672413617,
+        "quality_loss_focus_preset_mae_mean": 1.2611494672413617,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 0.16715567535695144,
+          "Computer Monitor Quality Loss": 2.9894696043898414,
+          "Large Print Quality Loss": 0.9538243443870495,
+          "Small Print Quality Loss": 0.6408136977961201,
+          "UHDTV Display Quality Loss": 1.5544840142768457
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_hf_noise_share_shape_profile.json"
+    }
+  ]
+}

--- a/artifacts/issue61_isp_family_psd_benchmark.json
+++ b/artifacts/issue61_isp_family_psd_benchmark.json
@@ -1,0 +1,373 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "roi_source": "reference",
+        "sensor_fill_factor": 1.5,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.04393768183373263,
+        "0.25": 0.03710788456836763,
+        "0.4": 0.0329077188294806,
+        "0.65": 0.03870720063357137,
+        "0.8": 0.05002485138358607,
+        "ori": 0.05646024794455208
+      },
+      "overall": {
+        "curve_mae_mean": 0.04231237218084573,
+        "mtf_abs_signed_rel_mean": 0.0848335121245157,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.017405731949021022,
+            "mre_mean": 0.08764571042450976,
+            "signed_rel_mean": 0.04656660347357008
+          },
+          "low": {
+            "mae_mean": 0.037300268705105874,
+            "mre_mean": 0.04667271753065407,
+            "signed_rel_mean": 0.02116254166025956
+          },
+          "mid": {
+            "mae_mean": 0.03872032320276679,
+            "mre_mean": 0.12241708324324026,
+            "signed_rel_mean": 0.1059461109531886
+          },
+          "top": {
+            "mae_mean": 0.07406627402274787,
+            "mre_mean": 0.20241614420154247,
+            "signed_rel_mean": -0.16565879241104461
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.026588479385846887,
+          "mtf30": 0.029031147782014672,
+          "mtf50": 0.009210531290681506
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.013046926325952163,
+          "Computer Monitor Acutance": 0.0619057128560007,
+          "Large Print Acutance": 0.04826432657695518,
+          "Small Print Acutance": 0.055962857427902676,
+          "UHDTV Display Acutance": 0.05347209296392057
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json"
+    },
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "hf_noise_share_gated_bump",
+        "roi_source": "reference",
+        "sensor_fill_factor": 1.5,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.04393768183373263,
+        "0.25": 0.03710788456836763,
+        "0.4": 0.0329077188294806,
+        "0.65": 0.03870720063357137,
+        "0.8": 0.05002485138358607,
+        "ori": 0.05646024794455208
+      },
+      "overall": {
+        "curve_mae_mean": 0.04231237218084573,
+        "mtf_abs_signed_rel_mean": 0.0848335121245157,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.017405731949021022,
+            "mre_mean": 0.08764571042450976,
+            "signed_rel_mean": 0.04656660347357008
+          },
+          "low": {
+            "mae_mean": 0.037300268705105874,
+            "mre_mean": 0.04667271753065407,
+            "signed_rel_mean": 0.02116254166025956
+          },
+          "mid": {
+            "mae_mean": 0.03872032320276679,
+            "mre_mean": 0.12241708324324026,
+            "signed_rel_mean": 0.1059461109531886
+          },
+          "top": {
+            "mae_mean": 0.07406627402274787,
+            "mre_mean": 0.20241614420154247,
+            "signed_rel_mean": -0.16565879241104461
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.026588479385846887,
+          "mtf30": 0.029031147782014672,
+          "mtf50": 0.009210531290681506
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.013046926325952163,
+          "Computer Monitor Acutance": 0.0619057128560007,
+          "Large Print Acutance": 0.04826432657695518,
+          "Small Print Acutance": 0.055962857427902676,
+          "UHDTV Display Acutance": 0.05347209296392057
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_hf_noise_share_shape_profile.json"
+    }
+  ]
+}

--- a/docs/issue61_isp_family_followup.md
+++ b/docs/issue61_isp_family_followup.md
@@ -1,0 +1,144 @@
+# Issue 61 ISP Family Follow-up
+
+This note records the bounded scene-/process-dependent ISP follow-up for issue `#61`.
+
+## Family
+
+This pass reuses the same measured high-frequency-noise-share ISP proxy from issue `#48`, but refreshes it on the newer direct-method baseline instead of the older intrinsic branch.
+
+The checked-in issue-61 candidate keeps the current static-bin ROI-reference direct-method baseline intact:
+
+- anchored high-frequency PSD calibration
+- `roi_source = reference`
+- static inferred reference-bin centers
+- `frequency_scale = 1.0`
+- sensor-only MTF compensation
+- unchanged matched-ORI, Acutance, and Quality Loss correction stack
+
+The only family change is one post-MTF scene-/process-dependent shape gate driven by the measured per-capture high-frequency noise share:
+
+- `mtf_shape_correction_mode: none -> hf_noise_share_gated_bump`
+- `gain = 0.035`
+- `share_gate_lo / hi = 0.05 / 0.08`
+- the same mid-band boost / high-band attenuation shape from issue `#48`
+
+## Source Basis
+
+This remains inside the source-backed ISP family identified in [dead_leaves_black_box_research.md](./dead_leaves_black_box_research.md):
+
+- scene-/process-dependent ISP state remains a high-priority missing family
+- denoising / sharpening can change texture measurements differently from edge response
+- the repo already exposes measured `high_frequency_noise_share` from processed dead-leaves captures
+
+So this pass tests the narrowest already-implemented proxy that is still tied to current processed-image evidence, without reopening ROI policy, frequency mapping, or chart/sensor compensation.
+
+## Profiles Compared
+
+Current direct-method baseline:
+
+- [../algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json](../algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json)
+
+Issue `#61` ISP proxy candidate:
+
+- [../algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_hf_noise_share_shape_profile.json](../algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_hf_noise_share_shape_profile.json)
+
+Artifacts:
+
+- [../artifacts/issue61_isp_family_psd_benchmark.json](../artifacts/issue61_isp_family_psd_benchmark.json)
+- [../artifacts/issue61_isp_family_acutance_benchmark.json](../artifacts/issue61_isp_family_acutance_benchmark.json)
+
+## Comparison Set
+
+This pass compares against:
+
+- PR `#30` current best merged canonical-target branch
+- PR `#49` older intrinsic-branch ISP proxy result
+- PR `#57` empirical `frequency_scale` follow-up
+- PR `#59` refreshed chart/sensor compensation result
+
+| Path | PSD `curve_mae_mean` | PSD signed-relative residual | `MTF20` | `MTF30` | `MTF50` | Acutance `curve_mae_mean` | `acutance_focus_preset_mae_mean` | `overall_quality_loss_mae_mean` | `5.5\" Phone Display Acutance` | `5.5\" Phone Display Quality Loss` |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| PR `#30` | `0.04497615` | `0.33019613` | `0.11418549` | `0.07118338` | `0.03341906` | `0.04497615` | `0.03479546` | `2.19874216` | `0.01380215` | `0.14297763` |
+| PR `#49` | `0.03280181` | `0.13993779` | `0.08576635` | `0.01789155` | `0.00719609` | `0.03283991` | `0.02890324` | `14.47328913` | `0.03513954` | `60.68418298` |
+| PR `#57` | `0.04810412` | `0.14593604` | `0.03158012` | `0.04783065` | `0.02157354` | `0.03666082` | `0.03699264` | `1.45822786` | `0.01681051` | `0.20232388` |
+| PR `#59` | `0.04237484` | `0.08462897` | `0.02678218` | `0.02913119` | `0.00922861` | `0.03683881` | `0.04126143` | `1.26266468` | `0.01290495` | `0.16998827` |
+| issue `#61` direct-method ISP proxy candidate | `0.04231237` | `0.08483351` | `0.02658848` | `0.02903115` | `0.00921053` | `0.03710696` | `0.04159317` | `1.26114947` | `0.01288791` | `0.16715568` |
+
+## Result
+
+Relative to the current direct-method baseline, this ISP proxy is effectively a downstream-only tweak:
+
+- PSD `curve_mae_mean`: unchanged at `0.04231237`
+- PSD signed-relative residual: unchanged at `0.08483351`
+- `MTF20 / MTF30 / MTF50`: unchanged at `0.02658848 / 0.02903115 / 0.00921053`
+- Acutance `curve_mae_mean`: `0.03679567 -> 0.03710696`
+- `acutance_focus_preset_mae_mean`: `0.04130714 -> 0.04159317`
+- `overall_quality_loss_mae_mean`: `1.26357125 -> 1.26114947`
+- `5.5" Phone Display Acutance`: `0.01290994 -> 0.01288791`
+- `5.5" Phone Display Quality Loss`: `0.16991880 -> 0.16715568`
+
+Relative to PR `#59`, the same pattern holds:
+
+- PSD `curve_mae_mean`: `0.04237484 -> 0.04231237`
+- PSD signed-relative residual: `0.08462897 -> 0.08483351`
+- `MTF20`: `0.02678218 -> 0.02658848`
+- `MTF30`: `0.02913119 -> 0.02903115`
+- `MTF50`: `0.00922861 -> 0.00921053`
+- Acutance `curve_mae_mean`: `0.03683881 -> 0.03710696`
+- `acutance_focus_preset_mae_mean`: `0.04126143 -> 0.04159317`
+- `overall_quality_loss_mae_mean`: `1.26266468 -> 1.26114947`
+- `5.5" Phone Display Acutance`: `0.01290495 -> 0.01288791`
+- `5.5" Phone Display Quality Loss`: `0.16998827 -> 0.16715568`
+
+Relative to PR `#57`, the issue-61 candidate keeps the current direct-method lower-layer recovery and slightly reduces the phone-dominated downstream error:
+
+- PSD `curve_mae_mean`: `0.04810412 -> 0.04231237`
+- PSD signed-relative residual: `0.14593604 -> 0.08483351`
+- `MTF20`: `0.03158012 -> 0.02658848`
+- `MTF30`: `0.04783065 -> 0.02903115`
+- `MTF50`: `0.02157354 -> 0.00921053`
+- Acutance `curve_mae_mean`: `0.03666082 -> 0.03710696`
+- `acutance_focus_preset_mae_mean`: `0.03699264 -> 0.04159317`
+- `overall_quality_loss_mae_mean`: `1.45822786 -> 1.26114947`
+- `5.5" Phone Display Acutance`: `0.01681051 -> 0.01288791`
+- `5.5" Phone Display Quality Loss`: `0.20232388 -> 0.16715568`
+
+Relative to PR `#49`, the newer direct-method branch dominates the older intrinsic ISP proxy on downstream failure even though the intrinsic branch still wins headline curve and focus-preset Acutance:
+
+- PSD `curve_mae_mean`: `0.03280181 -> 0.04231237`
+- PSD signed-relative residual: `0.13993779 -> 0.08483351`
+- `MTF20`: `0.08576635 -> 0.02658848`
+- `MTF30`: `0.01789155 -> 0.02903115`
+- `MTF50`: `0.00719609 -> 0.00921053`
+- Acutance `curve_mae_mean`: `0.03283991 -> 0.03710696`
+- `acutance_focus_preset_mae_mean`: `0.02890324 -> 0.04159317`
+- `overall_quality_loss_mae_mean`: `14.47328913 -> 1.26114947`
+- `5.5" Phone Display Acutance`: `0.03513954 -> 0.01288791`
+- `5.5" Phone Display Quality Loss`: `60.68418298 -> 0.16715568`
+
+Relative to PR `#30`, the issue-61 candidate still does not beat the older focus-preset Acutance aggregate or the phone Quality Loss baseline:
+
+- PSD `curve_mae_mean`: `0.04497615 -> 0.04231237`
+- PSD signed-relative residual: `0.33019613 -> 0.08483351`
+- `MTF20`: `0.11418549 -> 0.02658848`
+- `MTF30`: `0.07118338 -> 0.02903115`
+- `MTF50`: `0.03341906 -> 0.00921053`
+- Acutance `curve_mae_mean`: `0.04497615 -> 0.03710696`
+- `acutance_focus_preset_mae_mean`: `0.03479546 -> 0.04159317`
+- `overall_quality_loss_mae_mean`: `2.19874216 -> 1.26114947`
+- `5.5" Phone Display Acutance`: `0.01380215 -> 0.01288791`
+- `5.5" Phone Display Quality Loss`: `0.14297763 -> 0.16715568`
+
+## Conclusion
+
+This is another bounded mixed result, not a new default direct-method path.
+
+Refreshing the old `hf_noise_share_gated_bump` ISP proxy on the current direct-method baseline does exactly what the smaller direct-method hypothesis suggested: it leaves the PSD / MTF path unchanged in practice, slightly improves overall Quality Loss and the phone-preset downstream error, but slightly regresses the Acutance curve and focus-preset aggregate. That is useful as a source-backed negative because it says the remaining downstream gap is not solved by a small noise-share-gated shape tweak alone on the current direct-method line.
+
+The family is still healthier on the newer direct-method branch than it was on the older intrinsic branch because the direct-method path avoids the catastrophic phone Quality Loss failure from PR `#49`. But the effect size of this ISP proxy is too small and too mixed to justify promoting it as the next default path.
+
+## Validation
+
+- `python3 -m algo.benchmark_parity_psd_mtf 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_hf_noise_share_shape_profile.json --output artifacts/issue61_isp_family_psd_benchmark.json`
+- `python3 -m algo.benchmark_parity_acutance_quality_loss 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_hf_noise_share_shape_profile.json --output artifacts/issue61_isp_family_acutance_benchmark.json`
+- `python3 -m pytest tests/test_benchmark_parity_psd_mtf.py tests/test_benchmark_parity_acutance_quality_loss.py`


### PR DESCRIPTION
Refs #29
Refs #61
Context from #48
Context from #58
Context from #49
Context from #57
Context from #59

## Summary
- apply the existing source-backed `hf_noise_share_gated_bump` ISP proxy family on top of the current direct-method ROI-reference static-bin baseline
- add the bounded issue-61 candidate profile, benchmark artifacts, and follow-up note documenting the newer-branch result
- record that the PSD/MTF path is unchanged in practice while downstream Acutance/Quality-Loss movement stays mixed

## Result
- PSD `curve_mae_mean`, signed-relative residual, and `MTF20/30/50` stay unchanged in practice versus the current direct-method baseline
- Acutance `curve_mae_mean` regresses slightly: `0.03679567 -> 0.03710696`
- `acutance_focus_preset_mae_mean` regresses slightly: `0.04130714 -> 0.04159317`
- `overall_quality_loss_mae_mean` improves slightly: `1.26357125 -> 1.26114947`
- explicit Phone movement is also mixed but slightly favorable downstream: acutance `0.01290994 -> 0.01288791`, quality loss `0.16991880 -> 0.16715568`
- conclusion: bounded mixed result, not a new default direct-method path

## Validation
- `python3 -m pytest tests/test_benchmark_parity_psd_mtf.py tests/test_benchmark_parity_acutance_quality_loss.py`
- `python3 -m algo.benchmark_parity_psd_mtf 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_hf_noise_share_shape_profile.json --output artifacts/issue61_isp_family_psd_benchmark.json`
- `python3 -m algo.benchmark_parity_acutance_quality_loss 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_hf_noise_share_shape_profile.json --output artifacts/issue61_isp_family_acutance_benchmark.json`