### PR TITLE
Issue #63: audit empirical linearization family

### DIFF
--- a/algo/benchmark_parity_acutance_quality_loss.py
+++ b/algo/benchmark_parity_acutance_quality_loss.py
@@ -71,6 +71,8 @@ class Profile:
     gamma: float = 1.0
     linearization_mode: str = "power"
     linearization_toe: float = 0.0
+    black_percentile: float = 0.1
+    white_percentile: float = 99.9
     matched_ori_oecf_reference: bool = False
     matched_ori_oecf_strength: float = 1.0
     matched_ori_oecf_quantiles: tuple[float, ...] = (0.0, 0.1, 0.25, 0.5, 0.75, 0.9, 1.0)
@@ -347,6 +349,8 @@ def summarize_profile(
                 gamma=profile.gamma,
                 mode=profile.linearization_mode,
                 toe=profile.linearization_toe,
+                black_percentile=profile.black_percentile,
+                white_percentile=profile.white_percentile,
             )
             ori_roi = choose_roi(profile, ori_reference, ori_image)
             ori_estimate = estimate_dead_leaves_mtf(
@@ -560,6 +564,8 @@ def summarize_profile(
             gamma=profile.gamma,
             mode=profile.linearization_mode,
             toe=profile.linearization_toe,
+            black_percentile=profile.black_percentile,
+            white_percentile=profile.white_percentile,
         )
         roi = choose_roi(profile, reference, image)
         capture_key = capture_key_from_stem(raw_path.stem)
@@ -579,6 +585,8 @@ def summarize_profile(
                     gamma=profile.gamma,
                     mode=profile.linearization_mode,
                     toe=profile.linearization_toe,
+                    black_percentile=profile.black_percentile,
+                    white_percentile=profile.white_percentile,
                 )
                 ori_roi = choose_roi(profile, ori_reference, ori_image)
                 source_values, target_values = derive_quantile_transfer_curve(
@@ -688,6 +696,8 @@ def summarize_profile(
                         gamma=profile.gamma,
                         mode=profile.linearization_mode,
                         toe=profile.linearization_toe,
+                        black_percentile=profile.black_percentile,
+                        white_percentile=profile.white_percentile,
                     )
                     ori_roi = choose_roi(profile, ori_reference, ori_image)
                     intrinsic_reference_cache[capture_key] = (ori_reference, ori_image, ori_roi)
@@ -737,6 +747,8 @@ def summarize_profile(
                         gamma=profile.gamma,
                         mode=profile.linearization_mode,
                         toe=profile.linearization_toe,
+                        black_percentile=profile.black_percentile,
+                        white_percentile=profile.white_percentile,
                     )
                     ori_roi = choose_roi(profile, ori_reference, ori_image)
                     ori_estimate = estimate_dead_leaves_mtf(

--- a/algo/benchmark_parity_psd_mtf.py
+++ b/algo/benchmark_parity_psd_mtf.py
@@ -57,6 +57,8 @@ class Profile:
     gamma: float = 1.0
     linearization_mode: str = "power"
     linearization_toe: float = 0.0
+    black_percentile: float = 0.1
+    white_percentile: float = 99.9
     matched_ori_oecf_reference: bool = False
     matched_ori_oecf_strength: float = 1.0
     matched_ori_oecf_quantiles: tuple[float, ...] = (0.0, 0.1, 0.25, 0.5, 0.75, 0.9, 1.0)
@@ -323,6 +325,8 @@ def profile_payload(
             gamma=profile.gamma,
             mode=profile.linearization_mode,
             toe=profile.linearization_toe,
+            black_percentile=profile.black_percentile,
+            white_percentile=profile.white_percentile,
         )
         roi = choose_roi(profile, reference, image)
         capture_key = capture_key_from_stem(raw_path.stem)
@@ -342,6 +346,8 @@ def profile_payload(
                     gamma=profile.gamma,
                     mode=profile.linearization_mode,
                     toe=profile.linearization_toe,
+                    black_percentile=profile.black_percentile,
+                    white_percentile=profile.white_percentile,
                 )
                 ori_roi = choose_roi(profile, ori_reference, ori_image)
                 source_values, target_values = derive_quantile_transfer_curve(
@@ -455,6 +461,8 @@ def profile_payload(
                         gamma=profile.gamma,
                         mode=profile.linearization_mode,
                         toe=profile.linearization_toe,
+                        black_percentile=profile.black_percentile,
+                        white_percentile=profile.white_percentile,
                     )
                     ori_roi = choose_roi(profile, ori_reference, ori_image)
                     intrinsic_reference_cache[capture_key] = (ori_reference, ori_image, ori_roi)
@@ -502,6 +510,8 @@ def profile_payload(
                         gamma=profile.gamma,
                         mode=profile.linearization_mode,
                         toe=profile.linearization_toe,
+                        black_percentile=profile.black_percentile,
+                        white_percentile=profile.white_percentile,
                     )
                     ori_roi = choose_roi(profile, ori_reference, ori_image)
                     ori_estimate = estimate_dead_leaves_mtf(

--- a/algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_empirical_linearization_profile.json
+++ b/algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_empirical_linearization_profile.json
@@ -1,0 +1,193 @@
+{
+  "name": "deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_empirical_linearization",
+  "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+  "gamma": 1.0,
+  "linearization_mode": "power",
+  "linearization_toe": 0.0,
+  "black_percentile": 0.1,
+  "white_percentile": 99.5,
+  "bayer_pattern": "RGGB",
+  "bayer_mode": "demosaic_red",
+  "roi_source": "reference",
+  "roi_width": 1655,
+  "roi_height": 1673,
+  "roi_refine_percentile": 45.0,
+  "roi_refine_sigma": 5.0,
+  "roi_refine_min_border_margin": 8,
+  "roi_refine_search_radius": 4,
+  "roi_refine_step": 2,
+  "roi_refine_area_tolerance": 0.98,
+  "matched_ori_reference_anchor": true,
+  "matched_ori_correction_clip_lo": 0.5,
+  "matched_ori_correction_clip_hi": 2.0,
+  "matched_ori_anchor_mode": "acutance_only",
+  "matched_ori_strength_curve_frequencies": [
+    0.0,
+    0.12,
+    0.22,
+    0.35,
+    0.5
+  ],
+  "matched_ori_strength_curve_values": [
+    1.0,
+    1.0,
+    0.82,
+    0.95,
+    1.0
+  ],
+  "matched_ori_acutance_reference_anchor": true,
+  "matched_ori_acutance_correction_clip_lo": 0.9,
+  "matched_ori_acutance_correction_clip_hi": 1.1,
+  "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+  "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+    0.0,
+    0.25,
+    0.6,
+    0.8,
+    1.6,
+    2.5
+  ],
+  "matched_ori_acutance_curve_correction_clip_hi_values": [
+    1.02,
+    1.03,
+    0.895,
+    0.895,
+    1.05,
+    1.06
+  ],
+  "matched_ori_acutance_strength_curve_relative_scales": [
+    0.0,
+    0.2,
+    0.8,
+    1.6,
+    2.5
+  ],
+  "matched_ori_acutance_strength_curve_values": [
+    0.7,
+    0.69,
+    0.64,
+    0.62,
+    0.6
+  ],
+  "matched_ori_acutance_correction_delta_power": 1.0,
+  "matched_ori_acutance_curve_correction_delta_power": 0.95,
+  "matched_ori_acutance_preset_correction_delta_power": null,
+  "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+    0.0,
+    4.5,
+    5.8,
+    6.2
+  ],
+  "matched_ori_acutance_preset_correction_delta_power_values": [
+    1.05,
+    1.05,
+    1.85,
+    1.85
+  ],
+  "matched_ori_acutance_preset_strength_curve_relative_scales": [
+    0.0,
+    3.0,
+    4.5,
+    5.8,
+    6.2
+  ],
+  "matched_ori_acutance_preset_strength_curve_values": [
+    1.0,
+    1.0,
+    0.85,
+    0.45,
+    0.45
+  ],
+  "frequency_scale": 1.0,
+  "texture_support_scale": true,
+  "normalization_band_lo": 0.01,
+  "normalization_band_hi": 0.03,
+  "normalization_mode": "max",
+  "acutance_band_lo": 0.017,
+  "acutance_band_hi": 0.035,
+  "acutance_band_mode": "mean",
+  "noise_psd_model": "empirical",
+  "noise_psd_scale": 1.0,
+  "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+  "acutance_noise_share_band_lo": 0.36,
+  "acutance_noise_share_band_hi": 0.5,
+  "acutance_noise_share_scale_coefficients": [
+    521.08180962,
+    -26.62905791,
+    1.59615575
+  ],
+  "high_frequency_guard_start_cpp": 0.36,
+  "high_frequency_guard_stop_cpp": 0.5,
+  "mtf_compensation_mode": "sensor_aperture_sinc",
+  "sensor_fill_factor": 1.5,
+  "compensation_denominator_clip": 0.25,
+  "compensation_max_gain": 3.0,
+  "quality_loss_om_ceiling": 0.8851,
+  "quality_loss_coefficients": [
+    37.240228358776136,
+    26.54550669779819,
+    0.4538662637619741
+  ],
+  "quality_loss_preset_overrides": {
+    "Computer Monitor Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        5677361.198044325,
+        -16715685.9524707,
+        20317567.326582585,
+        -13046703.33912079,
+        4667794.619228022,
+        -882296.9160375095,
+        68863.59709647154
+      ]
+    },
+    "5.5\" Phone Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        -110912321.41149135,
+        50461107.51563171,
+        -9079490.127807735,
+        815148.8697247265,
+        -37712.984407641874,
+        854.6941149036079,
+        -6.261149027919645
+      ]
+    },
+    "UHDTV Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        1783462.6221675149,
+        -3813432.5606394163,
+        3326218.4642961356,
+        -1514886.1959663907,
+        380334.163146246,
+        -49956.87092015135,
+        2692.9566508574017
+      ]
+    },
+    "Small Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        6690980.837239251,
+        -12955277.716404187,
+        10300283.291740375,
+        -4303759.200708971,
+        996904.2653558743,
+        -121409.71509269004,
+        6084.6471373306085
+      ]
+    },
+    "Large Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        2355074.475971866,
+        -5276146.244338096,
+        4846781.143787682,
+        -2336594.295523967,
+        623766.4933095274,
+        -87476.30712136331,
+        5049.882965558553
+      ]
+    }
+  }
+}

