### PR TITLE
Issue #67: audit readout policy family

### DIFF
--- a/algo/benchmark_parity_acutance_quality_loss.py
+++ b/algo/benchmark_parity_acutance_quality_loss.py
@@ -390,6 +390,8 @@ def summarize_profile(
                 acutance_noise_share_scale_coefficients=tuple(
                     profile.acutance_noise_share_scale_coefficients
                 ),
+                readout_smoothing_window=profile.readout_smoothing_window,
+                readout_interpolation=profile.readout_interpolation,
                 high_frequency_guard_start_cpp=profile.high_frequency_guard_start_cpp,
                 high_frequency_guard_stop_cpp=profile.high_frequency_guard_stop_cpp,
             )
@@ -642,6 +644,8 @@ def summarize_profile(
             acutance_noise_share_scale_coefficients=tuple(
                 profile.acutance_noise_share_scale_coefficients
             ),
+            readout_smoothing_window=profile.readout_smoothing_window,
+            readout_interpolation=profile.readout_interpolation,
             high_frequency_guard_start_cpp=profile.high_frequency_guard_start_cpp,
             high_frequency_guard_stop_cpp=profile.high_frequency_guard_stop_cpp,
         )
@@ -788,6 +792,8 @@ def summarize_profile(
                         acutance_noise_share_scale_coefficients=tuple(
                             profile.acutance_noise_share_scale_coefficients
                         ),
+                        readout_smoothing_window=profile.readout_smoothing_window,
+                        readout_interpolation=profile.readout_interpolation,
                         high_frequency_guard_start_cpp=profile.high_frequency_guard_start_cpp,
                         high_frequency_guard_stop_cpp=profile.high_frequency_guard_stop_cpp,
                     )

--- a/algo/benchmark_parity_acutance_quality_loss.py
+++ b/algo/benchmark_parity_acutance_quality_loss.py
@@ -135,6 +135,8 @@ class Profile:
     matched_ori_acutance_preset_strength_curve_values: tuple[float, ...] | None = None
     frequency_bin_source: str = "reference_bins"
     frequency_scale: float = 1.0
+    readout_smoothing_window: int = 1
+    readout_interpolation: str = "linear"
     normalization_band_lo: float = 0.01
     normalization_band_hi: float = 0.03
     normalization_mode: str = "max"
