### PR TITLE
Issue #65: audit chart-prior inverse-linearization family

### DIFF
--- a/algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_chart_prior_slope_m006_anchored_hf_psd_roi_reference_only_empirical_linearization_profile.json
+++ b/algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_chart_prior_slope_m006_anchored_hf_psd_roi_reference_only_empirical_linearization_profile.json
@@ -1,0 +1,193 @@
+{
+  "name": "deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_chart_prior_slope_m006_anchored_hf_psd_roi_reference_only_empirical_linearization",
+  "calibration_file": "algo/deadleaf_13b10_psd_calibration_chart_prior_slope_m006.json",
+  "gamma": 1.0,
+  "linearization_mode": "power",
+  "linearization_toe": 0.0,
+  "black_percentile": 0.1,
+  "white_percentile": 99.5,
+  "bayer_pattern": "RGGB",
+  "bayer_mode": "demosaic_red",
+  "roi_source": "reference",
+  "roi_width": 1655,
+  "roi_height": 1673,
+  "roi_refine_percentile": 45.0,
+  "roi_refine_sigma": 5.0,
+  "roi_refine_min_border_margin": 8,
+  "roi_refine_search_radius": 4,
+  "roi_refine_step": 2,
+  "roi_refine_area_tolerance": 0.98,
+  "matched_ori_reference_anchor": true,
+  "matched_ori_correction_clip_lo": 0.5,
+  "matched_ori_correction_clip_hi": 2.0,
+  "matched_ori_anchor_mode": "acutance_only",
+  "matched_ori_strength_curve_frequencies": [
+    0.0,
+    0.12,
+    0.22,
+    0.35,
+    0.5
+  ],
+  "matched_ori_strength_curve_values": [
+    1.0,
+    1.0,
+    0.82,
+    0.95,
+    1.0
+  ],
+  "matched_ori_acutance_reference_anchor": true,
+  "matched_ori_acutance_correction_clip_lo": 0.9,
+  "matched_ori_acutance_correction_clip_hi": 1.1,
+  "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+  "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+    0.0,
+    0.25,
+    0.6,
+    0.8,
+    1.6,
+    2.5
+  ],
+  "matched_ori_acutance_curve_correction_clip_hi_values": [
+    1.02,
+    1.03,
+    0.895,
+    0.895,
+    1.05,
+    1.06
+  ],
+  "matched_ori_acutance_strength_curve_relative_scales": [
+    0.0,
+    0.2,
+    0.8,
+    1.6,
+    2.5
+  ],
+  "matched_ori_acutance_strength_curve_values": [
+    0.7,
+    0.69,
+    0.64,
+    0.62,
+    0.6
+  ],
+  "matched_ori_acutance_correction_delta_power": 1.0,
+  "matched_ori_acutance_curve_correction_delta_power": 0.95,
+  "matched_ori_acutance_preset_correction_delta_power": null,
+  "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+    0.0,
+    4.5,
+    5.8,
+    6.2
+  ],
+  "matched_ori_acutance_preset_correction_delta_power_values": [
+    1.05,
+    1.05,
+    1.85,
+    1.85
+  ],
+  "matched_ori_acutance_preset_strength_curve_relative_scales": [
+    0.0,
+    3.0,
+    4.5,
+    5.8,
+    6.2
+  ],
+  "matched_ori_acutance_preset_strength_curve_values": [
+    1.0,
+    1.0,
+    0.85,
+    0.45,
+    0.45
+  ],
+  "frequency_scale": 1.0,
+  "texture_support_scale": true,
+  "normalization_band_lo": 0.01,
+  "normalization_band_hi": 0.03,
+  "normalization_mode": "max",
+  "acutance_band_lo": 0.017,
+  "acutance_band_hi": 0.035,
+  "acutance_band_mode": "mean",
+  "noise_psd_model": "empirical",
+  "noise_psd_scale": 1.0,
+  "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+  "acutance_noise_share_band_lo": 0.36,
+  "acutance_noise_share_band_hi": 0.5,
+  "acutance_noise_share_scale_coefficients": [
+    521.08180962,
+    -26.62905791,
+    1.59615575
+  ],
+  "high_frequency_guard_start_cpp": 0.36,
+  "high_frequency_guard_stop_cpp": 0.5,
+  "mtf_compensation_mode": "sensor_aperture_sinc",
+  "sensor_fill_factor": 1.5,
+  "compensation_denominator_clip": 0.25,
+  "compensation_max_gain": 3.0,
+  "quality_loss_om_ceiling": 0.8851,
+  "quality_loss_coefficients": [
+    37.240228358776136,
+    26.54550669779819,
+    0.4538662637619741
+  ],
+  "quality_loss_preset_overrides": {
+    "Computer Monitor Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        5677361.198044325,
+        -16715685.9524707,
+        20317567.326582585,
+        -13046703.33912079,
+        4667794.619228022,
+        -882296.9160375095,
+        68863.59709647154
+      ]
+    },
+    "5.5\" Phone Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        -110912321.41149135,
+        50461107.51563171,
+        -9079490.127807735,
+        815148.8697247265,
+        -37712.984407641874,
+        854.6941149036079,
+        -6.261149027919645
+      ]
+    },
+    "UHDTV Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        1783462.6221675149,
+        -3813432.5606394163,
+        3326218.4642961356,
+        -1514886.1959663907,
+        380334.163146246,
+        -49956.87092015135,
+        2692.9566508574017
+      ]
+    },
+    "Small Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        6690980.837239251,
+        -12955277.716404187,
+        10300283.291740375,
+        -4303759.200708971,
+        996904.2653558743,
+        -121409.71509269004,
+        6084.6471373306085
+      ]
+    },
+    "Large Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        2355074.475971866,
+        -5276146.244338096,
+        4846781.143787682,
+        -2336594.295523967,
+        623766.4933095274,
+        -87476.30712136331,
+        5049.882965558553
+      ]
+    }
+  }
+}