--- a/artifacts/issue63_empirical_linearization_acutance_benchmark.json
+++ b/artifacts/issue63_empirical_linearization_acutance_benchmark.json
@@ -1,0 +1,495 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "roi_source": "reference",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.042461139101273825,
+        "0.25": 0.03438329907650581,
+        "0.4": 0.028222441215812154,
+        "0.65": 0.03228872676435854,
+        "0.8": 0.040189721146270965,
+        "ori": 0.0451547726413977
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 1.3478855541024857,
+        "0.25": 1.3065197488765725,
+        "0.4": 1.1903152267233512,
+        "0.65": 0.33169210926209886,
+        "0.8": 1.149561056616232,
+        "ori": 2.315457257974792
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.04130714367806507,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.012909940589898264,
+          "Computer Monitor Acutance": 0.053503296232802214,
+          "Large Print Acutance": 0.048029164175666376,
+          "Small Print Acutance": 0.0440934456167187,
+          "UHDTV Display Acutance": 0.047999871775239775
+        },
+        "curve_mae_mean": 0.036795670048548175,
+        "overall_quality_loss_mae_mean": 1.2635712539874173,
+        "quality_loss_focus_preset_mae_mean": 1.2635712539874173,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 0.1699187951448336,
+          "Computer Monitor Quality Loss": 2.9887158785513286,
+          "Large Print Quality Loss": 0.9753964866987435,
+          "Small Print Quality Loss": 0.6445598500524008,
+          "UHDTV Display Quality Loss": 1.5392652594897804
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json"
+    },
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 1.0,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "power",
+        "linearization_toe": 0.0,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "roi_source": "reference",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.017427314851735876,
+        "0.25": 0.017294252475129952,
+        "0.4": 0.021482340684367662,
+        "0.65": 0.036506743635582276,
+        "0.8": 0.049038924019615376,
+        "ori": 0.06931437781269942
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 1.1374015851335626,
+        "0.25": 1.1990104772898045,
+        "0.4": 1.6412472818901467,
+        "0.65": 0.730449437792704,
+        "0.8": 1.3056116089499543,
+        "ori": 3.9215498838037313
+      },
+      "delta_vs_first_profile": {
+        "acutance_focus_preset_mae_mean": -0.02821068997245834,
+        "curve_mae_mean": -0.005164991497550231,
+        "overall_quality_loss_mae_mean": 0.2582828688249197,
+        "quality_loss_focus_preset_mae_mean": 0.2582828688249197
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.013096453705606729,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.012339726096799753,
+          "Computer Monitor Acutance": 0.01211298333455687,
+          "Large Print Acutance": 0.008652070267904098,
+          "Small Print Acutance": 0.010307146668849663,
+          "UHDTV Display Acutance": 0.022070342159923255
+        },
+        "curve_mae_mean": 0.031630678550997944,
+        "overall_quality_loss_mae_mean": 1.521854122812337,
+        "quality_loss_focus_preset_mae_mean": 1.521854122812337,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 0.31667488505906133,
+          "Computer Monitor Quality Loss": 3.32218083965815,
+          "Large Print Quality Loss": 1.3349872027109564,
+          "Small Print Quality Loss": 1.1811005461400752,
+          "UHDTV Display Quality Loss": 1.4543271404934428
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_empirical_linearization_profile.json"
+    }
+  ]
+}