@@ -1073,6 +1075,8 @@ def summarize_profile(
             "quality_loss_coefficients": profile.quality_loss_coefficients,
             "quality_loss_preset_overrides": profile.quality_loss_preset_overrides,
             "frequency_scale": profile.frequency_scale,
+            "readout_smoothing_window": profile.readout_smoothing_window,
+            "readout_interpolation": profile.readout_interpolation,
             "texture_support_scale": profile.texture_support_scale,
             "calibration_file": profile.calibration_file,
             "acutance_noise_scale_mode": profile.acutance_noise_scale_mode,

--- a/algo/benchmark_parity_psd_mtf.py
+++ b/algo/benchmark_parity_psd_mtf.py
@@ -121,6 +121,8 @@ class Profile:
     matched_ori_acutance_preset_strength_curve_values: tuple[float, ...] | None = None
     frequency_bin_source: str = "reference_bins"
     frequency_scale: float = 1.0
+    readout_smoothing_window: int = 1
+    readout_interpolation: str = "linear"
     normalization_band_lo: float = 0.01
     normalization_band_hi: float = 0.03
     normalization_mode: str = "max"
@@ -637,7 +639,12 @@ def profile_payload(
                     strength_curve_frequencies=profile.matched_ori_strength_curve_frequencies,
                     strength_curve_values=profile.matched_ori_strength_curve_values,
                 )
-        metrics = compute_mtf_metrics(scaled_frequencies, compensated_mtf)
+        metrics = compute_mtf_metrics(
+            scaled_frequencies,
+            compensated_mtf,
+            smoothing_window=profile.readout_smoothing_window,
+            interpolation_mode=profile.readout_interpolation,
+        )
         mtf50_errors.append(
             abs(metrics.mtf50 - interpolate_threshold(reference.frequencies_cpp, reference.mtf, 0.5))
         )
@@ -746,6 +753,8 @@ def profile_payload(
             "matched_ori_acutance_preset_strength_curve_relative_scales": profile.matched_ori_acutance_preset_strength_curve_relative_scales,
             "matched_ori_acutance_preset_strength_curve_values": profile.matched_ori_acutance_preset_strength_curve_values,
             "frequency_scale": profile.frequency_scale,
+            "readout_smoothing_window": profile.readout_smoothing_window,
+            "readout_interpolation": profile.readout_interpolation,
             "texture_support_scale": profile.texture_support_scale,
             "signal_psd_correction_gain": profile.signal_psd_correction_gain,
             "acutance_noise_scale_mode": profile.acutance_noise_scale_mode,

--- a/algo/benchmark_parity_psd_mtf.py
+++ b/algo/benchmark_parity_psd_mtf.py
@@ -403,6 +403,8 @@ def profile_payload(
             acutance_noise_share_scale_coefficients=tuple(
                 profile.acutance_noise_share_scale_coefficients
             ),
+            readout_smoothing_window=profile.readout_smoothing_window,
+            readout_interpolation=profile.readout_interpolation,
             high_frequency_guard_start_cpp=profile.high_frequency_guard_start_cpp,
             high_frequency_guard_stop_cpp=profile.high_frequency_guard_stop_cpp,
         )
@@ -551,6 +553,8 @@ def profile_payload(
                         acutance_noise_share_scale_coefficients=tuple(
                             profile.acutance_noise_share_scale_coefficients
                         ),
+                        readout_smoothing_window=profile.readout_smoothing_window,
+                        readout_interpolation=profile.readout_interpolation,
                         high_frequency_guard_start_cpp=profile.high_frequency_guard_start_cpp,
                         high_frequency_guard_stop_cpp=profile.high_frequency_guard_stop_cpp,
                     )

--- a/algo/dead_leaves.py
+++ b/algo/dead_leaves.py
@@ -1605,6 +1605,8 @@ def estimate_dead_leaves_mtf(
     acutance_noise_share_band: tuple[float, float] = ACUTANCE_HF_NOISE_SHARE_BAND,
     acutance_noise_share_scale_coefficients: tuple[float, float, float] = ACUTANCE_HF_NOISE_SHARE_SCALE_COEFFICIENTS,
     acutance_noise_scale_clip: tuple[float, float] = ACUTANCE_NOISE_SCALE_CLIP,
+    readout_smoothing_window: int = 1,
+    readout_interpolation: str = "linear",
     high_frequency_guard_start_cpp: float | None = None,
     high_frequency_guard_stop_cpp: float = 0.5,
 ) -> SpectrumResult:
@@ -1697,7 +1699,12 @@ def estimate_dead_leaves_mtf(
         reference_band=acutance_reference_band,
         reference_mode=acutance_reference_mode,
     )
-    metrics = compute_mtf_metrics(frequencies_cpp, mtf)
+    metrics = compute_mtf_metrics(
+        frequencies_cpp,
+        mtf,
+        smoothing_window=readout_smoothing_window,
+        interpolation_mode=readout_interpolation,
+    )
 
     return SpectrumResult(
         roi=roi,

--- a/algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_chart_prior_slope_m006_anchored_hf_psd_roi_reference_only_empirical_linearization_readout7_profile.json
+++ b/algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_chart_prior_slope_m006_anchored_hf_psd_roi_reference_only_empirical_linearization_readout7_profile.json
@@ -1,0 +1,195 @@
+{
+  "name": "deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_chart_prior_slope_m006_anchored_hf_psd_roi_reference_only_empirical_linearization_readout7",
+  "calibration_file": "algo/deadleaf_13b10_psd_calibration_chart_prior_slope_m006.json",
+  "gamma": 1.0,
+  "linearization_mode": "power",
+  "linearization_toe": 0.0,
+  "black_percentile": 0.1,
+  "white_percentile": 99.5,
+  "bayer_pattern": "RGGB",
+  "bayer_mode": "demosaic_red",
+  "roi_source": "reference",
+  "roi_width": 1655,
+  "roi_height": 1673,
+  "roi_refine_percentile": 45.0,
+  "roi_refine_sigma": 5.0,
+  "roi_refine_min_border_margin": 8,
+  "roi_refine_search_radius": 4,
+  "roi_refine_step": 2,
+  "roi_refine_area_tolerance": 0.98,
+  "matched_ori_reference_anchor": true,
+  "matched_ori_correction_clip_lo": 0.5,
+  "matched_ori_correction_clip_hi": 2.0,
+  "matched_ori_anchor_mode": "acutance_only",
+  "matched_ori_strength_curve_frequencies": [
+    0.0,
+    0.12,
+    0.22,
+    0.35,
+    0.5
+  ],
+  "matched_ori_strength_curve_values": [
+    1.0,
+    1.0,
+    0.82,
+    0.95,
+    1.0
+  ],
+  "matched_ori_acutance_reference_anchor": true,
+  "matched_ori_acutance_correction_clip_lo": 0.9,
+  "matched_ori_acutance_correction_clip_hi": 1.1,
+  "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+  "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+    0.0,
+    0.25,
+    0.6,
+    0.8,
+    1.6,
+    2.5
+  ],
+  "matched_ori_acutance_curve_correction_clip_hi_values": [
+    1.02,
+    1.03,
+    0.895,
+    0.895,
+    1.05,
+    1.06
+  ],
+  "matched_ori_acutance_strength_curve_relative_scales": [
+    0.0,
+    0.2,
+    0.8,
+    1.6,
+    2.5
+  ],
+  "matched_ori_acutance_strength_curve_values": [
+    0.7,
+    0.69,
+    0.64,
+    0.62,
+    0.6
+  ],
+  "matched_ori_acutance_correction_delta_power": 1.0,
+  "matched_ori_acutance_curve_correction_delta_power": 0.95,
+  "matched_ori_acutance_preset_correction_delta_power": null,
+  "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+    0.0,
+    4.5,
+    5.8,
+    6.2
+  ],
+  "matched_ori_acutance_preset_correction_delta_power_values": [
+    1.05,
+    1.05,
+    1.85,
+    1.85
+  ],
+  "matched_ori_acutance_preset_strength_curve_relative_scales": [
+    0.0,
+    3.0,
+    4.5,
+    5.8,
+    6.2
+  ],
+  "matched_ori_acutance_preset_strength_curve_values": [
+    1.0,
+    1.0,
+    0.85,
+    0.45,
+    0.45
+  ],
+  "frequency_scale": 1.0,
+  "readout_smoothing_window": 7,
+  "readout_interpolation": "linear",
+  "texture_support_scale": true,
+  "normalization_band_lo": 0.01,
+  "normalization_band_hi": 0.03,
+  "normalization_mode": "max",
+  "acutance_band_lo": 0.017,
+  "acutance_band_hi": 0.035,
+  "acutance_band_mode": "mean",
+  "noise_psd_model": "empirical",
+  "noise_psd_scale": 1.0,
+  "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+  "acutance_noise_share_band_lo": 0.36,
+  "acutance_noise_share_band_hi": 0.5,
+  "acutance_noise_share_scale_coefficients": [
+    521.08180962,
+    -26.62905791,
+    1.59615575
+  ],
+  "high_frequency_guard_start_cpp": 0.36,
+  "high_frequency_guard_stop_cpp": 0.5,
+  "mtf_compensation_mode": "sensor_aperture_sinc",
+  "sensor_fill_factor": 1.5,
+  "compensation_denominator_clip": 0.25,
+  "compensation_max_gain": 3.0,
+  "quality_loss_om_ceiling": 0.8851,
+  "quality_loss_coefficients": [
+    37.240228358776136,
+    26.54550669779819,
+    0.4538662637619741
+  ],
+  "quality_loss_preset_overrides": {
+    "Computer Monitor Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        5677361.198044325,
+        -16715685.9524707,
+        20317567.326582585,
+        -13046703.33912079,
+        4667794.619228022,
+        -882296.9160375095,
+        68863.59709647154
+      ]
+    },
+    "5.5\" Phone Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        -110912321.41149135,
+        50461107.51563171,
+        -9079490.127807735,
+        815148.8697247265,
+        -37712.984407641874,
+        854.6941149036079,
+        -6.261149027919645
+      ]
+    },
+    "UHDTV Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        1783462.6221675149,
+        -3813432.5606394163,
+        3326218.4642961356,
+        -1514886.1959663907,
+        380334.163146246,
+        -49956.87092015135,
+        2692.9566508574017
+      ]
+    },
+    "Small Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        6690980.837239251,
+        -12955277.716404187,
+        10300283.291740375,
+        -4303759.200708971,
+        996904.2653558743,
+        -121409.71509269004,
+        6084.6471373306085
+      ]
+    },
+    "Large Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        2355074.475971866,
+        -5276146.244338096,
+        4846781.143787682,
+        -2336594.295523967,
+        623766.4933095274,
+        -87476.30712136331,
+        5049.882965558553
+      ]
+    }
+  }
+}