--- a/artifacts/issue65_chart_prior_inverse_linearization_acutance_benchmark.json
+++ b/artifacts/issue65_chart_prior_inverse_linearization_acutance_benchmark.json
@@ -1,0 +1,495 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 1.0,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "power",
+        "linearization_toe": 0.0,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "roi_source": "reference",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.017427314851735876,
+        "0.25": 0.017294252475129952,
+        "0.4": 0.021482340684367662,
+        "0.65": 0.036506743635582276,
+        "0.8": 0.049038924019615376,
+        "ori": 0.06931437781269942
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 1.1374015851335626,
+        "0.25": 1.1990104772898045,
+        "0.4": 1.6412472818901467,
+        "0.65": 0.730449437792704,
+        "0.8": 1.3056116089499543,
+        "ori": 3.9215498838037313
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.013096453705606729,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.012339726096799753,
+          "Computer Monitor Acutance": 0.01211298333455687,
+          "Large Print Acutance": 0.008652070267904098,
+          "Small Print Acutance": 0.010307146668849663,
+          "UHDTV Display Acutance": 0.022070342159923255
+        },
+        "curve_mae_mean": 0.031630678550997944,
+        "overall_quality_loss_mae_mean": 1.521854122812337,
+        "quality_loss_focus_preset_mae_mean": 1.521854122812337,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 0.31667488505906133,
+          "Computer Monitor Quality Loss": 3.32218083965815,
+          "Large Print Quality Loss": 1.3349872027109564,
+          "Small Print Quality Loss": 1.1811005461400752,
+          "UHDTV Display Quality Loss": 1.4543271404934428
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_empirical_linearization_profile.json"
+    },
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_chart_prior_slope_m006.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 1.0,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "power",
+        "linearization_toe": 0.0,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "roi_source": "reference",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.017448101240412062,
+        "0.25": 0.01736791545570121,
+        "0.4": 0.02168242826708363,
+        "0.65": 0.036925875416073624,
+        "0.8": 0.04958203513966884,
+        "ori": 0.06990835321399928
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 1.1350079816882492,
+        "0.25": 1.2040863386631087,
+        "0.4": 1.6472203876645644,
+        "0.65": 0.7316356074769051,
+        "0.8": 1.304484601709131,
+        "ori": 4.004515558621977
+      },
+      "delta_vs_first_profile": {
+        "acutance_focus_preset_mae_mean": -2.8172533986367196e-05,
+        "curve_mae_mean": 0.0002688403325824956,
+        "overall_quality_loss_mae_mean": 0.009920855742561852,
+        "quality_loss_focus_preset_mae_mean": 0.009920855742561852
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.013068281171620361,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.012338772438470614,
+          "Computer Monitor Acutance": 0.01204952686089712,
+          "Large Print Acutance": 0.008671051021070398,
+          "Small Print Acutance": 0.010307033705187688,
+          "UHDTV Display Acutance": 0.021975021832475978
+        },
+        "curve_mae_mean": 0.03189951888358044,
+        "overall_quality_loss_mae_mean": 1.5317749785548989,
+        "quality_loss_focus_preset_mae_mean": 1.5317749785548989,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 0.31661995869798404,
+          "Computer Monitor Quality Loss": 3.3813933594483125,
+          "Large Print Quality Loss": 1.3322211490442237,
+          "Small Print Quality Loss": 1.1810605359751631,
+          "UHDTV Display Quality Loss": 1.4475798896088106
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_chart_prior_slope_m006_anchored_hf_psd_roi_reference_only_empirical_linearization_profile.json"
+    }
+  ]
+}