--- a/artifacts/issue63_empirical_linearization_psd_benchmark.json
+++ b/artifacts/issue63_empirical_linearization_psd_benchmark.json
@@ -1,0 +1,373 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "roi_source": "reference",
+        "sensor_fill_factor": 1.5,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.04393768183373263,
+        "0.25": 0.03710788456836763,
+        "0.4": 0.0329077188294806,
+        "0.65": 0.03870720063357137,
+        "0.8": 0.05002485138358607,
+        "ori": 0.05646024794455208
+      },
+      "overall": {
+        "curve_mae_mean": 0.04231237218084573,
+        "mtf_abs_signed_rel_mean": 0.0848335121245157,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.017405731949021022,
+            "mre_mean": 0.08764571042450976,
+            "signed_rel_mean": 0.04656660347357008
+          },
+          "low": {
+            "mae_mean": 0.037300268705105874,
+            "mre_mean": 0.04667271753065407,
+            "signed_rel_mean": 0.02116254166025956
+          },
+          "mid": {
+            "mae_mean": 0.03872032320276679,
+            "mre_mean": 0.12241708324324026,
+            "signed_rel_mean": 0.1059461109531886
+          },
+          "top": {
+            "mae_mean": 0.07406627402274787,
+            "mre_mean": 0.20241614420154247,
+            "signed_rel_mean": -0.16565879241104461
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.026588479385846887,
+          "mtf30": 0.029031147782014672,
+          "mtf50": 0.009210531290681506
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.013046926325952163,
+          "Computer Monitor Acutance": 0.0619057128560007,
+          "Large Print Acutance": 0.04826432657695518,
+          "Small Print Acutance": 0.055962857427902676,
+          "UHDTV Display Acutance": 0.05347209296392057
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json"
+    },
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 1.0,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "power",
+        "linearization_toe": 0.0,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "roi_source": "reference",
+        "sensor_fill_factor": 1.5,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.01614445530218654,
+        "0.25": 0.024167319177931263,
+        "0.4": 0.040639129443753336,
+        "0.65": 0.06656422352173443,
+        "0.8": 0.08058345761593085,
+        "ori": 0.1047361462477163
+      },
+      "overall": {
+        "curve_mae_mean": 0.04943690928490546,
+        "mtf_abs_signed_rel_mean": 0.10525591547107517,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.05266236622941153,
+            "mre_mean": 0.2330989040160393,
+            "signed_rel_mean": 0.23185876804125333
+          },
+          "low": {
+            "mae_mean": 0.03746958388253656,
+            "mre_mean": 0.047391562188913064,
+            "signed_rel_mean": 0.02706576810029983
+          },
+          "mid": {
+            "mae_mean": 0.048055144818181586,
+            "mre_mean": 0.15867614948526176,
+            "signed_rel_mean": 0.15189251472252688
+          },
+          "top": {
+            "mae_mean": 0.07375331751315588,
+            "mre_mean": 0.20549052982050214,
+            "signed_rel_mean": -0.01020661102022065
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.03805077337414969,
+          "mtf30": 0.04422298499845122,
+          "mtf50": 0.021589249154774382
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.01180938978066858,
+          "Computer Monitor Acutance": 0.04465557619415565,
+          "Large Print Acutance": 0.04939352096212955,
+          "Small Print Acutance": 0.049496770799479145,
+          "UHDTV Display Acutance": 0.05056936432941209
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_empirical_linearization_profile.json"
+    }
+  ]
+}