--- a/artifacts/issue67_readout_policy_acutance_benchmark.json
+++ b/artifacts/issue67_readout_policy_acutance_benchmark.json
@@ -1,0 +1,499 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_chart_prior_slope_m006.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 1.0,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "power",
+        "linearization_toe": 0.0,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "readout_interpolation": "linear",
+        "readout_smoothing_window": 1,
+        "roi_source": "reference",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.017448101240412062,
+        "0.25": 0.01736791545570121,
+        "0.4": 0.02168242826708363,
+        "0.65": 0.036925875416073624,
+        "0.8": 0.04958203513966884,
+        "ori": 0.06990835321399928
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 1.1350079816882492,
+        "0.25": 1.2040863386631087,
+        "0.4": 1.6472203876645644,
+        "0.65": 0.7316356074769051,
+        "0.8": 1.304484601709131,
+        "ori": 4.004515558621977
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.013068281171620361,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.012338772438470614,
+          "Computer Monitor Acutance": 0.01204952686089712,
+          "Large Print Acutance": 0.008671051021070398,
+          "Small Print Acutance": 0.010307033705187688,
+          "UHDTV Display Acutance": 0.021975021832475978
+        },
+        "curve_mae_mean": 0.03189951888358044,
+        "overall_quality_loss_mae_mean": 1.5317749785548989,
+        "quality_loss_focus_preset_mae_mean": 1.5317749785548989,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 0.31661995869798404,
+          "Computer Monitor Quality Loss": 3.3813933594483125,
+          "Large Print Quality Loss": 1.3322211490442237,
+          "Small Print Quality Loss": 1.1810605359751631,
+          "UHDTV Display Quality Loss": 1.4475798896088106
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_chart_prior_slope_m006_anchored_hf_psd_roi_reference_only_empirical_linearization_profile.json"
+    },
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_chart_prior_slope_m006.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 1.0,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "power",
+        "linearization_toe": 0.0,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "readout_interpolation": "linear",
+        "readout_smoothing_window": 7,
+        "roi_source": "reference",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.017448101240412062,
+        "0.25": 0.01736791545570121,
+        "0.4": 0.02168242826708363,
+        "0.65": 0.036925875416073624,
+        "0.8": 0.04958203513966884,
+        "ori": 0.06990835321399928
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 1.1350079816882492,
+        "0.25": 1.2040863386631087,
+        "0.4": 1.6472203876645644,
+        "0.65": 0.7316356074769051,
+        "0.8": 1.304484601709131,
+        "ori": 4.004515558621977
+      },
+      "delta_vs_first_profile": {
+        "acutance_focus_preset_mae_mean": 0.0,
+        "curve_mae_mean": 0.0,
+        "overall_quality_loss_mae_mean": 0.0,
+        "quality_loss_focus_preset_mae_mean": 0.0
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.013068281171620361,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.012338772438470614,
+          "Computer Monitor Acutance": 0.01204952686089712,
+          "Large Print Acutance": 0.008671051021070398,
+          "Small Print Acutance": 0.010307033705187688,
+          "UHDTV Display Acutance": 0.021975021832475978
+        },
+        "curve_mae_mean": 0.03189951888358044,
+        "overall_quality_loss_mae_mean": 1.5317749785548989,
+        "quality_loss_focus_preset_mae_mean": 1.5317749785548989,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 0.31661995869798404,
+          "Computer Monitor Quality Loss": 3.3813933594483125,
+          "Large Print Quality Loss": 1.3322211490442237,
+          "Small Print Quality Loss": 1.1810605359751631,
+          "UHDTV Display Quality Loss": 1.4475798896088106
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_chart_prior_slope_m006_anchored_hf_psd_roi_reference_only_empirical_linearization_readout7_profile.json"
+    }
+  ]
+}