--- a/artifacts/issue65_chart_prior_inverse_linearization_psd_benchmark.json
+++ b/artifacts/issue65_chart_prior_inverse_linearization_psd_benchmark.json
@@ -1,0 +1,373 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 1.0,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "power",
+        "linearization_toe": 0.0,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "roi_source": "reference",
+        "sensor_fill_factor": 1.5,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.01614445530218654,
+        "0.25": 0.024167319177931263,
+        "0.4": 0.040639129443753336,
+        "0.65": 0.06656422352173443,
+        "0.8": 0.08058345761593085,
+        "ori": 0.1047361462477163
+      },
+      "overall": {
+        "curve_mae_mean": 0.04943690928490546,
+        "mtf_abs_signed_rel_mean": 0.10525591547107517,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.05266236622941153,
+            "mre_mean": 0.2330989040160393,
+            "signed_rel_mean": 0.23185876804125333
+          },
+          "low": {
+            "mae_mean": 0.03746958388253656,
+            "mre_mean": 0.047391562188913064,
+            "signed_rel_mean": 0.02706576810029983
+          },
+          "mid": {
+            "mae_mean": 0.048055144818181586,
+            "mre_mean": 0.15867614948526176,
+            "signed_rel_mean": 0.15189251472252688
+          },
+          "top": {
+            "mae_mean": 0.07375331751315588,
+            "mre_mean": 0.20549052982050214,
+            "signed_rel_mean": -0.01020661102022065
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.03805077337414969,
+          "mtf30": 0.04422298499845122,
+          "mtf50": 0.021589249154774382
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.01180938978066858,
+          "Computer Monitor Acutance": 0.04465557619415565,
+          "Large Print Acutance": 0.04939352096212955,
+          "Small Print Acutance": 0.049496770799479145,
+          "UHDTV Display Acutance": 0.05056936432941209
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_empirical_linearization_profile.json"
+    },
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_chart_prior_slope_m006.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 1.0,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "power",
+        "linearization_toe": 0.0,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "roi_source": "reference",
+        "sensor_fill_factor": 1.5,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.016322063652857145,
+        "0.25": 0.024419552314034837,
+        "0.4": 0.04097323554230806,
+        "0.65": 0.06703757506913807,
+        "0.8": 0.08119033179806093,
+        "ori": 0.1053761780357946
+      },
+      "overall": {
+        "curve_mae_mean": 0.04982241197194546,
+        "mtf_abs_signed_rel_mean": 0.1367037111198927,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.06558826191276415,
+            "mre_mean": 0.2904906243092526,
+            "signed_rel_mean": 0.2904286919045339
+          },
+          "low": {
+            "mae_mean": 0.03746958388253656,
+            "mre_mean": 0.047391562188913064,
+            "signed_rel_mean": 0.02706576810029983
+          },
+          "mid": {
+            "mae_mean": 0.048055144818181586,
+            "mre_mean": 0.15867614948526176,
+            "signed_rel_mean": 0.15189251472252688
+          },
+          "top": {
+            "mae_mean": 0.08183418464720686,
+            "mre_mean": 0.23765776999053645,
+            "signed_rel_mean": 0.0774278697522102
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.042778033341942426,
+          "mtf30": 0.04902803854046335,
+          "mtf50": 0.021589249154774382
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.01180880776459689,
+          "Computer Monitor Acutance": 0.04514890573500606,
+          "Large Print Acutance": 0.04947043834146943,
+          "Small Print Acutance": 0.04949754812674552,
+          "UHDTV Display Acutance": 0.05077059995903473
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_chart_prior_slope_m006_anchored_hf_psd_roi_reference_only_empirical_linearization_profile.json"
+    }
+  ]
+}