--- a/docs/issue63_empirical_linearization_followup.md
+++ b/docs/issue63_empirical_linearization_followup.md
@@ -1,0 +1,93 @@
+# Issue 63 Empirical Linearization Follow-up
+
+Issue: `#63`  
+Refs: `#29`, `#63`  
+Context from: `#31`, `#32`, `#41`, `#52`, `#56`, `#58`, `#61`, `#62`
+
+## Why this pass
+
+Issue `#63` asked for one bounded empirical OECF / inverse-linearization family on top of the post-`PR #62` direct-method baseline.
+
+The repo still lacks measured Stepchart / Colorcheck OECF artifacts, so this pass stays inside the smallest source-backed empirical branch already suggested by the repo evidence:
+
+- the current direct-method baseline still uses the older `toe_power` proxy
+- the historical linearization sweep under `demosaic_red` favored `gamma = 1.0` with a tighter white percentile rather than the literal `Gamma = 0.5` interpretation
+- the parity benchmark profiles did not yet expose `black_percentile` / `white_percentile`, so this issue first adds that missing schema support
+
+That enabler is the smallest viable prerequisite slice required to express an empirical percentile-based linearization family on the current branch.
+
+## What changed
+
+- Added `black_percentile` and `white_percentile` profile fields to:
+  - `algo/benchmark_parity_psd_mtf.py`
+  - `algo/benchmark_parity_acutance_quality_loss.py`
+- Added focused tests covering the new profile fields in:
+  - `tests/test_benchmark_parity_psd_mtf.py`
+  - `tests/test_benchmark_parity_acutance_quality_loss.py`
+- Added the bounded issue-63 candidate profile:
+  - `algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_empirical_linearization_profile.json`
+- Added tracked benchmark artifacts:
+  - `artifacts/issue63_empirical_linearization_psd_benchmark.json`
+  - `artifacts/issue63_empirical_linearization_acutance_benchmark.json`
+
+## Candidate
+
+Baseline from `PR #62`:
+
+- `gamma = 0.5`
+- `linearization_mode = toe_power`
+- `linearization_toe = 0.12`
+- implicit percentile normalization defaults (`black_percentile = 0.1`, `white_percentile = 99.9`)
+
+Issue-63 candidate:
+
+- `gamma = 1.0`
+- `linearization_mode = power`
+- `linearization_toe = 0.0`
+- `black_percentile = 0.1`
+- `white_percentile = 99.5`
+
+Everything else on the newer direct-method line stays fixed.
+
+## Result
+
+This is a bounded mixed result, not a new default direct-method path.
+
+Compared with the current `PR #62` direct-method baseline:
+
+- PSD `curve_mae_mean` regresses: `0.04231237 -> 0.04943691`
+- PSD signed-relative residual regresses: `0.08483351 -> 0.10525592`
+- threshold MAE regresses across all reported points:
+  - `MTF20`: `0.02658848 -> 0.03805077`
+  - `MTF30`: `0.02903115 -> 0.04422298`
+  - `MTF50`: `0.00921053 -> 0.02158925`
+- Acutance `curve_mae_mean` improves: `0.03679567 -> 0.03163068`
+- `acutance_focus_preset_mae_mean` improves sharply: `0.04130714 -> 0.01309645`
+- `overall_quality_loss_mae_mean` regresses materially: `1.26357125 -> 1.52185412`
+- explicit Phone movement is mixed:
+  - Phone Acutance improves slightly: `0.01290994 -> 0.01233973`
+  - Phone Quality Loss regresses: `0.16991880 -> 0.31667489`
+
+Compared with the umbrella README gate recorded in `planning/workgraph.yaml` (`PR #30`):
+
+- Acutance-side metrics are lower:
+  - `curve_mae_mean`: `0.03163068` vs `0.03683438`
+  - `acutance_focus_preset_mae_mean`: `0.01309645` vs `0.04249131`
+- but `overall_quality_loss_mae_mean` is still worse: `1.52185412` vs `1.22214341`
+- and the PSD / threshold side is not competitive enough to justify replacing the current direct-method baseline
+
+## Working conclusion
+
+This pass narrows the post-`PR #62` empirical linearization family:
+
+- the repo now supports percentile-based empirical linearization settings in the parity profile schema
+- replacing the current toe proxy with the stronger `power + gamma=1.0 + white_percentile=99.5` branch does improve Acutance alignment substantially
+- but it does so by sacrificing the current direct-method PSD / MTF fit and by worsening overall Quality Loss
+
+So the remaining parity gap is not solved by this empirical linearization branch alone on the newer direct-method line.
+
+## Validation
+
+- `python3 -m pytest tests/test_benchmark_parity_psd_mtf.py tests/test_benchmark_parity_acutance_quality_loss.py`
+- `python3 -m algo.benchmark_parity_psd_mtf 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_empirical_linearization_profile.json --output artifacts/issue63_empirical_linearization_psd_benchmark.json`
+- `python3 -m algo.benchmark_parity_acutance_quality_loss 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_empirical_linearization_profile.json --output artifacts/issue63_empirical_linearization_acutance_benchmark.json`