--- a/artifacts/issue67_readout_policy_psd_benchmark.json
+++ b/artifacts/issue67_readout_policy_psd_benchmark.json
@@ -1,0 +1,377 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_chart_prior_slope_m006.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 1.0,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "power",
+        "linearization_toe": 0.0,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "readout_interpolation": "linear",
+        "readout_smoothing_window": 1,
+        "roi_source": "reference",
+        "sensor_fill_factor": 1.5,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.016322063652857145,
+        "0.25": 0.024419552314034837,
+        "0.4": 0.04097323554230806,
+        "0.65": 0.06703757506913807,
+        "0.8": 0.08119033179806093,
+        "ori": 0.1053761780357946
+      },
+      "overall": {
+        "curve_mae_mean": 0.04982241197194546,
+        "mtf_abs_signed_rel_mean": 0.1367037111198927,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.06558826191276415,
+            "mre_mean": 0.2904906243092526,
+            "signed_rel_mean": 0.2904286919045339
+          },
+          "low": {
+            "mae_mean": 0.03746958388253656,
+            "mre_mean": 0.047391562188913064,
+            "signed_rel_mean": 0.02706576810029983
+          },
+          "mid": {
+            "mae_mean": 0.048055144818181586,
+            "mre_mean": 0.15867614948526176,
+            "signed_rel_mean": 0.15189251472252688
+          },
+          "top": {
+            "mae_mean": 0.08183418464720686,
+            "mre_mean": 0.23765776999053645,
+            "signed_rel_mean": 0.0774278697522102
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.042778033341942426,
+          "mtf30": 0.04902803854046335,
+          "mtf50": 0.021589249154774382
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.01180880776459689,
+          "Computer Monitor Acutance": 0.04514890573500606,
+          "Large Print Acutance": 0.04947043834146943,
+          "Small Print Acutance": 0.04949754812674552,
+          "UHDTV Display Acutance": 0.05077059995903473
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_chart_prior_slope_m006_anchored_hf_psd_roi_reference_only_empirical_linearization_profile.json"
+    },
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_chart_prior_slope_m006.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 1.0,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "power",
+        "linearization_toe": 0.0,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "readout_interpolation": "linear",
+        "readout_smoothing_window": 7,
+        "roi_source": "reference",
+        "sensor_fill_factor": 1.5,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.016322063652857145,
+        "0.25": 0.024419552314034837,
+        "0.4": 0.04097323554230806,
+        "0.65": 0.06703757506913807,
+        "0.8": 0.08119033179806093,
+        "ori": 0.1053761780357946
+      },
+      "overall": {
+        "curve_mae_mean": 0.04982241197194546,
+        "mtf_abs_signed_rel_mean": 0.1367037111198927,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.06558826191276415,
+            "mre_mean": 0.2904906243092526,
+            "signed_rel_mean": 0.2904286919045339
+          },
+          "low": {
+            "mae_mean": 0.03746958388253656,
+            "mre_mean": 0.047391562188913064,
+            "signed_rel_mean": 0.02706576810029983
+          },
+          "mid": {
+            "mae_mean": 0.048055144818181586,
+            "mre_mean": 0.15867614948526176,
+            "signed_rel_mean": 0.15189251472252688
+          },
+          "top": {
+            "mae_mean": 0.08183418464720686,
+            "mre_mean": 0.23765776999053645,
+            "signed_rel_mean": 0.0774278697522102
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.043514415552122654,
+          "mtf30": 0.049474379968693985,
+          "mtf50": 0.02450493402291129
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.01180880776459689,
+          "Computer Monitor Acutance": 0.04514890573500606,
+          "Large Print Acutance": 0.04947043834146943,
+          "Small Print Acutance": 0.04949754812674552,
+          "UHDTV Display Acutance": 0.05077059995903473
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_chart_prior_slope_m006_anchored_hf_psd_roi_reference_only_empirical_linearization_readout7_profile.json"
+    }
+  ]
+}