--- a/docs/issue65_chart_prior_inverse_linearization_followup.md
+++ b/docs/issue65_chart_prior_inverse_linearization_followup.md
@@ -1,0 +1,100 @@
+# Issue 65 Chart-Prior / Inverse-Linearization Follow-up
+
+Issue: `#65`  
+Refs: `#29`, `#65`  
+Context from: `#31`, `#32`, `#41`, `#63`, `#64`
+
+## Why this pass
+
+Issue `#65` asked for one bounded chart-prior / inverse-linearization family that is justified by current repo evidence and existing dead-leaves captures, without waiting on new Stepchart or Colorcheck artifacts.
+
+The narrowest family already supported by the repo evidence was:
+
+- the issue-`#63` empirical inverse-linearization branch on the current direct-method line
+- combined with the issue-`#41` bounded chart-prior slope calibration, which already proved that chart-prior shape is a real signal-bearing lever inside the current ideal-PSD family
+
+This stays narrower than the broader measured-OECF direction because it does not introduce new external chart-patch measurements or reopen a generic proxy sweep. It reuses one already-documented chart-prior perturbation and applies it to the already-bounded empirical inverse-linearization branch from `PR #64`.
+
+## What changed
+
+- Added the bounded issue-65 candidate profile:
+  - `algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_chart_prior_slope_m006_anchored_hf_psd_roi_reference_only_empirical_linearization_profile.json`
+- Added tracked benchmark artifacts:
+  - `artifacts/issue65_chart_prior_inverse_linearization_psd_benchmark.json`
+  - `artifacts/issue65_chart_prior_inverse_linearization_acutance_benchmark.json`
+
+No runtime code changed in this pass. The implementation is a bounded profile-only follow-up on top of the merged `PR #64` schema support.
+
+## Candidate
+
+Baseline from `PR #64`:
+
+- `calibration_file = algo/deadleaf_13b10_psd_calibration_anchored.json`
+- `linearization_mode = power`
+- `gamma = 1.0`
+- `black_percentile = 0.1`
+- `white_percentile = 99.5`
+
+Issue-65 candidate:
+
+- keeps the full `PR #64` direct-method profile fixed
+- swaps only the calibration file to `algo/deadleaf_13b10_psd_calibration_chart_prior_slope_m006.json`
+
+That makes the issue-65 slice the direct composition of the bounded issue-41 chart-prior lever and the bounded issue-63 empirical linearization lever.
+
+## Result Versus PR 64
+
+This is another bounded negative result, not a new default path and not a useful refinement of the `PR #64` branch.
+
+Compared with the `PR #64` empirical-linearization profile:
+
+- PSD `curve_mae_mean` regresses: `0.04943691 -> 0.04982241`
+- PSD signed-relative residual regresses materially: `0.10525592 -> 0.13670371`
+- threshold MAE regresses:
+  - `MTF20`: `0.03805077 -> 0.04277803`
+  - `MTF30`: `0.04422298 -> 0.04902804`
+  - `MTF50`: unchanged at `0.02158925`
+- Acutance `curve_mae_mean` regresses slightly: `0.03163068 -> 0.03189952`
+- `acutance_focus_preset_mae_mean` improves only trivially: `0.01309645 -> 0.01306828`
+- `overall_quality_loss_mae_mean` regresses: `1.52185412 -> 1.53177498`
+- explicit Phone movement is negligible and still mixed:
+  - Phone Acutance improves slightly: `0.01233973 -> 0.01233877`
+  - Phone Quality Loss improves slightly: `0.31667489 -> 0.31661996`
+
+The issue-41 slope lever helped the old branch only by moving the curve aggressively while destabilizing threshold behavior. On top of the issue-63 empirical linearization branch, it no longer even buys a meaningful curve improvement; it mostly preserves the old regressions and makes the lower-layer PSD readouts worse.
+
+## Result Versus Umbrella Gate
+
+The umbrella README gate recorded in `planning/workgraph.yaml` still points to `PR #30` as the current best branch:
+
+- `curve_mae_mean = 0.03683438`
+- `acutance_focus_preset_mae_mean = 0.04249131`
+- `overall_quality_loss_mae_mean = 1.22214341`
+- `phone_display_acutance_mae = 0.01380215`
+
+Compared with that gate, the issue-65 candidate still has:
+
+- stronger aggregate Acutance metrics
+  - `curve_mae_mean`: `0.03189952`
+  - `acutance_focus_preset_mae_mean`: `0.01306828`
+  - `5.5\" Phone Display Acutance`: `0.01233877`
+- but much worse aggregate Quality Loss
+  - `overall_quality_loss_mae_mean`: `1.53177498`
+- and the PSD / reported-MTF side remains too weak to justify replacing the current main-line workaround branch
+
+So issue `#65` does not move the repo closer to the canonical observable target enough to justify promoting this family.
+
+## Working Conclusion
+
+This pass closes one explicit current-data-supported chart-prior / inverse-linearization family:
+
+- the family is well-justified by existing repo evidence because it composes the already-recorded issue-41 chart-prior slope lever with the already-recorded issue-63 empirical inverse-linearization branch
+- the family is still narrower than the broader measured-OECF direction because it requires no new external chart artifacts
+- the result is not merely mixed; on the current direct-method branch it is effectively a bounded negative refinement of `PR #64`
+
+So the remaining canonical parity gap is still not explained or solved by combining the current empirical linearization branch with this one bounded chart-prior slope variant.
+
+## Validation
+
+- `python3 -m algo.benchmark_parity_psd_mtf 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_empirical_linearization_profile.json algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_chart_prior_slope_m006_anchored_hf_psd_roi_reference_only_empirical_linearization_profile.json --output artifacts/issue65_chart_prior_inverse_linearization_psd_benchmark.json`
+- `python3 -m algo.benchmark_parity_acutance_quality_loss 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_empirical_linearization_profile.json algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_chart_prior_slope_m006_anchored_hf_psd_roi_reference_only_empirical_linearization_profile.json --output artifacts/issue65_chart_prior_inverse_linearization_acutance_benchmark.json`