--- a/tests/test_benchmark_parity_acutance_quality_loss.py
+++ b/tests/test_benchmark_parity_acutance_quality_loss.py
@@ -67,6 +67,16 @@ class BenchmarkParityAcutanceQualityLossTest(unittest.TestCase):
         self.assertEqual(phone.viewing_distance_cm, 25.55)
         self.assertEqual(monitor.viewing_distance_cm, 39.3)
 
+    def test_profile_allows_empirical_linearization_percentiles(self) -> None:
+        profile = Profile(
+            name="test",
+            calibration_file="algo/deadleaf_13b10_psd_calibration.json",
+            black_percentile=0.0,
+            white_percentile=99.5,
+        )
+        self.assertEqual(profile.black_percentile, 0.0)
+        self.assertEqual(profile.white_percentile, 99.5)
+
     def test_choose_roi_reference_refined_uses_reference_seed(self) -> None:
         image = np.zeros((20, 20), dtype=np.float32)
         reference = SimpleNamespace(lrtb=RoiBounds(left=4, right=9, top=5, bottom=10))

--- a/tests/test_benchmark_parity_psd_mtf.py
+++ b/tests/test_benchmark_parity_psd_mtf.py
@@ -267,6 +267,16 @@ class BenchmarkParityPsdMtfTest(unittest.TestCase):
         self.assertEqual(profile.mtf_compensation_mode, "chart_sensor_aperture_sinc")
         self.assertEqual(profile.chart_fill_factor, 0.5)
 