--- a/docs/issue67_readout_policy_followup.md
+++ b/docs/issue67_readout_policy_followup.md
@@ -25,6 +25,7 @@ No broader direct-method retuning is reopened here.
 - Added `readout_smoothing_window` / `readout_interpolation` profile-schema support to:
   - `algo/benchmark_parity_psd_mtf.py`
   - `algo/benchmark_parity_acutance_quality_loss.py`
+- Wired those fields through the shared `estimate_dead_leaves_mtf(...)` readout path in `algo/dead_leaves.py`, so the issue-67 profile now exercises a real threshold-readout change instead of metadata-only profile fields.
 - Added focused tests covering the new profile fields in:
   - `tests/test_benchmark_parity_psd_mtf.py`
   - `tests/test_benchmark_parity_acutance_quality_loss.py`
@@ -68,6 +69,8 @@ Compared with the merged `PR #66` profile:
 - `overall_quality_loss_mae_mean` is unchanged: `1.53177498 -> 1.53177498`
 
 So on the current direct-method branch, the bounded readout-policy change does not improve the lower-layer tradeoff at all. It only changes threshold extraction, and in this branch it changes it for the worse.
+
+The unchanged PSD and Acutance / Quality Loss metrics are expected here because this family only changes threshold readout policy. After the code-path fix on this branch, the benchmark still reproduces the same issue-67 conclusion: the readout settings are exercised for threshold extraction, but they do not move the underlying PSD or Acutance-side fit.
 
 ## Relation To Existing README Evidence
 