### PR DESCRIPTION
Refs #29
Refs #65
Context from #31
Context from #32
Context from #41
Context from #63
Context from #64

## Summary
- add one bounded chart-prior plus inverse-linearization profile by composing the issue-41 chart-prior slope calibration with the issue-63 empirical linearization settings on the current direct-method line
- add tracked PSD and Acutance/Quality Loss benchmark artifacts for that exact family
- document why this is the narrowest current-data-supported chart-prior / inverse-linearization slice and record the outcome

## Result
- compared with PR #64, the candidate is a bounded negative refinement: PSD curve MAE, signed-relative residual, MTF20, MTF30, Acutance curve MAE, and overall Quality Loss all regress
- only trivial Acutance-side improvements remain, so this does not become a new default path
- compared with the umbrella gate in #29, aggregate Acutance is still lower but Quality Loss remains materially worse

## Validation
- python3 -m algo.benchmark_parity_psd_mtf 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_empirical_linearization_profile.json algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_chart_prior_slope_m006_anchored_hf_psd_roi_reference_only_empirical_linearization_profile.json --output artifacts/issue65_chart_prior_inverse_linearization_psd_benchmark.json
- python3 -m algo.benchmark_parity_acutance_quality_loss 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_empirical_linearization_profile.json algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_chart_prior_slope_m006_anchored_hf_psd_roi_reference_only_empirical_linearization_profile.json --output artifacts/issue65_chart_prior_inverse_linearization_acutance_benchmark.json