+    def test_profile_allows_empirical_linearization_percentiles(self) -> None:
+        profile = Profile(
+            name="test",
+            calibration_file="algo/deadleaf_13b10_psd_calibration.json",
+            black_percentile=0.0,
+            white_percentile=99.5,
+        )
+        self.assertEqual(profile.black_percentile, 0.0)
+        self.assertEqual(profile.white_percentile, 99.5)
+
     def test_intrinsic_scope_can_limit_full_reference_to_acutance_side_only(self) -> None:
         capture_key = "OV13b10_AG8_ET5500_deadleaf_12M_40"
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
Refs #29
Refs #63
Context from #31
Context from #32
Context from #41
Context from #52
Context from #56
Context from #58
Context from #61
Context from #62

## Summary
- add percentile-based empirical linearization fields to the direct-method parity benchmark profile schema so issue-63 can express a bounded inverse-linearization family on the post-PR-62 branch
- add the issue-63 empirical linearization profile, tracked benchmark artifacts, and follow-up note
- benchmark a power-mode empirical linearization branch (`gamma=1.0`, `white_percentile=99.5`) against the current PR-62 direct-method baseline

## Result
- PSD / MTF regresses versus the current direct-method baseline: `curve_mae_mean` `0.04231237 -> 0.04943691`, signed-relative residual `0.08483351 -> 0.10525592`, and `MTF20 / 30 / 50` all worsen
- Acutance-side metrics improve materially: `curve_mae_mean` `0.03679567 -> 0.03163068` and `acutance_focus_preset_mae_mean` `0.04130714 -> 0.01309645`
- overall Quality Loss regresses: `1.26357125 -> 1.52185412`
- explicit Phone movement is mixed: Phone Acutance improves slightly `0.01290994 -> 0.01233973`, but Phone Quality Loss worsens `0.16991880 -> 0.31667489`
- conclusion: bounded mixed result, not a new default direct-method path

## Validation
- `python3 -m pytest tests/test_benchmark_parity_psd_mtf.py tests/test_benchmark_parity_acutance_quality_loss.py`
- `python3 -m algo.benchmark_parity_psd_mtf 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_empirical_linearization_profile.json --output artifacts/issue63_empirical_linearization_psd_benchmark.json`
- `python3 -m algo.benchmark_parity_acutance_quality_loss 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_empirical_linearization_profile.json --output artifacts/issue63_empirical_linearization_acutance_benchmark.json`