--- a/docs/issue67_readout_policy_followup.md
+++ b/docs/issue67_readout_policy_followup.md
@@ -1,0 +1,124 @@
+# Issue 67 Readout-Policy Follow-up
+
+Issue: `#67`  
+Refs: `#29`, `#67`  
+Context from: `#52`, `#53`, `#54`, `#55`, `#56`, `#57`, `#65`, `#66`
+
+## Why this pass
+
+Issue `#67` asked for one bounded readout-policy family on top of the current direct-method branch after `PR #66`.
+
+This is the cleanest last direct-method slice still explicitly named in `algo/README.md`:
+
+- the README still lists the remaining direct-method gap as `frequency mapping / ROI policy / readout policy`
+- the same README also records prior readout-policy benchmarking and warns that readout policy is not a good default repair path
+
+So this issue tests the narrowest possible readout-policy family that the repo already called out:
+
+- baseline: `readout_smoothing_window = 1`, `readout_interpolation = linear`
+- candidate: `readout_smoothing_window = 7`, `readout_interpolation = linear`
+
+No broader direct-method retuning is reopened here.
+
+## What changed
+
+- Added `readout_smoothing_window` / `readout_interpolation` profile-schema support to:
+  - `algo/benchmark_parity_psd_mtf.py`
+  - `algo/benchmark_parity_acutance_quality_loss.py`
+- Added focused tests covering the new profile fields in:
+  - `tests/test_benchmark_parity_psd_mtf.py`
+  - `tests/test_benchmark_parity_acutance_quality_loss.py`
+- Added the bounded issue-67 candidate profile:
+  - `algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_chart_prior_slope_m006_anchored_hf_psd_roi_reference_only_empirical_linearization_readout7_profile.json`
+- Added tracked benchmark artifacts:
+  - `artifacts/issue67_readout_policy_psd_benchmark.json`
+  - `artifacts/issue67_readout_policy_acutance_benchmark.json`
+
+## Candidate
+
+Baseline from `PR #66`:
+
+- current issue-65 direct-method profile
+- `readout_smoothing_window = 1`
+- `readout_interpolation = linear`
+
+Issue-67 candidate:
+
+- keeps the full `PR #66` profile fixed
+- changes only:
+  - `readout_smoothing_window = 7`
+  - `readout_interpolation = linear`
+
+This is the exact bounded readout-policy branch already highlighted in `algo/README.md`.
+
+## Result Versus PR 66
+
+This closes as a bounded negative result.
+
+Compared with the merged `PR #66` profile:
+
+- PSD `curve_mae_mean` is unchanged: `0.04982241 -> 0.04982241`
+- PSD signed-relative residual is unchanged: `0.13670371 -> 0.13670371`
+- threshold MAE gets worse across the board:
+  - `MTF20`: `0.04277803 -> 0.04351442`
+  - `MTF30`: `0.04902804 -> 0.04947438`
+  - `MTF50`: `0.02158925 -> 0.02450493`
+- Acutance `curve_mae_mean` is unchanged: `0.03189952 -> 0.03189952`
+- `acutance_focus_preset_mae_mean` is unchanged: `0.01306828 -> 0.01306828`
+- `overall_quality_loss_mae_mean` is unchanged: `1.53177498 -> 1.53177498`
+
+So on the current direct-method branch, the bounded readout-policy change does not improve the lower-layer tradeoff at all. It only changes threshold extraction, and in this branch it changes it for the worse.
+
+## Relation To Existing README Evidence
+
+The README already recorded a cautionary result on an older branch:
+
+- `window=7, interpolation=linear` slightly improved `MTF50`
+- but it also worsened `MTF20`
+
+Issue `#67` was still worth testing because that earlier evidence lived on a different direct-method surface, before the current ROI / frequency-mapping / inverse-linearization descendants.
+
+The current result is even weaker:
+
+- the same bounded readout-policy family no longer improves `MTF50`
+- it now regresses `MTF20`, `MTF30`, and `MTF50`
+- and it leaves the Acutance / Quality Loss side completely unchanged
+
+That makes the repo's prior caution stronger, not weaker.
+
+## Result Versus Umbrella Gate
+
+The umbrella README gate in `planning/workgraph.yaml` still points to `PR #30`:
+
+- `curve_mae_mean = 0.03683438`
+- `acutance_focus_preset_mae_mean = 0.04249131`
+- `overall_quality_loss_mae_mean = 1.22214341`
+- `phone_display_acutance_mae = 0.01380215`
+
+Compared with that gate, the issue-67 candidate still has:
+
+- lower Acutance-side metrics
+  - `curve_mae_mean = 0.03189952`
+  - `acutance_focus_preset_mae_mean = 0.01306828`
+  - `5.5\" Phone Display Acutance = 0.01233877`
+- but much worse overall Quality Loss:
+  - `overall_quality_loss_mae_mean = 1.53177498`
+- and a non-competitive PSD / threshold side
+
+So this readout-policy family does not move the repo closer to the canonical observable target enough to justify more work inside the current direct-method line.
+
+## Working Conclusion
+
+This issue closes the remaining explicitly named readout-policy family inside the current direct-method branch:
+
+- it is justified by existing repo evidence because `algo/README.md` names readout policy explicitly and already identifies the narrow `window=7, linear` branch
+- the issue remains bounded because it changes only the threshold readout policy and leaves ROI, frequency mapping, chart/sensor, ISP, and inverse-linearization settings fixed
+- the result is a bounded negative outcome
+
+On the current branch, readout policy is not just a weak default repair path; it is effectively exhausted as a useful bounded direct-method follow-up.
+
+## Validation
+
+- `python3 -m pytest tests/test_benchmark_parity_psd_mtf.py tests/test_benchmark_parity_acutance_quality_loss.py`
+- `python3 -m algo.benchmark_parity_psd_mtf 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_chart_prior_slope_m006_anchored_hf_psd_roi_reference_only_empirical_linearization_profile.json algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_chart_prior_slope_m006_anchored_hf_psd_roi_reference_only_empirical_linearization_readout7_profile.json --output artifacts/issue67_readout_policy_psd_benchmark.json`
+- `python3 -m algo.benchmark_parity_acutance_quality_loss 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_chart_prior_slope_m006_anchored_hf_psd_roi_reference_only_empirical_linearization_profile.json algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_chart_prior_slope_m006_anchored_hf_psd_roi_reference_only_empirical_linearization_readout7_profile.json --output artifacts/issue67_readout_policy_acutance_benchmark.json`

--- a/tests/test_benchmark_parity_acutance_quality_loss.py
+++ b/tests/test_benchmark_parity_acutance_quality_loss.py
@@ -77,6 +77,16 @@ class BenchmarkParityAcutanceQualityLossTest(unittest.TestCase):
         self.assertEqual(profile.black_percentile, 0.0)
         self.assertEqual(profile.white_percentile, 99.5)
 
+    def test_profile_allows_readout_policy_fields(self) -> None:
+        profile = Profile(
+            name="test",
+            calibration_file="algo/deadleaf_13b10_psd_calibration.json",
+            readout_smoothing_window=7,
+            readout_interpolation="linear",
+        )
+        self.assertEqual(profile.readout_smoothing_window, 7)
+        self.assertEqual(profile.readout_interpolation, "linear")
+
     def test_choose_roi_reference_refined_uses_reference_seed(self) -> None:
         image = np.zeros((20, 20), dtype=np.float32)
         reference = SimpleNamespace(lrtb=RoiBounds(left=4, right=9, top=5, bottom=10))

--- a/tests/test_benchmark_parity_acutance_quality_loss.py
+++ b/tests/test_benchmark_parity_acutance_quality_loss.py
@@ -144,6 +144,8 @@ class BenchmarkParityAcutanceQualityLossTest(unittest.TestCase):
                 calibration_file="calibration.json",
                 roi_source="reference",
                 frequency_bin_source="observable_table",
+                readout_smoothing_window=7,
+                readout_interpolation="linear",
             )
 
             with (
@@ -226,6 +228,8 @@ class BenchmarkParityAcutanceQualityLossTest(unittest.TestCase):
                 estimate_mtf.call_args.kwargs["num_bins"],
                 len(reference.frequencies_cpp),
             )
+            self.assertEqual(estimate_mtf.call_args.kwargs["readout_smoothing_window"], 7)
+            self.assertEqual(estimate_mtf.call_args.kwargs["readout_interpolation"], "linear")
 
     def test_reference_correction_curve_is_clipped(self) -> None:
         correction = derive_reference_correction_curve(

--- a/tests/test_benchmark_parity_psd_mtf.py
+++ b/tests/test_benchmark_parity_psd_mtf.py
@@ -36,6 +36,16 @@ class BenchmarkParityPsdMtfTest(unittest.TestCase):
         self.assertAlmostEqual(summary["high"]["signed_rel_mean"], -0.3)
         self.assertAlmostEqual(summary["top"]["signed_rel_mean"], -0.4)
 
+    def test_profile_allows_readout_policy_fields(self) -> None:
+        profile = Profile(
+            name="test",
+            calibration_file="algo/deadleaf_13b10_psd_calibration.json",
+            readout_smoothing_window=7,
+            readout_interpolation="linear",
+        )
+        self.assertEqual(profile.readout_smoothing_window, 7)
+        self.assertEqual(profile.readout_interpolation, "linear")
+
     def test_choose_roi_reference_refined_uses_reference_seed(self) -> None:
         image = np.zeros((20, 20), dtype=np.float32)
         reference = SimpleNamespace(lrtb=RoiBounds(left=4, right=9, top=5, bottom=10))

--- a/tests/test_benchmark_parity_psd_mtf.py
+++ b/tests/test_benchmark_parity_psd_mtf.py
@@ -87,6 +87,8 @@ class BenchmarkParityPsdMtfTest(unittest.TestCase):
                 calibration_file="calibration.json",
                 roi_source="reference",
                 frequency_bin_source="observable_table",
+                readout_smoothing_window=7,
+                readout_interpolation="linear",
             )
 
             with (
@@ -136,6 +138,8 @@ class BenchmarkParityPsdMtfTest(unittest.TestCase):
                 estimate_mtf.call_args.kwargs["num_bins"],
                 len(reference.frequencies_cpp),
             )
+            self.assertEqual(estimate_mtf.call_args.kwargs["readout_smoothing_window"], 7)
+            self.assertEqual(estimate_mtf.call_args.kwargs["readout_interpolation"], "linear")
 
     def test_capture_key_from_stem_strips_denoise_suffix(self) -> None:
         self.assertEqual(


### PR DESCRIPTION
Refs #29
Refs #67
Context from #52
Context from #53
Context from #54
Context from #55
Context from #56
Context from #57
Context from #65
Context from #66

## Summary
- add the minimum benchmark-profile schema support needed to express per-profile readout smoothing/interpolation settings
- add one bounded README-backed readout-policy candidate by keeping the PR #66 profile fixed and switching only to `readout_smoothing_window = 7`, `readout_interpolation = linear`
- add tracked PSD and Acutance/Quality Loss artifacts plus the issue-67 follow-up note

## Result
- on the current PR #66 direct-method line, the bounded readout-policy candidate is a negative result
- PSD curve MAE and signed-relative residual stay unchanged, Acutance/Quality Loss stay unchanged, and all tracked threshold MAEs regress
- unlike the older README benchmark surface, this branch does not even buy an MTF50 improvement, so the repo's caution about readout policy becomes stronger

## Validation
- python3 -m pytest tests/test_benchmark_parity_psd_mtf.py tests/test_benchmark_parity_acutance_quality_loss.py
- python3 -m algo.benchmark_parity_psd_mtf 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_chart_prior_slope_m006_anchored_hf_psd_roi_reference_only_empirical_linearization_profile.json algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_chart_prior_slope_m006_anchored_hf_psd_roi_reference_only_empirical_linearization_readout7_profile.json --output artifacts/issue67_readout_policy_psd_benchmark.json
- python3 -m algo.benchmark_parity_acutance_quality_loss 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_chart_prior_slope_m006_anchored_hf_psd_roi_reference_only_empirical_linearization_profile.json algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_chart_prior_slope_m006_anchored_hf_psd_roi_reference_only_empirical_linearization_readout7_profile.json --output artifacts/issue67_readout_policy_acutance_benchmark.json
