### PR TITLE
Issue #69: build canonical parity scoreboard

### DIFF
--- a/algo/build_canonical_parity_scoreboard.py
+++ b/algo/build_canonical_parity_scoreboard.py
@@ -1,0 +1,677 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+
+TREND_ARTIFACT_PRIORITY = (
+    "artifacts/amodel_gray_texture_series_penalty_benchmark.json",
+    "artifacts/amodel_gray_texture_benchmark.json",
+    "artifacts/amodel_gain_hypothesis_benchmark.json",
+    "artifacts/amodel_gain_trend_benchmark.json",
+)
+
+STATUS_DEFINITIONS = {
+    "parity-valid": (
+        "Still kept as a live parity candidate or retained release reference rather than only as "
+        "a diagnostic probe."
+    ),
+    "diagnostic-only": (
+        "Useful for explaining a residual or narrowing the next slice, but not kept as the "
+        "current default or a release-safe replacement."
+    ),
+    "archived / exhausted": (
+        "Closed bounded negative or legacy-only line; kept for historical comparison but not for "
+        "further direct follow-up on the current surface."
+    ),
+}
+
+
+@dataclass(frozen=True)
+class ReleaseFamilySpec:
+    family_id: str
+    label: str
+    profile_path: str
+    status: str
+    status_reason: str
+    doc_paths: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class DirectMethodSpec:
+    family_id: str
+    label: str
+    status: str
+    status_reason: str
+    doc_paths: tuple[str, ...]
+    psd_artifact_path: str
+    acutance_artifact_path: str
+
+
+RELEASE_FAMILIES = (
+    ReleaseFamilySpec(
+        family_id="release_parity_fit",
+        label="release/parity_fit",
+        profile_path="release/deadleaf_13b10_release/config/parity_fit_profile.release.json",
+        status="parity-valid",
+        status_reason="Current release default and primary target profile.",
+        doc_paths=("release/deadleaf_13b10_release/README.md",),
+    ),
+    ReleaseFamilySpec(
+        family_id="release_recommended",
+        label="release/recommended",
+        profile_path="release/deadleaf_13b10_release/config/recommended_profile.release.json",
+        status="parity-valid",
+        status_reason=(
+            "Retained split-workaround parity reference; no longer primary, but still an active "
+            "comparison line rather than a pure diagnostic control."
+        ),
+        doc_paths=(
+            "release/deadleaf_13b10_release/README.md",
+            "docs/parity_acutance_quality_loss_validation.md",
+        ),
+    ),
+    ReleaseFamilySpec(
+        family_id="release_experimental_shape",
+        label="release/experimental_shape",
+        profile_path="release/deadleaf_13b10_release/config/experimental_shape_profile.release.json",
+        status="diagnostic-only",
+        status_reason="Current experiment reference for trend mismatch, not a shipped default.",
+        doc_paths=(
+            "docs/amodel_gain_trend_experiment.md",
+            "docs/amodel_gray_texture_series_penalty_followup.md",
+        ),
+    ),
+    ReleaseFamilySpec(
+        family_id="release_imatest_parity",
+        label="release/imatest_parity",
+        profile_path="release/deadleaf_13b10_release/config/imatest_parity_profile.release.json",
+        status="diagnostic-only",
+        status_reason="README marks this literal-gamma route as a reference-only hypothesis.",
+        doc_paths=("release/deadleaf_13b10_release/README.md",),
+    ),
+    ReleaseFamilySpec(
+        family_id="release_imatest_parity_sensor_comp",
+        label="release/imatest_parity_sensor_comp",
+        profile_path="release/deadleaf_13b10_release/config/imatest_parity_sensor_comp_profile.release.json",
+        status="diagnostic-only",
+        status_reason="README marks this literal-parity plus sensor-comp line as reference-only.",
+        doc_paths=("release/deadleaf_13b10_release/README.md",),
+    ),
+    ReleaseFamilySpec(
+        family_id="release_imatest_parity_sensor_comp_toe",
+        label="release/imatest_parity_sensor_comp_toe",
+        profile_path="release/deadleaf_13b10_release/config/imatest_parity_sensor_comp_toe_profile.release.json",
+        status="diagnostic-only",
+        status_reason="README marks this literal-parity plus sensor-comp plus toe line as reference-only.",
+        doc_paths=("release/deadleaf_13b10_release/README.md",),
+    ),
+    ReleaseFamilySpec(
+        family_id="release_parity_gain_noise",
+        label="release/parity_gain_noise",
+        profile_path="release/deadleaf_13b10_release/config/parity_gain_noise_profile.release.json",
+        status="diagnostic-only",
+        status_reason="Gain-noise hypothesis trims delta error slightly but does not fix trend direction.",
+        doc_paths=("docs/amodel_gain_hypothesis_followup.md",),
+    ),
+    ReleaseFamilySpec(
+        family_id="release_parity_gain_shape",
+        label="release/parity_gain_shape",
+        profile_path="release/deadleaf_13b10_release/config/parity_gain_shape_profile.release.json",
+        status="diagnostic-only",
+        status_reason="Gain-shape hypothesis remains inconclusive and is not strong enough for promotion.",
+        doc_paths=(
+            "docs/amodel_gain_hypothesis_followup.md",
+            "docs/amodel_gray_texture_followup.md",
+        ),
+    ),
+    ReleaseFamilySpec(
+        family_id="release_parity_gray_shape",
+        label="release/parity_gray_shape",
+        profile_path="release/deadleaf_13b10_release/config/parity_gray_shape_profile.release.json",
+        status="diagnostic-only",
+        status_reason="Gray-only factor isolate improves delta magnitude but not direction-match count.",
+        doc_paths=("docs/amodel_gray_texture_followup.md",),
+    ),
+    ReleaseFamilySpec(
+        family_id="release_parity_texture_shape",
+        label="release/parity_texture_shape",
+        profile_path="release/deadleaf_13b10_release/config/parity_texture_shape_profile.release.json",
+        status="diagnostic-only",
+        status_reason="Texture-support-only isolate leaves trend direction unresolved and inflates series error.",
+        doc_paths=("docs/amodel_gray_texture_followup.md",),
+    ),
+    ReleaseFamilySpec(
+        family_id="release_parity_gray_texture_shape",
+        label="release/parity_gray_texture_shape",
+        profile_path="release/deadleaf_13b10_release/config/parity_gray_texture_shape_profile.release.json",
+        status="diagnostic-only",
+        status_reason="Best explanatory gray-plus-texture trend branch, but still experiment-only because series MAE is too high.",
+        doc_paths=(
+            "docs/amodel_gray_texture_followup.md",
+            "docs/amodel_gray_texture_series_penalty_followup.md",
+        ),
+    ),
+    ReleaseFamilySpec(
+        family_id="release_parity_gray_texture_shape_freq110",
+        label="release/parity_gray_texture_shape_freq110",
+        profile_path="release/deadleaf_13b10_release/config/parity_gray_texture_shape_freq110_profile.release.json",
+        status="diagnostic-only",
+        status_reason="Narrowed experiment-only gray-plus-texture variant; still not the preferred tradeoff.",
+        doc_paths=("docs/amodel_gray_texture_series_penalty_followup.md",),
+    ),
+    ReleaseFamilySpec(
+        family_id="release_parity_gray_texture_shape_freq105",
+        label="release/parity_gray_texture_shape_freq105",
+        profile_path="release/deadleaf_13b10_release/config/parity_gray_texture_shape_freq105_profile.release.json",
+        status="diagnostic-only",
+        status_reason="Current best gray-plus-texture compromise, but still experiment-only pending release-facing validation.",
+        doc_paths=("docs/amodel_gray_texture_series_penalty_followup.md",),
+    ),
+    ReleaseFamilySpec(
+        family_id="release_parity_gray_texture_shape_nofreq",
+        label="release/parity_gray_texture_shape_nofreq",
+        profile_path="release/deadleaf_13b10_release/config/parity_gray_texture_shape_nofreq_profile.release.json",
+        status="diagnostic-only",
+        status_reason="Useful narrowed control inside the gray-plus-texture family, not a promoted release path.",
+        doc_paths=("docs/amodel_gray_texture_series_penalty_followup.md",),
+    ),
+    ReleaseFamilySpec(
+        family_id="release_legacy_linear",
+        label="release/legacy_linear",
+        profile_path="release/deadleaf_13b10_release/config/legacy_linear_profile.release.json",
+        status="archived / exhausted",
+        status_reason="Legacy comparison baseline retained only for historical contrast.",
+        doc_paths=("release/deadleaf_13b10_release/README.md",),
+    ),
+)
+
+
+DIRECT_METHOD_FAMILIES = (
+    DirectMethodSpec(
+        family_id="direct_issue29_anchored_hf_psd",
+        label="direct/issue29_anchored_hf_psd",
+        status="parity-valid",
+        status_reason=(
+            "Small but real source-backed lower-layer improvement that stayed downstream-safe "
+            "enough to keep as a tracked candidate."
+        ),
+        doc_paths=("docs/issue29_anchored_high_frequency_psd_followup.md",),
+        psd_artifact_path="artifacts/issue29_anchored_high_frequency_psd_benchmark.json",
+        acutance_artifact_path="artifacts/issue29_anchored_high_frequency_acutance_benchmark.json",
+    ),
+    DirectMethodSpec(
+        family_id="direct_issue52_roi_reference",
+        label="direct/issue52_roi_reference",
+        status="diagnostic-only",
+        status_reason="Clear lower-layer win, but Quality Loss regressed too much for adoption.",
+        doc_paths=("docs/issue52_direct_roi_reference_followup.md",),
+        psd_artifact_path="artifacts/issue52_roi_reference_psd_benchmark.json",
+        acutance_artifact_path="artifacts/issue52_roi_reference_acutance_benchmark.json",
+    ),
+    DirectMethodSpec(
+        family_id="direct_issue54_observable_bins",
+        label="direct/issue54_observable_bins",
+        status="archived / exhausted",
+        status_reason="Closed frequency-bin branch; static inferred bins remained the better default on this dataset.",
+        doc_paths=("docs/issue54_observable_frequency_bins_followup.md",),
+        psd_artifact_path="artifacts/issue54_observable_frequency_bins_psd_benchmark.json",
+        acutance_artifact_path="artifacts/issue54_observable_frequency_bins_acutance_benchmark.json",
+    ),
+    DirectMethodSpec(
+        family_id="direct_issue56_empirical_frequency_scale",
+        label="direct/issue56_empirical_frequency_scale",
+        status="archived / exhausted",
+        status_reason="Closed empirical frequency-scale line; threshold-only gain did not transfer to the full parity objective.",
+        doc_paths=("docs/issue56_empirical_frequency_scale_followup.md",),
+        psd_artifact_path="artifacts/issue56_empirical_frequency_scale_psd_benchmark.json",
+        acutance_artifact_path="artifacts/issue56_empirical_frequency_scale_acutance_benchmark.json",
+    ),
+    DirectMethodSpec(
+        family_id="direct_issue58_chart_sensor_comp",
+        label="direct/issue58_chart_sensor_comp",
+        status="diagnostic-only",
+        status_reason="Healthier than the older chart/sensor branch, but still not strong enough to replace the default line.",
+        doc_paths=("docs/issue58_chart_sensor_compensation_followup.md",),
+        psd_artifact_path="artifacts/issue58_chart_sensor_compensation_psd_benchmark.json",
+        acutance_artifact_path="artifacts/issue58_chart_sensor_compensation_acutance_benchmark.json",
+    ),
+    DirectMethodSpec(
+        family_id="direct_issue61_isp_family",
+        label="direct/issue61_isp_family",
+        status="diagnostic-only",
+        status_reason="Useful source-backed negative showing the remaining gap is not solved by the bounded ISP proxy alone.",
+        doc_paths=("docs/issue61_isp_family_followup.md",),
+        psd_artifact_path="artifacts/issue61_isp_family_psd_benchmark.json",
+        acutance_artifact_path="artifacts/issue61_isp_family_acutance_benchmark.json",
+    ),
+    DirectMethodSpec(
+        family_id="direct_issue63_empirical_linearization",
+        label="direct/issue63_empirical_linearization",
+        status="diagnostic-only",
+        status_reason="Important mixed branch: Acutance improved sharply, but PSD and Quality Loss stayed too weak for promotion.",
+        doc_paths=("docs/issue63_empirical_linearization_followup.md",),
+        psd_artifact_path="artifacts/issue63_empirical_linearization_psd_benchmark.json",
+        acutance_artifact_path="artifacts/issue63_empirical_linearization_acutance_benchmark.json",
+    ),
+    DirectMethodSpec(
+        family_id="direct_issue65_chart_prior_inverse_linearization",
+        label="direct/issue65_chart_prior_inverse_linearization",
+        status="archived / exhausted",
+        status_reason="Explicit bounded negative refinement of the issue-63 branch.",
+        doc_paths=("docs/issue65_chart_prior_inverse_linearization_followup.md",),
+        psd_artifact_path="artifacts/issue65_chart_prior_inverse_linearization_psd_benchmark.json",
+        acutance_artifact_path="artifacts/issue65_chart_prior_inverse_linearization_acutance_benchmark.json",
+    ),
+    DirectMethodSpec(
+        family_id="direct_issue67_readout_policy",
+        label="direct/issue67_readout_policy",
+        status="archived / exhausted",
+        status_reason="Explicitly exhausted readout-policy family after the bounded negative re-check.",
+        doc_paths=("docs/issue67_readout_policy_followup.md",),
+        psd_artifact_path="artifacts/issue67_readout_policy_psd_benchmark.json",
+        acutance_artifact_path="artifacts/issue67_readout_policy_acutance_benchmark.json",
+    ),
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build the canonical parity scoreboard from tracked artifacts."
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Repository root. Defaults to the parent of this script.",
+    )
+    parser.add_argument(
+        "--output-json",
+        type=Path,
+        default=Path("artifacts/canonical_parity_scoreboard.json"),
+        help="Repo-relative output path for the machine-readable scoreboard.",
+    )
+    parser.add_argument(
+        "--output-md",
+        type=Path,
+        default=Path("docs/canonical_parity_scoreboard.md"),
+        help="Repo-relative output path for the Markdown scoreboard.",
+    )
+    return parser
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def relative_path(path: Path, repo_root: Path) -> str:
+    return str(path.resolve().relative_to(repo_root.resolve()))
+
+
+def iter_trend_entries(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    if "profiles" in payload:
+        return list(payload["profiles"])
+    entries: list[dict[str, Any]] = []
+    baseline = payload.get("baseline")
+    if isinstance(baseline, dict):
+        entries.append(baseline)
+    hypotheses = payload.get("hypotheses")
+    if isinstance(hypotheses, list):
+        entries.extend(entry for entry in hypotheses if isinstance(entry, dict))
+    return entries
+
+
+def build_trend_index(repo_root: Path) -> dict[str, dict[str, Any]]:
+    index: dict[str, dict[str, Any]] = {}
+    for artifact_path in TREND_ARTIFACT_PRIORITY:
+        payload = load_json(repo_root / artifact_path)
+        for entry in iter_trend_entries(payload):
+            profile_name = Path(entry["profile_path"]).name
+            if profile_name in index:
+                continue
+            index[profile_name] = {
+                "artifact_path": artifact_path,
+                "profile_path": entry["profile_path"],
+                "summary": entry["summary"],
+            }
+    return index
+
+
+def build_trend_metrics(
+    trend_index: dict[str, dict[str, Any]],
+    profile_name: str,
+) -> tuple[dict[str, Any], list[str]]:
+    trend_entry = trend_index.get(profile_name)
+    if trend_entry is None:
+        return (
+            {
+                "trend_direction_match_rate": None,
+                "trend_direction_match_count": None,
+                "trend_direction_group_count": None,
+                "gain_trend_series_shape_error": None,
+                "gain_trend_delta_mae_mean": None,
+            },
+            [],
+        )
+
+    summary = trend_entry["summary"]
+    match_count = int(summary["focus_preset_direction_match_count"])
+    group_count = int(summary["focus_preset_direction_group_count"])
+    match_rate = None
+    if group_count:
+        match_rate = match_count / group_count
+    return (
+        {
+            "trend_direction_match_rate": match_rate,
+            "trend_direction_match_count": match_count,
+            "trend_direction_group_count": group_count,
+            "gain_trend_series_shape_error": float(summary["focus_preset_series_mae_mean"]),
+            "gain_trend_delta_mae_mean": float(summary["focus_preset_gain_delta_mae_mean"]),
+        },
+        [trend_entry["artifact_path"]],
+    )
+
+
+def build_release_row(
+    spec: ReleaseFamilySpec,
+    repo_root: Path,
+    trend_index: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    profile_name = Path(spec.profile_path).name
+    trend_metrics, trend_artifacts = build_trend_metrics(trend_index, profile_name)
+    profile_path = repo_root / spec.profile_path
+    return {
+        "family_id": spec.family_id,
+        "label": spec.label,
+        "family_type": "release_profile",
+        "status": spec.status,
+        "status_reason": spec.status_reason,
+        "trend_coverage": any(
+            trend_metrics[key] is not None
+            for key in (
+                "trend_direction_match_rate",
+                "gain_trend_series_shape_error",
+            )
+        ),
+        "dead_leaves_coverage": False,
+        **trend_metrics,
+        "curve_mae_mean": None,
+        "focus_preset_acutance_mae_mean": None,
+        "overall_quality_loss_mae_mean": None,
+        "mtf_threshold_mae": {
+            "mtf20": None,
+            "mtf30": None,
+            "mtf50": None,
+        },
+        "acutance_preset_mae": {
+            '5.5" Phone Display Acutance': None,
+            "Computer Monitor Acutance": None,
+            "UHDTV Display Acutance": None,
+            "Small Print Acutance": None,
+            "Large Print Acutance": None,
+        },
+        "quality_loss_preset_mae": {},
+        "sources": {
+            "primary_path": relative_path(profile_path, repo_root),
+            "doc_paths": list(spec.doc_paths),
+            "artifact_paths": trend_artifacts,
+        },
+    }
+
+
+def build_direct_method_row(spec: DirectMethodSpec, repo_root: Path) -> dict[str, Any]:
+    psd_payload = load_json(repo_root / spec.psd_artifact_path)
+    acutance_payload = load_json(repo_root / spec.acutance_artifact_path)
+    psd_profile = psd_payload["profiles"][-1]
+    acutance_profile = acutance_payload["profiles"][-1]
+    profile_path = str(acutance_profile["profile_path"])
+    return {
+        "family_id": spec.family_id,
+        "label": spec.label,
+        "family_type": "direct_method_branch",
+        "status": spec.status,
+        "status_reason": spec.status_reason,
+        "trend_coverage": False,
+        "dead_leaves_coverage": True,
+        "trend_direction_match_rate": None,
+        "trend_direction_match_count": None,
+        "trend_direction_group_count": None,
+        "gain_trend_series_shape_error": None,
+        "gain_trend_delta_mae_mean": None,
+        "curve_mae_mean": float(acutance_profile["overall"]["curve_mae_mean"]),
+        "focus_preset_acutance_mae_mean": float(
+            acutance_profile["overall"]["acutance_focus_preset_mae_mean"]
+        ),
+        "overall_quality_loss_mae_mean": float(
+            acutance_profile["overall"]["overall_quality_loss_mae_mean"]
+        ),
+        "mtf_threshold_mae": {
+            key: float(value)
+            for key, value in psd_profile["overall"]["mtf_threshold_mae"].items()
+        },
+        "acutance_preset_mae": {
+            key: float(value)
+            for key, value in acutance_profile["overall"]["acutance_preset_mae"].items()
+        },
+        "quality_loss_preset_mae": {
+            key: float(value)
+            for key, value in acutance_profile["overall"]["quality_loss_preset_mae"].items()
+        },
+        "sources": {
+            "primary_path": profile_path,
+            "doc_paths": list(spec.doc_paths),
+            "artifact_paths": [
+                spec.psd_artifact_path,
+                spec.acutance_artifact_path,
+            ],
+        },
+    }
+
+
+def sort_key(row: dict[str, Any]) -> tuple[Any, ...]:
+    trend_rate = row["trend_direction_match_rate"]
+    trend_error = row["gain_trend_series_shape_error"]
+    curve_mae = row["curve_mae_mean"]
+    focus_mae = row["focus_preset_acutance_mae_mean"]
+    return (
+        0 if trend_rate is not None else 1,
+        -(trend_rate if trend_rate is not None else -1.0),
+        trend_error if trend_error is not None else math.inf,
+        curve_mae if curve_mae is not None else math.inf,
+        focus_mae if focus_mae is not None else math.inf,
+        row["label"],
+    )
+
+
+def build_scoreboard(repo_root: Path) -> dict[str, Any]:
+    trend_index = build_trend_index(repo_root)
+    rows = [
+        *(build_release_row(spec, repo_root, trend_index) for spec in RELEASE_FAMILIES),
+        *(build_direct_method_row(spec, repo_root) for spec in DIRECT_METHOD_FAMILIES),
+    ]
+    ordered_rows = sorted(rows, key=sort_key)
+    for rank, row in enumerate(ordered_rows, start=1):
+        row["rank"] = rank
+    return {
+        "scoreboard_version": 1,
+        "ranking_policy": {
+            "primary": "trend_direction_match_rate desc",
+            "trend_tiebreaker": "gain_trend_series_shape_error asc",
+            "secondary": "curve_mae_mean asc",
+            "tertiary": "focus_preset_acutance_mae_mean asc",
+            "missing_value_policy": (
+                "Rows without tracked trend coverage sort after rows with trend coverage. "
+                "Rows without tracked dead-leaves parity coverage keep null parity fields."
+            ),
+        },
+        "status_definitions": STATUS_DEFINITIONS,
+        "rows": ordered_rows,
+    }
+
+
+def format_value(value: float | None, *, digits: int = 5) -> str:
+    if value is None:
+        return "-"
+    return f"{value:.{digits}f}"
+
+
+def format_rate(row: dict[str, Any]) -> str:
+    count = row["trend_direction_match_count"]
+    total = row["trend_direction_group_count"]
+    rate = row["trend_direction_match_rate"]
+    if count is None or total is None or rate is None:
+        return "-"
+    return f"{count}/{total} ({rate:.3f})"
+
+
+def format_source(row: dict[str, Any]) -> str:
+    artifact_paths = row["sources"]["artifact_paths"]
+    if not artifact_paths:
+        return row["sources"]["primary_path"]
+    artifact_names = ", ".join(Path(path).name for path in artifact_paths)
+    return f"{row['sources']['primary_path']} [{artifact_names}]"
+
+
+def render_markdown(scoreboard: dict[str, Any]) -> str:
+    rows = scoreboard["rows"]
+    lines = [
+        "# Canonical Parity Scoreboard",
+        "",
+        "This scoreboard is the repo-local decision surface requested by issue `#69`.",
+        "",
+        "Ranking policy:",
+        "",
+        "1. `trend direction match rate` descending",
+        "2. `gain-trend series shape error` ascending as the trend tie-breaker",
+        "3. `curve_mae_mean` ascending",
+        "4. `focus preset acutance mae mean` ascending",
+        "",
+        "Coverage note:",
+        "",
+        "- release-profile rows carry tracked A-model trend metrics when the repo has a checked-in gain-trend benchmark for that exact release config.",
+        "- direct-method rows carry tracked dead-leaves parity metrics from the issue artifacts; these rows currently have no exact checked-in A-model trend benchmark on the same profile path, so trend fields remain `-`.",
+        "",
+        "| Rank | Family | Type | Status | Trend match | Series err | Curve MAE | Focus Acu MAE | Phone A | Monitor A | UHDTV A | Small Print A | Large Print A | MTF20 | MTF30 | MTF50 | Overall QL | Source |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for row in rows:
+        presets = row["acutance_preset_mae"]
+        mtf = row["mtf_threshold_mae"]
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    str(row["rank"]),
+                    row["label"],
+                    row["family_type"],
+                    row["status"],
+                    format_rate(row),
+                    format_value(row["gain_trend_series_shape_error"]),
+                    format_value(row["curve_mae_mean"]),
+                    format_value(row["focus_preset_acutance_mae_mean"]),
+                    format_value(presets['5.5" Phone Display Acutance']),
+                    format_value(presets["Computer Monitor Acutance"]),
+                    format_value(presets["UHDTV Display Acutance"]),
+                    format_value(presets["Small Print Acutance"]),
+                    format_value(presets["Large Print Acutance"]),
+                    format_value(mtf["mtf20"]),
+                    format_value(mtf["mtf30"]),
+                    format_value(mtf["mtf50"]),
+                    format_value(row["overall_quality_loss_mae_mean"]),
+                    format_source(row),
+                ]
+            )
+            + " |"
+        )
+
+    top_trend_row = next((row for row in rows if row["trend_coverage"]), None)
+    top_direct_row = next((row for row in rows if row["family_type"] == "direct_method_branch"), None)
+    top_parity_valid_direct_row = next(
+        (
+            row
+            for row in rows
+            if row["family_type"] == "direct_method_branch" and row["status"] == "parity-valid"
+        ),
+        None,
+    )
+    exhausted_rows = [row["label"] for row in rows if row["status"] == "archived / exhausted"]
+
+    lines.extend(
+        [
+            "",
+            "## Current Readout",
+            "",
+            (
+                f"- Top tracked trend row: `{top_trend_row['label']}` with "
+                f"`{format_rate(top_trend_row)}` and series error "
+                f"`{format_value(top_trend_row['gain_trend_series_shape_error'])}`; "
+                f"status = `{top_trend_row['status']}`."
+                if top_trend_row is not None
+                else "- No tracked trend rows were found."
+            ),
+            (
+                f"- Top tracked direct-method row by the fixed sort: `{top_direct_row['label']}` with "
+                f"`curve_mae_mean = {format_value(top_direct_row['curve_mae_mean'])}` and "
+                f"`overall_quality_loss_mae_mean = {format_value(top_direct_row['overall_quality_loss_mae_mean'])}`; "
+                f"status = `{top_direct_row['status']}`."
+                if top_direct_row is not None
+                else "- No tracked direct-method rows were found."
+            ),
+            (
+                f"- Best still-parity-valid direct-method row: `{top_parity_valid_direct_row['label']}` with "
+                f"`curve_mae_mean = {format_value(top_parity_valid_direct_row['curve_mae_mean'])}` and "
+                f"`overall_quality_loss_mae_mean = {format_value(top_parity_valid_direct_row['overall_quality_loss_mae_mean'])}`."
+                if top_parity_valid_direct_row is not None
+                else "- No parity-valid direct-method rows are currently tracked."
+            ),
+            (
+                "- Explicit archived / exhausted lines in the current scoreboard: "
+                + ", ".join(f"`{label}`" for label in exhausted_rows)
+                + "."
+                if exhausted_rows
+                else "- No archived / exhausted lines are currently marked."
+            ),
+            "",
+            "The machine-readable companion artifact at "
+            "`artifacts/canonical_parity_scoreboard.json` keeps the full status reasons, "
+            "per-preset values, and provenance paths for later issues to cite directly.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_outputs(
+    scoreboard: dict[str, Any],
+    *,
+    repo_root: Path,
+    output_json: Path,
+    output_md: Path,
+) -> None:
+    json_path = output_json if output_json.is_absolute() else repo_root / output_json
+    md_path = output_md if output_md.is_absolute() else repo_root / output_md
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+    md_path.parent.mkdir(parents=True, exist_ok=True)
+    json_path.write_text(json.dumps(scoreboard, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    md_path.write_text(render_markdown(scoreboard), encoding="utf-8")
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    repo_root = args.repo_root.resolve()
+    scoreboard = build_scoreboard(repo_root)
+    write_outputs(
+        scoreboard,
+        repo_root=repo_root,
+        output_json=args.output_json,
+        output_md=args.output_md,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/artifacts/canonical_parity_scoreboard.json
+++ b/artifacts/canonical_parity_scoreboard.json
@@ -1,0 +1,1038 @@
+{
+  "ranking_policy": {
+    "missing_value_policy": "Rows without tracked trend coverage sort after rows with trend coverage. Rows without tracked dead-leaves parity coverage keep null parity fields.",
+    "primary": "trend_direction_match_rate desc",
+    "secondary": "curve_mae_mean asc",
+    "tertiary": "focus_preset_acutance_mae_mean asc",
+    "trend_tiebreaker": "gain_trend_series_shape_error asc"
+  },
+  "rows": [
+    {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": null,
+        "Computer Monitor Acutance": null,
+        "Large Print Acutance": null,
+        "Small Print Acutance": null,
+        "UHDTV Display Acutance": null
+      },
+      "curve_mae_mean": null,
+      "dead_leaves_coverage": false,
+      "family_id": "release_imatest_parity",
+      "family_type": "release_profile",
+      "focus_preset_acutance_mae_mean": null,
+      "gain_trend_delta_mae_mean": 0.06870956775010477,
+      "gain_trend_series_shape_error": 0.05837536063942883,
+      "label": "release/imatest_parity",
+      "mtf_threshold_mae": {
+        "mtf20": null,
+        "mtf30": null,
+        "mtf50": null
+      },
+      "overall_quality_loss_mae_mean": null,
+      "quality_loss_preset_mae": {},
+      "rank": 1,
+      "sources": {
+        "artifact_paths": [
+          "artifacts/amodel_gain_trend_benchmark.json"
+        ],
+        "doc_paths": [
+          "release/deadleaf_13b10_release/README.md"
+        ],
+        "primary_path": "release/deadleaf_13b10_release/config/imatest_parity_profile.release.json"
+      },
+      "status": "diagnostic-only",
+      "status_reason": "README marks this literal-gamma route as a reference-only hypothesis.",
+      "trend_coverage": true,
+      "trend_direction_group_count": 20,
+      "trend_direction_match_count": 16,
+      "trend_direction_match_rate": 0.8
+    },
+    {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": null,
+        "Computer Monitor Acutance": null,
+        "Large Print Acutance": null,
+        "Small Print Acutance": null,
+        "UHDTV Display Acutance": null
+      },
+      "curve_mae_mean": null,
+      "dead_leaves_coverage": false,
+      "family_id": "release_parity_gray_texture_shape",
+      "family_type": "release_profile",
+      "focus_preset_acutance_mae_mean": null,
+      "gain_trend_delta_mae_mean": 0.0050580877970985896,
+      "gain_trend_series_shape_error": 0.06772595724030461,
+      "label": "release/parity_gray_texture_shape",
+      "mtf_threshold_mae": {
+        "mtf20": null,
+        "mtf30": null,
+        "mtf50": null
+      },
+      "overall_quality_loss_mae_mean": null,
+      "quality_loss_preset_mae": {},
+      "rank": 2,
+      "sources": {
+        "artifact_paths": [
+          "artifacts/amodel_gray_texture_series_penalty_benchmark.json"
+        ],
+        "doc_paths": [
+          "docs/amodel_gray_texture_followup.md",
+          "docs/amodel_gray_texture_series_penalty_followup.md"
+        ],
+        "primary_path": "release/deadleaf_13b10_release/config/parity_gray_texture_shape_profile.release.json"
+      },
+      "status": "diagnostic-only",
+      "status_reason": "Best explanatory gray-plus-texture trend branch, but still experiment-only because series MAE is too high.",
+      "trend_coverage": true,
+      "trend_direction_group_count": 20,
+      "trend_direction_match_count": 16,
+      "trend_direction_match_rate": 0.8
+    },
+    {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": null,
+        "Computer Monitor Acutance": null,
+        "Large Print Acutance": null,
+        "Small Print Acutance": null,
+        "UHDTV Display Acutance": null
+      },
+      "curve_mae_mean": null,
+      "dead_leaves_coverage": false,
+      "family_id": "release_parity_gray_texture_shape_freq105",
+      "family_type": "release_profile",
+      "focus_preset_acutance_mae_mean": null,
+      "gain_trend_delta_mae_mean": 0.007121980812272152,
+      "gain_trend_series_shape_error": 0.033400791758490575,
+      "label": "release/parity_gray_texture_shape_freq105",
+      "mtf_threshold_mae": {
+        "mtf20": null,
+        "mtf30": null,
+        "mtf50": null
+      },
+      "overall_quality_loss_mae_mean": null,
+      "quality_loss_preset_mae": {},
+      "rank": 3,
+      "sources": {
+        "artifact_paths": [
+          "artifacts/amodel_gray_texture_series_penalty_benchmark.json"
+        ],
+        "doc_paths": [
+          "docs/amodel_gray_texture_series_penalty_followup.md"
+        ],
+        "primary_path": "release/deadleaf_13b10_release/config/parity_gray_texture_shape_freq105_profile.release.json"
+      },
+      "status": "diagnostic-only",
+      "status_reason": "Current best gray-plus-texture compromise, but still experiment-only pending release-facing validation.",
+      "trend_coverage": true,
+      "trend_direction_group_count": 20,
+      "trend_direction_match_count": 14,
+      "trend_direction_match_rate": 0.7
+    },
+    {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": null,
+        "Computer Monitor Acutance": null,
+        "Large Print Acutance": null,
+        "Small Print Acutance": null,
+        "UHDTV Display Acutance": null
+      },
+      "curve_mae_mean": null,
+      "dead_leaves_coverage": false,
+      "family_id": "release_parity_gray_texture_shape_freq110",
+      "family_type": "release_profile",
+      "focus_preset_acutance_mae_mean": null,
+      "gain_trend_delta_mae_mean": 0.006528946201597688,
+      "gain_trend_series_shape_error": 0.04817592512793509,
+      "label": "release/parity_gray_texture_shape_freq110",
+      "mtf_threshold_mae": {
+        "mtf20": null,
+        "mtf30": null,
+        "mtf50": null
+      },
+      "overall_quality_loss_mae_mean": null,
+      "quality_loss_preset_mae": {},
+      "rank": 4,
+      "sources": {
+        "artifact_paths": [
+          "artifacts/amodel_gray_texture_series_penalty_benchmark.json"
+        ],
+        "doc_paths": [
+          "docs/amodel_gray_texture_series_penalty_followup.md"
+        ],
+        "primary_path": "release/deadleaf_13b10_release/config/parity_gray_texture_shape_freq110_profile.release.json"
+      },
+      "status": "diagnostic-only",
+      "status_reason": "Narrowed experiment-only gray-plus-texture variant; still not the preferred tradeoff.",
+      "trend_coverage": true,
+      "trend_direction_group_count": 20,
+      "trend_direction_match_count": 14,
+      "trend_direction_match_rate": 0.7
+    },
+    {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": null,
+        "Computer Monitor Acutance": null,
+        "Large Print Acutance": null,
+        "Small Print Acutance": null,
+        "UHDTV Display Acutance": null
+      },
+      "curve_mae_mean": null,
+      "dead_leaves_coverage": false,
+      "family_id": "release_parity_gray_texture_shape_nofreq",
+      "family_type": "release_profile",
+      "focus_preset_acutance_mae_mean": null,
+      "gain_trend_delta_mae_mean": 0.00791616394778347,
+      "gain_trend_series_shape_error": 0.024104731516268456,
+      "label": "release/parity_gray_texture_shape_nofreq",
+      "mtf_threshold_mae": {
+        "mtf20": null,
+        "mtf30": null,
+        "mtf50": null
+      },
+      "overall_quality_loss_mae_mean": null,
+      "quality_loss_preset_mae": {},
+      "rank": 5,
+      "sources": {
+        "artifact_paths": [
+          "artifacts/amodel_gray_texture_series_penalty_benchmark.json"
+        ],
+        "doc_paths": [
+          "docs/amodel_gray_texture_series_penalty_followup.md"
+        ],
+        "primary_path": "release/deadleaf_13b10_release/config/parity_gray_texture_shape_nofreq_profile.release.json"
+      },
+      "status": "diagnostic-only",
+      "status_reason": "Useful narrowed control inside the gray-plus-texture family, not a promoted release path.",
+      "trend_coverage": true,
+      "trend_direction_group_count": 20,
+      "trend_direction_match_count": 13,
+      "trend_direction_match_rate": 0.65
+    },
+    {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": null,
+        "Computer Monitor Acutance": null,
+        "Large Print Acutance": null,
+        "Small Print Acutance": null,
+        "UHDTV Display Acutance": null
+      },
+      "curve_mae_mean": null,
+      "dead_leaves_coverage": false,
+      "family_id": "release_experimental_shape",
+      "family_type": "release_profile",
+      "focus_preset_acutance_mae_mean": null,
+      "gain_trend_delta_mae_mean": 0.00787786012495714,
+      "gain_trend_series_shape_error": 0.030057989404713624,
+      "label": "release/experimental_shape",
+      "mtf_threshold_mae": {
+        "mtf20": null,
+        "mtf30": null,
+        "mtf50": null
+      },
+      "overall_quality_loss_mae_mean": null,
+      "quality_loss_preset_mae": {},
+      "rank": 6,
+      "sources": {
+        "artifact_paths": [
+          "artifacts/amodel_gray_texture_series_penalty_benchmark.json"
+        ],
+        "doc_paths": [
+          "docs/amodel_gain_trend_experiment.md",
+          "docs/amodel_gray_texture_series_penalty_followup.md"
+        ],
+        "primary_path": "release/deadleaf_13b10_release/config/experimental_shape_profile.release.json"
+      },
+      "status": "diagnostic-only",
+      "status_reason": "Current experiment reference for trend mismatch, not a shipped default.",
+      "trend_coverage": true,
+      "trend_direction_group_count": 20,
+      "trend_direction_match_count": 13,
+      "trend_direction_match_rate": 0.65
+    },
+    {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": null,
+        "Computer Monitor Acutance": null,
+        "Large Print Acutance": null,
+        "Small Print Acutance": null,
+        "UHDTV Display Acutance": null
+      },
+      "curve_mae_mean": null,
+      "dead_leaves_coverage": false,
+      "family_id": "release_parity_gain_noise",
+      "family_type": "release_profile",
+      "focus_preset_acutance_mae_mean": null,
+      "gain_trend_delta_mae_mean": 0.015633658156600415,
+      "gain_trend_series_shape_error": 0.018044548678085155,
+      "label": "release/parity_gain_noise",
+      "mtf_threshold_mae": {
+        "mtf20": null,
+        "mtf30": null,
+        "mtf50": null
+      },
+      "overall_quality_loss_mae_mean": null,
+      "quality_loss_preset_mae": {},
+      "rank": 7,
+      "sources": {
+        "artifact_paths": [
+          "artifacts/amodel_gain_hypothesis_benchmark.json"
+        ],
+        "doc_paths": [
+          "docs/amodel_gain_hypothesis_followup.md"
+        ],
+        "primary_path": "release/deadleaf_13b10_release/config/parity_gain_noise_profile.release.json"
+      },
+      "status": "diagnostic-only",
+      "status_reason": "Gain-noise hypothesis trims delta error slightly but does not fix trend direction.",
+      "trend_coverage": true,
+      "trend_direction_group_count": 20,
+      "trend_direction_match_count": 3,
+      "trend_direction_match_rate": 0.15
+    },
+    {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": null,
+        "Computer Monitor Acutance": null,
+        "Large Print Acutance": null,
+        "Small Print Acutance": null,
+        "UHDTV Display Acutance": null
+      },
+      "curve_mae_mean": null,
+      "dead_leaves_coverage": false,
+      "family_id": "release_parity_fit",
+      "family_type": "release_profile",
+      "focus_preset_acutance_mae_mean": null,
+      "gain_trend_delta_mae_mean": 0.018148882951082922,
+      "gain_trend_series_shape_error": 0.018628257751567734,
+      "label": "release/parity_fit",
+      "mtf_threshold_mae": {
+        "mtf20": null,
+        "mtf30": null,
+        "mtf50": null
+      },
+      "overall_quality_loss_mae_mean": null,
+      "quality_loss_preset_mae": {},
+      "rank": 8,
+      "sources": {
+        "artifact_paths": [
+          "artifacts/amodel_gray_texture_series_penalty_benchmark.json"
+        ],
+        "doc_paths": [
+          "release/deadleaf_13b10_release/README.md"
+        ],
+        "primary_path": "release/deadleaf_13b10_release/config/parity_fit_profile.release.json"
+      },
+      "status": "parity-valid",
+      "status_reason": "Current release default and primary target profile.",
+      "trend_coverage": true,
+      "trend_direction_group_count": 20,
+      "trend_direction_match_count": 3,
+      "trend_direction_match_rate": 0.15
+    },
+    {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": null,
+        "Computer Monitor Acutance": null,
+        "Large Print Acutance": null,
+        "Small Print Acutance": null,
+        "UHDTV Display Acutance": null
+      },
+      "curve_mae_mean": null,
+      "dead_leaves_coverage": false,
+      "family_id": "release_parity_gain_shape",
+      "family_type": "release_profile",
+      "focus_preset_acutance_mae_mean": null,
+      "gain_trend_delta_mae_mean": 0.015299928492502122,
+      "gain_trend_series_shape_error": 0.01876579065541799,
+      "label": "release/parity_gain_shape",
+      "mtf_threshold_mae": {
+        "mtf20": null,
+        "mtf30": null,
+        "mtf50": null
+      },
+      "overall_quality_loss_mae_mean": null,
+      "quality_loss_preset_mae": {},
+      "rank": 9,
+      "sources": {
+        "artifact_paths": [
+          "artifacts/amodel_gray_texture_benchmark.json"
+        ],
+        "doc_paths": [
+          "docs/amodel_gain_hypothesis_followup.md",
+          "docs/amodel_gray_texture_followup.md"
+        ],
+        "primary_path": "release/deadleaf_13b10_release/config/parity_gain_shape_profile.release.json"
+      },
+      "status": "diagnostic-only",
+      "status_reason": "Gain-shape hypothesis remains inconclusive and is not strong enough for promotion.",
+      "trend_coverage": true,
+      "trend_direction_group_count": 20,
+      "trend_direction_match_count": 3,
+      "trend_direction_match_rate": 0.15
+    },
+    {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": null,
+        "Computer Monitor Acutance": null,
+        "Large Print Acutance": null,
+        "Small Print Acutance": null,
+        "UHDTV Display Acutance": null
+      },
+      "curve_mae_mean": null,
+      "dead_leaves_coverage": false,
+      "family_id": "release_parity_gray_shape",
+      "family_type": "release_profile",
+      "focus_preset_acutance_mae_mean": null,
+      "gain_trend_delta_mae_mean": 0.01025376937953503,
+      "gain_trend_series_shape_error": 0.03119366329719798,
+      "label": "release/parity_gray_shape",
+      "mtf_threshold_mae": {
+        "mtf20": null,
+        "mtf30": null,
+        "mtf50": null
+      },
+      "overall_quality_loss_mae_mean": null,
+      "quality_loss_preset_mae": {},
+      "rank": 10,
+      "sources": {
+        "artifact_paths": [
+          "artifacts/amodel_gray_texture_benchmark.json"
+        ],
+        "doc_paths": [
+          "docs/amodel_gray_texture_followup.md"
+        ],
+        "primary_path": "release/deadleaf_13b10_release/config/parity_gray_shape_profile.release.json"
+      },
+      "status": "diagnostic-only",
+      "status_reason": "Gray-only factor isolate improves delta magnitude but not direction-match count.",
+      "trend_coverage": true,
+      "trend_direction_group_count": 20,
+      "trend_direction_match_count": 3,
+      "trend_direction_match_rate": 0.15
+    },
+    {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": null,
+        "Computer Monitor Acutance": null,
+        "Large Print Acutance": null,
+        "Small Print Acutance": null,
+        "UHDTV Display Acutance": null
+      },
+      "curve_mae_mean": null,
+      "dead_leaves_coverage": false,
+      "family_id": "release_recommended",
+      "family_type": "release_profile",
+      "focus_preset_acutance_mae_mean": null,
+      "gain_trend_delta_mae_mean": 0.013764105189251674,
+      "gain_trend_series_shape_error": 0.0661801340077346,
+      "label": "release/recommended",
+      "mtf_threshold_mae": {
+        "mtf20": null,
+        "mtf30": null,
+        "mtf50": null
+      },
+      "overall_quality_loss_mae_mean": null,
+      "quality_loss_preset_mae": {},
+      "rank": 11,
+      "sources": {
+        "artifact_paths": [
+          "artifacts/amodel_gain_trend_benchmark.json"
+        ],
+        "doc_paths": [
+          "release/deadleaf_13b10_release/README.md",
+          "docs/parity_acutance_quality_loss_validation.md"
+        ],
+        "primary_path": "release/deadleaf_13b10_release/config/recommended_profile.release.json"
+      },
+      "status": "parity-valid",
+      "status_reason": "Retained split-workaround parity reference; no longer primary, but still an active comparison line rather than a pure diagnostic control.",
+      "trend_coverage": true,
+      "trend_direction_group_count": 20,
+      "trend_direction_match_count": 3,
+      "trend_direction_match_rate": 0.15
+    },
+    {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": null,
+        "Computer Monitor Acutance": null,
+        "Large Print Acutance": null,
+        "Small Print Acutance": null,
+        "UHDTV Display Acutance": null
+      },
+      "curve_mae_mean": null,
+      "dead_leaves_coverage": false,
+      "family_id": "release_parity_texture_shape",
+      "family_type": "release_profile",
+      "focus_preset_acutance_mae_mean": null,
+      "gain_trend_delta_mae_mean": 0.010781724255412763,
+      "gain_trend_series_shape_error": 0.11212136133925217,
+      "label": "release/parity_texture_shape",
+      "mtf_threshold_mae": {
+        "mtf20": null,
+        "mtf30": null,
+        "mtf50": null
+      },
+      "overall_quality_loss_mae_mean": null,
+      "quality_loss_preset_mae": {},
+      "rank": 12,
+      "sources": {
+        "artifact_paths": [
+          "artifacts/amodel_gray_texture_benchmark.json"
+        ],
+        "doc_paths": [
+          "docs/amodel_gray_texture_followup.md"
+        ],
+        "primary_path": "release/deadleaf_13b10_release/config/parity_texture_shape_profile.release.json"
+      },
+      "status": "diagnostic-only",
+      "status_reason": "Texture-support-only isolate leaves trend direction unresolved and inflates series error.",
+      "trend_coverage": true,
+      "trend_direction_group_count": 20,
+      "trend_direction_match_count": 3,
+      "trend_direction_match_rate": 0.15
+    },
+    {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": 0.012339726096799753,
+        "Computer Monitor Acutance": 0.01211298333455687,
+        "Large Print Acutance": 0.008652070267904098,
+        "Small Print Acutance": 0.010307146668849663,
+        "UHDTV Display Acutance": 0.022070342159923255
+      },
+      "curve_mae_mean": 0.031630678550997944,
+      "dead_leaves_coverage": true,
+      "family_id": "direct_issue63_empirical_linearization",
+      "family_type": "direct_method_branch",
+      "focus_preset_acutance_mae_mean": 0.013096453705606729,
+      "gain_trend_delta_mae_mean": null,
+      "gain_trend_series_shape_error": null,
+      "label": "direct/issue63_empirical_linearization",
+      "mtf_threshold_mae": {
+        "mtf20": 0.03805077337414969,
+        "mtf30": 0.04422298499845122,
+        "mtf50": 0.021589249154774382
+      },
+      "overall_quality_loss_mae_mean": 1.521854122812337,
+      "quality_loss_preset_mae": {
+        "5.5\" Phone Display Quality Loss": 0.31667488505906133,
+        "Computer Monitor Quality Loss": 3.32218083965815,
+        "Large Print Quality Loss": 1.3349872027109564,
+        "Small Print Quality Loss": 1.1811005461400752,
+        "UHDTV Display Quality Loss": 1.4543271404934428
+      },
+      "rank": 13,
+      "sources": {
+        "artifact_paths": [
+          "artifacts/issue63_empirical_linearization_psd_benchmark.json",
+          "artifacts/issue63_empirical_linearization_acutance_benchmark.json"
+        ],
+        "doc_paths": [
+          "docs/issue63_empirical_linearization_followup.md"
+        ],
+        "primary_path": "algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_empirical_linearization_profile.json"
+      },
+      "status": "diagnostic-only",
+      "status_reason": "Important mixed branch: Acutance improved sharply, but PSD and Quality Loss stayed too weak for promotion.",
+      "trend_coverage": false,
+      "trend_direction_group_count": null,
+      "trend_direction_match_count": null,
+      "trend_direction_match_rate": null
+    },
+    {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": 0.012338772438470614,
+        "Computer Monitor Acutance": 0.01204952686089712,
+        "Large Print Acutance": 0.008671051021070398,
+        "Small Print Acutance": 0.010307033705187688,
+        "UHDTV Display Acutance": 0.021975021832475978
+      },
+      "curve_mae_mean": 0.03189951888358044,
+      "dead_leaves_coverage": true,
+      "family_id": "direct_issue65_chart_prior_inverse_linearization",
+      "family_type": "direct_method_branch",
+      "focus_preset_acutance_mae_mean": 0.013068281171620361,
+      "gain_trend_delta_mae_mean": null,
+      "gain_trend_series_shape_error": null,
+      "label": "direct/issue65_chart_prior_inverse_linearization",
+      "mtf_threshold_mae": {
+        "mtf20": 0.042778033341942426,
+        "mtf30": 0.04902803854046335,
+        "mtf50": 0.021589249154774382
+      },
+      "overall_quality_loss_mae_mean": 1.5317749785548989,
+      "quality_loss_preset_mae": {
+        "5.5\" Phone Display Quality Loss": 0.31661995869798404,
+        "Computer Monitor Quality Loss": 3.3813933594483125,
+        "Large Print Quality Loss": 1.3322211490442237,
+        "Small Print Quality Loss": 1.1810605359751631,
+        "UHDTV Display Quality Loss": 1.4475798896088106
+      },
+      "rank": 14,
+      "sources": {
+        "artifact_paths": [
+          "artifacts/issue65_chart_prior_inverse_linearization_psd_benchmark.json",
+          "artifacts/issue65_chart_prior_inverse_linearization_acutance_benchmark.json"
+        ],
+        "doc_paths": [
+          "docs/issue65_chart_prior_inverse_linearization_followup.md"
+        ],
+        "primary_path": "algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_chart_prior_slope_m006_anchored_hf_psd_roi_reference_only_empirical_linearization_profile.json"
+      },
+      "status": "archived / exhausted",
+      "status_reason": "Explicit bounded negative refinement of the issue-63 branch.",
+      "trend_coverage": false,
+      "trend_direction_group_count": null,
+      "trend_direction_match_count": null,
+      "trend_direction_match_rate": null
+    },
+    {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": 0.012338772438470614,
+        "Computer Monitor Acutance": 0.01204952686089712,
+        "Large Print Acutance": 0.008671051021070398,
+        "Small Print Acutance": 0.010307033705187688,
+        "UHDTV Display Acutance": 0.021975021832475978
+      },
+      "curve_mae_mean": 0.03189951888358044,
+      "dead_leaves_coverage": true,
+      "family_id": "direct_issue67_readout_policy",
+      "family_type": "direct_method_branch",
+      "focus_preset_acutance_mae_mean": 0.013068281171620361,
+      "gain_trend_delta_mae_mean": null,
+      "gain_trend_series_shape_error": null,
+      "label": "direct/issue67_readout_policy",
+      "mtf_threshold_mae": {
+        "mtf20": 0.043514415552122654,
+        "mtf30": 0.049474379968693985,
+        "mtf50": 0.02450493402291129
+      },
+      "overall_quality_loss_mae_mean": 1.5317749785548989,
+      "quality_loss_preset_mae": {
+        "5.5\" Phone Display Quality Loss": 0.31661995869798404,
+        "Computer Monitor Quality Loss": 3.3813933594483125,
+        "Large Print Quality Loss": 1.3322211490442237,
+        "Small Print Quality Loss": 1.1810605359751631,
+        "UHDTV Display Quality Loss": 1.4475798896088106
+      },
+      "rank": 15,
+      "sources": {
+        "artifact_paths": [
+          "artifacts/issue67_readout_policy_psd_benchmark.json",
+          "artifacts/issue67_readout_policy_acutance_benchmark.json"
+        ],
+        "doc_paths": [
+          "docs/issue67_readout_policy_followup.md"
+        ],
+        "primary_path": "algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_chart_prior_slope_m006_anchored_hf_psd_roi_reference_only_empirical_linearization_readout7_profile.json"
+      },
+      "status": "archived / exhausted",
+      "status_reason": "Explicitly exhausted readout-policy family after the bounded negative re-check.",
+      "trend_coverage": false,
+      "trend_direction_group_count": null,
+      "trend_direction_match_count": null,
+      "trend_direction_match_rate": null
+    },
+    {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": 0.016810511427410642,
+        "Computer Monitor Acutance": 0.054237735168271614,
+        "Large Print Acutance": 0.03862844832111008,
+        "Small Print Acutance": 0.030348558063282082,
+        "UHDTV Display Acutance": 0.04493795294455284
+      },
+      "curve_mae_mean": 0.03666081546909307,
+      "dead_leaves_coverage": true,
+      "family_id": "direct_issue56_empirical_frequency_scale",
+      "family_type": "direct_method_branch",
+      "focus_preset_acutance_mae_mean": 0.03699264118492546,
+      "gain_trend_delta_mae_mean": null,
+      "gain_trend_series_shape_error": null,
+      "label": "direct/issue56_empirical_frequency_scale",
+      "mtf_threshold_mae": {
+        "mtf20": 0.031580123999406,
+        "mtf30": 0.047830649248861,
+        "mtf50": 0.021573538079002308
+      },
+      "overall_quality_loss_mae_mean": 1.4582278636293544,
+      "quality_loss_preset_mae": {
+        "5.5\" Phone Display Quality Loss": 0.2023238841227169,
+        "Computer Monitor Quality Loss": 3.6376862499825835,
+        "Large Print Quality Loss": 0.9626965715082461,
+        "Small Print Quality Loss": 0.7457710410703663,
+        "UHDTV Display Quality Loss": 1.7426615714628597
+      },
+      "rank": 16,
+      "sources": {
+        "artifact_paths": [
+          "artifacts/issue56_empirical_frequency_scale_psd_benchmark.json",
+          "artifacts/issue56_empirical_frequency_scale_acutance_benchmark.json"
+        ],
+        "doc_paths": [
+          "docs/issue56_empirical_frequency_scale_followup.md"
+        ],
+        "primary_path": "/tmp/issue56_freqscale_1095.json"
+      },
+      "status": "archived / exhausted",
+      "status_reason": "Closed empirical frequency-scale line; threshold-only gain did not transfer to the full parity objective.",
+      "trend_coverage": false,
+      "trend_direction_group_count": null,
+      "trend_direction_match_count": null,
+      "trend_direction_match_rate": null
+    },
+    {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": 0.013802247905288301,
+        "Computer Monitor Acutance": 0.052665183748573804,
+        "Large Print Acutance": 0.05132586418527154,
+        "Small Print Acutance": 0.046702107662187464,
+        "UHDTV Display Acutance": 0.04793875259218785
+      },
+      "curve_mae_mean": 0.03678903166100513,
+      "dead_leaves_coverage": true,
+      "family_id": "direct_issue29_anchored_hf_psd",
+      "family_type": "direct_method_branch",
+      "focus_preset_acutance_mae_mean": 0.042486831218701795,
+      "gain_trend_delta_mae_mean": null,
+      "gain_trend_series_shape_error": null,
+      "label": "direct/issue29_anchored_hf_psd",
+      "mtf_threshold_mae": {
+        "mtf20": 0.03301077142967389,
+        "mtf30": 0.03693639342667963,
+        "mtf50": 0.009332615436071163
+      },
+      "overall_quality_loss_mae_mean": 1.2214989544377113,
+      "quality_loss_preset_mae": {
+        "5.5\" Phone Display Quality Loss": 0.14297991495607307,
+        "Computer Monitor Quality Loss": 2.902905846061304,
+        "Large Print Quality Loss": 0.9548172583377941,
+        "Small Print Quality Loss": 0.6076935256225349,
+        "UHDTV Display Quality Loss": 1.4990982272108502
+      },
+      "rank": 17,
+      "sources": {
+        "artifact_paths": [
+          "artifacts/issue29_anchored_high_frequency_psd_benchmark.json",
+          "artifacts/issue29_anchored_high_frequency_acutance_benchmark.json"
+        ],
+        "doc_paths": [
+          "docs/issue29_anchored_high_frequency_psd_followup.md"
+        ],
+        "primary_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_profile.json"
+      },
+      "status": "parity-valid",
+      "status_reason": "Small but real source-backed lower-layer improvement that stayed downstream-safe enough to keep as a tracked candidate.",
+      "trend_coverage": false,
+      "trend_direction_group_count": null,
+      "trend_direction_match_count": null,
+      "trend_direction_match_rate": null
+    },
+    {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": 0.012909940589898264,
+        "Computer Monitor Acutance": 0.053503296232802214,
+        "Large Print Acutance": 0.048029164175666376,
+        "Small Print Acutance": 0.0440934456167187,
+        "UHDTV Display Acutance": 0.047999871775239775
+      },
+      "curve_mae_mean": 0.036795670048548175,
+      "dead_leaves_coverage": true,
+      "family_id": "direct_issue52_roi_reference",
+      "family_type": "direct_method_branch",
+      "focus_preset_acutance_mae_mean": 0.04130714367806507,
+      "gain_trend_delta_mae_mean": null,
+      "gain_trend_series_shape_error": null,
+      "label": "direct/issue52_roi_reference",
+      "mtf_threshold_mae": {
+        "mtf20": 0.026588479385846887,
+        "mtf30": 0.029031147782014672,
+        "mtf50": 0.009210531290681506
+      },
+      "overall_quality_loss_mae_mean": 1.2635712539874173,
+      "quality_loss_preset_mae": {
+        "5.5\" Phone Display Quality Loss": 0.1699187951448336,
+        "Computer Monitor Quality Loss": 2.9887158785513286,
+        "Large Print Quality Loss": 0.9753964866987435,
+        "Small Print Quality Loss": 0.6445598500524008,
+        "UHDTV Display Quality Loss": 1.5392652594897804
+      },
+      "rank": 18,
+      "sources": {
+        "artifact_paths": [
+          "artifacts/issue52_roi_reference_psd_benchmark.json",
+          "artifacts/issue52_roi_reference_acutance_benchmark.json"
+        ],
+        "doc_paths": [
+          "docs/issue52_direct_roi_reference_followup.md"
+        ],
+        "primary_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json"
+      },
+      "status": "diagnostic-only",
+      "status_reason": "Clear lower-layer win, but Quality Loss regressed too much for adoption.",
+      "trend_coverage": false,
+      "trend_direction_group_count": null,
+      "trend_direction_match_count": null,
+      "trend_direction_match_rate": null
+    },
+    {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": 0.012904952445893157,
+        "Computer Monitor Acutance": 0.053520742514481544,
+        "Large Print Acutance": 0.047952708317223675,
+        "Small Print Acutance": 0.043974804440237894,
+        "UHDTV Display Acutance": 0.04795393982961792
+      },
+      "curve_mae_mean": 0.0368388092478103,
+      "dead_leaves_coverage": true,
+      "family_id": "direct_issue58_chart_sensor_comp",
+      "family_type": "direct_method_branch",
+      "focus_preset_acutance_mae_mean": 0.04126142950949084,
+      "gain_trend_delta_mae_mean": null,
+      "gain_trend_series_shape_error": null,
+      "label": "direct/issue58_chart_sensor_comp",
+      "mtf_threshold_mae": {
+        "mtf20": 0.026782180896081077,
+        "mtf30": 0.029131186223176352,
+        "mtf50": 0.009228613371601612
+      },
+      "overall_quality_loss_mae_mean": 1.2626646788288407,
+      "quality_loss_preset_mae": {
+        "5.5\" Phone Display Quality Loss": 0.16998827003204747,
+        "Computer Monitor Quality Loss": 2.9822377122465236,
+        "Large Print Quality Loss": 0.9752058029182098,
+        "Small Print Quality Loss": 0.6442552253418805,
+        "UHDTV Display Quality Loss": 1.5416363836055424
+      },
+      "rank": 19,
+      "sources": {
+        "artifact_paths": [
+          "artifacts/issue58_chart_sensor_compensation_psd_benchmark.json",
+          "artifacts/issue58_chart_sensor_compensation_acutance_benchmark.json"
+        ],
+        "doc_paths": [
+          "docs/issue58_chart_sensor_compensation_followup.md"
+        ],
+        "primary_path": "algo/deadleaf_13b10_imatest_chart_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json"
+      },
+      "status": "diagnostic-only",
+      "status_reason": "Healthier than the older chart/sensor branch, but still not strong enough to replace the default line.",
+      "trend_coverage": false,
+      "trend_direction_group_count": null,
+      "trend_direction_match_count": null,
+      "trend_direction_match_rate": null
+    },
+    {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": 0.012632859545328204,
+        "Computer Monitor Acutance": 0.05327084155351432,
+        "Large Print Acutance": 0.04762663123263737,
+        "Small Print Acutance": 0.043478956082953275,
+        "UHDTV Display Acutance": 0.04763101217961305
+      },
+      "curve_mae_mean": 0.03690674373255725,
+      "dead_leaves_coverage": true,
+      "family_id": "direct_issue54_observable_bins",
+      "family_type": "direct_method_branch",
+      "focus_preset_acutance_mae_mean": 0.04092806011880924,
+      "gain_trend_delta_mae_mean": null,
+      "gain_trend_series_shape_error": null,
+      "label": "direct/issue54_observable_bins",
+      "mtf_threshold_mae": {
+        "mtf20": 0.021093664116902187,
+        "mtf30": 0.02920595943030816,
+        "mtf50": 0.009428579810416034
+      },
+      "overall_quality_loss_mae_mean": 1.272290038135693,
+      "quality_loss_preset_mae": {
+        "5.5\" Phone Display Quality Loss": 0.17403968250594493,
+        "Computer Monitor Quality Loss": 3.005541718007179,
+        "Large Print Quality Loss": 0.9797306535035449,
+        "Small Print Quality Loss": 0.6463902403067138,
+        "UHDTV Display Quality Loss": 1.5557478963550824
+      },
+      "rank": 20,
+      "sources": {
+        "artifact_paths": [
+          "artifacts/issue54_observable_frequency_bins_psd_benchmark.json",
+          "artifacts/issue54_observable_frequency_bins_acutance_benchmark.json"
+        ],
+        "doc_paths": [
+          "docs/issue54_observable_frequency_bins_followup.md"
+        ],
+        "primary_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_observable_bins_profile.json"
+      },
+      "status": "archived / exhausted",
+      "status_reason": "Closed frequency-bin branch; static inferred bins remained the better default on this dataset.",
+      "trend_coverage": false,
+      "trend_direction_group_count": null,
+      "trend_direction_match_count": null,
+      "trend_direction_match_rate": null
+    },
+    {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": 0.012887907037208319,
+        "Computer Monitor Acutance": 0.053691360633422315,
+        "Large Print Acutance": 0.048609151243059,
+        "Small Print Acutance": 0.044689945622090124,
+        "UHDTV Display Acutance": 0.048087482733436014
+      },
+      "curve_mae_mean": 0.03710695877117158,
+      "dead_leaves_coverage": true,
+      "family_id": "direct_issue61_isp_family",
+      "family_type": "direct_method_branch",
+      "focus_preset_acutance_mae_mean": 0.04159316945384316,
+      "gain_trend_delta_mae_mean": null,
+      "gain_trend_series_shape_error": null,
+      "label": "direct/issue61_isp_family",
+      "mtf_threshold_mae": {
+        "mtf20": 0.026588479385846887,
+        "mtf30": 0.029031147782014672,
+        "mtf50": 0.009210531290681506
+      },
+      "overall_quality_loss_mae_mean": 1.2611494672413617,
+      "quality_loss_preset_mae": {
+        "5.5\" Phone Display Quality Loss": 0.16715567535695144,
+        "Computer Monitor Quality Loss": 2.9894696043898414,
+        "Large Print Quality Loss": 0.9538243443870495,
+        "Small Print Quality Loss": 0.6408136977961201,
+        "UHDTV Display Quality Loss": 1.5544840142768457
+      },
+      "rank": 21,
+      "sources": {
+        "artifact_paths": [
+          "artifacts/issue61_isp_family_psd_benchmark.json",
+          "artifacts/issue61_isp_family_acutance_benchmark.json"
+        ],
+        "doc_paths": [
+          "docs/issue61_isp_family_followup.md"
+        ],
+        "primary_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_hf_noise_share_shape_profile.json"
+      },
+      "status": "diagnostic-only",
+      "status_reason": "Useful source-backed negative showing the remaining gap is not solved by the bounded ISP proxy alone.",
+      "trend_coverage": false,
+      "trend_direction_group_count": null,
+      "trend_direction_match_count": null,
+      "trend_direction_match_rate": null
+    },
+    {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": null,
+        "Computer Monitor Acutance": null,
+        "Large Print Acutance": null,
+        "Small Print Acutance": null,
+        "UHDTV Display Acutance": null
+      },
+      "curve_mae_mean": null,
+      "dead_leaves_coverage": false,
+      "family_id": "release_imatest_parity_sensor_comp",
+      "family_type": "release_profile",
+      "focus_preset_acutance_mae_mean": null,
+      "gain_trend_delta_mae_mean": null,
+      "gain_trend_series_shape_error": null,
+      "label": "release/imatest_parity_sensor_comp",
+      "mtf_threshold_mae": {
+        "mtf20": null,
+        "mtf30": null,
+        "mtf50": null
+      },
+      "overall_quality_loss_mae_mean": null,
+      "quality_loss_preset_mae": {},
+      "rank": 22,
+      "sources": {
+        "artifact_paths": [],
+        "doc_paths": [
+          "release/deadleaf_13b10_release/README.md"
+        ],
+        "primary_path": "release/deadleaf_13b10_release/config/imatest_parity_sensor_comp_profile.release.json"
+      },
+      "status": "diagnostic-only",
+      "status_reason": "README marks this literal-parity plus sensor-comp line as reference-only.",
+      "trend_coverage": false,
+      "trend_direction_group_count": null,
+      "trend_direction_match_count": null,
+      "trend_direction_match_rate": null
+    },
+    {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": null,
+        "Computer Monitor Acutance": null,
+        "Large Print Acutance": null,
+        "Small Print Acutance": null,
+        "UHDTV Display Acutance": null
+      },
+      "curve_mae_mean": null,
+      "dead_leaves_coverage": false,
+      "family_id": "release_imatest_parity_sensor_comp_toe",
+      "family_type": "release_profile",
+      "focus_preset_acutance_mae_mean": null,
+      "gain_trend_delta_mae_mean": null,
+      "gain_trend_series_shape_error": null,
+      "label": "release/imatest_parity_sensor_comp_toe",
+      "mtf_threshold_mae": {
+        "mtf20": null,
+        "mtf30": null,
+        "mtf50": null
+      },
+      "overall_quality_loss_mae_mean": null,
+      "quality_loss_preset_mae": {},
+      "rank": 23,
+      "sources": {
+        "artifact_paths": [],
+        "doc_paths": [
+          "release/deadleaf_13b10_release/README.md"
+        ],
+        "primary_path": "release/deadleaf_13b10_release/config/imatest_parity_sensor_comp_toe_profile.release.json"
+      },
+      "status": "diagnostic-only",
+      "status_reason": "README marks this literal-parity plus sensor-comp plus toe line as reference-only.",
+      "trend_coverage": false,
+      "trend_direction_group_count": null,
+      "trend_direction_match_count": null,
+      "trend_direction_match_rate": null
+    },
+    {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": null,
+        "Computer Monitor Acutance": null,
+        "Large Print Acutance": null,
+        "Small Print Acutance": null,
+        "UHDTV Display Acutance": null
+      },
+      "curve_mae_mean": null,
+      "dead_leaves_coverage": false,
+      "family_id": "release_legacy_linear",
+      "family_type": "release_profile",
+      "focus_preset_acutance_mae_mean": null,
+      "gain_trend_delta_mae_mean": null,
+      "gain_trend_series_shape_error": null,
+      "label": "release/legacy_linear",
+      "mtf_threshold_mae": {
+        "mtf20": null,
+        "mtf30": null,
+        "mtf50": null
+      },
+      "overall_quality_loss_mae_mean": null,
+      "quality_loss_preset_mae": {},
+      "rank": 24,
+      "sources": {
+        "artifact_paths": [],
+        "doc_paths": [
+          "release/deadleaf_13b10_release/README.md"
+        ],
+        "primary_path": "release/deadleaf_13b10_release/config/legacy_linear_profile.release.json"
+      },
+      "status": "archived / exhausted",
+      "status_reason": "Legacy comparison baseline retained only for historical contrast.",
+      "trend_coverage": false,
+      "trend_direction_group_count": null,
+      "trend_direction_match_count": null,
+      "trend_direction_match_rate": null
+    }
+  ],
+  "scoreboard_version": 1,
+  "status_definitions": {
+    "archived / exhausted": "Closed bounded negative or legacy-only line; kept for historical comparison but not for further direct follow-up on the current surface.",
+    "diagnostic-only": "Useful for explaining a residual or narrowing the next slice, but not kept as the current default or a release-safe replacement.",
+    "parity-valid": "Still kept as a live parity candidate or retained release reference rather than only as a diagnostic probe."
+  }
+}

--- a/docs/canonical_parity_scoreboard.md
+++ b/docs/canonical_parity_scoreboard.md
@@ -1,0 +1,51 @@
+# Canonical Parity Scoreboard
+
+This scoreboard is the repo-local decision surface requested by issue `#69`.
+
+Ranking policy:
+
+1. `trend direction match rate` descending
+2. `gain-trend series shape error` ascending as the trend tie-breaker
+3. `curve_mae_mean` ascending
+4. `focus preset acutance mae mean` ascending
+
+Coverage note:
+
+- release-profile rows carry tracked A-model trend metrics when the repo has a checked-in gain-trend benchmark for that exact release config.
+- direct-method rows carry tracked dead-leaves parity metrics from the issue artifacts; these rows currently have no exact checked-in A-model trend benchmark on the same profile path, so trend fields remain `-`.
+
+| Rank | Family | Type | Status | Trend match | Series err | Curve MAE | Focus Acu MAE | Phone A | Monitor A | UHDTV A | Small Print A | Large Print A | MTF20 | MTF30 | MTF50 | Overall QL | Source |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | release/imatest_parity | release_profile | diagnostic-only | 16/20 (0.800) | 0.05838 | - | - | - | - | - | - | - | - | - | - | - | release/deadleaf_13b10_release/config/imatest_parity_profile.release.json [amodel_gain_trend_benchmark.json] |
+| 2 | release/parity_gray_texture_shape | release_profile | diagnostic-only | 16/20 (0.800) | 0.06773 | - | - | - | - | - | - | - | - | - | - | - | release/deadleaf_13b10_release/config/parity_gray_texture_shape_profile.release.json [amodel_gray_texture_series_penalty_benchmark.json] |
+| 3 | release/parity_gray_texture_shape_freq105 | release_profile | diagnostic-only | 14/20 (0.700) | 0.03340 | - | - | - | - | - | - | - | - | - | - | - | release/deadleaf_13b10_release/config/parity_gray_texture_shape_freq105_profile.release.json [amodel_gray_texture_series_penalty_benchmark.json] |
+| 4 | release/parity_gray_texture_shape_freq110 | release_profile | diagnostic-only | 14/20 (0.700) | 0.04818 | - | - | - | - | - | - | - | - | - | - | - | release/deadleaf_13b10_release/config/parity_gray_texture_shape_freq110_profile.release.json [amodel_gray_texture_series_penalty_benchmark.json] |
+| 5 | release/parity_gray_texture_shape_nofreq | release_profile | diagnostic-only | 13/20 (0.650) | 0.02410 | - | - | - | - | - | - | - | - | - | - | - | release/deadleaf_13b10_release/config/parity_gray_texture_shape_nofreq_profile.release.json [amodel_gray_texture_series_penalty_benchmark.json] |
+| 6 | release/experimental_shape | release_profile | diagnostic-only | 13/20 (0.650) | 0.03006 | - | - | - | - | - | - | - | - | - | - | - | release/deadleaf_13b10_release/config/experimental_shape_profile.release.json [amodel_gray_texture_series_penalty_benchmark.json] |
+| 7 | release/parity_gain_noise | release_profile | diagnostic-only | 3/20 (0.150) | 0.01804 | - | - | - | - | - | - | - | - | - | - | - | release/deadleaf_13b10_release/config/parity_gain_noise_profile.release.json [amodel_gain_hypothesis_benchmark.json] |
+| 8 | release/parity_fit | release_profile | parity-valid | 3/20 (0.150) | 0.01863 | - | - | - | - | - | - | - | - | - | - | - | release/deadleaf_13b10_release/config/parity_fit_profile.release.json [amodel_gray_texture_series_penalty_benchmark.json] |
+| 9 | release/parity_gain_shape | release_profile | diagnostic-only | 3/20 (0.150) | 0.01877 | - | - | - | - | - | - | - | - | - | - | - | release/deadleaf_13b10_release/config/parity_gain_shape_profile.release.json [amodel_gray_texture_benchmark.json] |
+| 10 | release/parity_gray_shape | release_profile | diagnostic-only | 3/20 (0.150) | 0.03119 | - | - | - | - | - | - | - | - | - | - | - | release/deadleaf_13b10_release/config/parity_gray_shape_profile.release.json [amodel_gray_texture_benchmark.json] |
+| 11 | release/recommended | release_profile | parity-valid | 3/20 (0.150) | 0.06618 | - | - | - | - | - | - | - | - | - | - | - | release/deadleaf_13b10_release/config/recommended_profile.release.json [amodel_gain_trend_benchmark.json] |
+| 12 | release/parity_texture_shape | release_profile | diagnostic-only | 3/20 (0.150) | 0.11212 | - | - | - | - | - | - | - | - | - | - | - | release/deadleaf_13b10_release/config/parity_texture_shape_profile.release.json [amodel_gray_texture_benchmark.json] |
+| 13 | direct/issue63_empirical_linearization | direct_method_branch | diagnostic-only | - | - | 0.03163 | 0.01310 | 0.01234 | 0.01211 | 0.02207 | 0.01031 | 0.00865 | 0.03805 | 0.04422 | 0.02159 | 1.52185 | algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_empirical_linearization_profile.json [issue63_empirical_linearization_psd_benchmark.json, issue63_empirical_linearization_acutance_benchmark.json] |
+| 14 | direct/issue65_chart_prior_inverse_linearization | direct_method_branch | archived / exhausted | - | - | 0.03190 | 0.01307 | 0.01234 | 0.01205 | 0.02198 | 0.01031 | 0.00867 | 0.04278 | 0.04903 | 0.02159 | 1.53177 | algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_chart_prior_slope_m006_anchored_hf_psd_roi_reference_only_empirical_linearization_profile.json [issue65_chart_prior_inverse_linearization_psd_benchmark.json, issue65_chart_prior_inverse_linearization_acutance_benchmark.json] |
+| 15 | direct/issue67_readout_policy | direct_method_branch | archived / exhausted | - | - | 0.03190 | 0.01307 | 0.01234 | 0.01205 | 0.02198 | 0.01031 | 0.00867 | 0.04351 | 0.04947 | 0.02450 | 1.53177 | algo/deadleaf_13b10_imatest_sensor_comp_power_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_chart_prior_slope_m006_anchored_hf_psd_roi_reference_only_empirical_linearization_readout7_profile.json [issue67_readout_policy_psd_benchmark.json, issue67_readout_policy_acutance_benchmark.json] |
+| 16 | direct/issue56_empirical_frequency_scale | direct_method_branch | archived / exhausted | - | - | 0.03666 | 0.03699 | 0.01681 | 0.05424 | 0.04494 | 0.03035 | 0.03863 | 0.03158 | 0.04783 | 0.02157 | 1.45823 | /tmp/issue56_freqscale_1095.json [issue56_empirical_frequency_scale_psd_benchmark.json, issue56_empirical_frequency_scale_acutance_benchmark.json] |
+| 17 | direct/issue29_anchored_hf_psd | direct_method_branch | parity-valid | - | - | 0.03679 | 0.04249 | 0.01380 | 0.05267 | 0.04794 | 0.04670 | 0.05133 | 0.03301 | 0.03694 | 0.00933 | 1.22150 | algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_profile.json [issue29_anchored_high_frequency_psd_benchmark.json, issue29_anchored_high_frequency_acutance_benchmark.json] |
+| 18 | direct/issue52_roi_reference | direct_method_branch | diagnostic-only | - | - | 0.03680 | 0.04131 | 0.01291 | 0.05350 | 0.04800 | 0.04409 | 0.04803 | 0.02659 | 0.02903 | 0.00921 | 1.26357 | algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json [issue52_roi_reference_psd_benchmark.json, issue52_roi_reference_acutance_benchmark.json] |
+| 19 | direct/issue58_chart_sensor_comp | direct_method_branch | diagnostic-only | - | - | 0.03684 | 0.04126 | 0.01290 | 0.05352 | 0.04795 | 0.04397 | 0.04795 | 0.02678 | 0.02913 | 0.00923 | 1.26266 | algo/deadleaf_13b10_imatest_chart_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_profile.json [issue58_chart_sensor_compensation_psd_benchmark.json, issue58_chart_sensor_compensation_acutance_benchmark.json] |
+| 20 | direct/issue54_observable_bins | direct_method_branch | archived / exhausted | - | - | 0.03691 | 0.04093 | 0.01263 | 0.05327 | 0.04763 | 0.04348 | 0.04763 | 0.02109 | 0.02921 | 0.00943 | 1.27229 | algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_observable_bins_profile.json [issue54_observable_frequency_bins_psd_benchmark.json, issue54_observable_frequency_bins_acutance_benchmark.json] |
+| 21 | direct/issue61_isp_family | direct_method_branch | diagnostic-only | - | - | 0.03711 | 0.04159 | 0.01289 | 0.05369 | 0.04809 | 0.04469 | 0.04861 | 0.02659 | 0.02903 | 0.00921 | 1.26115 | algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_roi_reference_only_hf_noise_share_shape_profile.json [issue61_isp_family_psd_benchmark.json, issue61_isp_family_acutance_benchmark.json] |
+| 22 | release/imatest_parity_sensor_comp | release_profile | diagnostic-only | - | - | - | - | - | - | - | - | - | - | - | - | - | release/deadleaf_13b10_release/config/imatest_parity_sensor_comp_profile.release.json |
+| 23 | release/imatest_parity_sensor_comp_toe | release_profile | diagnostic-only | - | - | - | - | - | - | - | - | - | - | - | - | - | release/deadleaf_13b10_release/config/imatest_parity_sensor_comp_toe_profile.release.json |
+| 24 | release/legacy_linear | release_profile | archived / exhausted | - | - | - | - | - | - | - | - | - | - | - | - | - | release/deadleaf_13b10_release/config/legacy_linear_profile.release.json |
+
+## Current Readout
+
+- Top tracked trend row: `release/imatest_parity` with `16/20 (0.800)` and series error `0.05838`; status = `diagnostic-only`.
+- Top tracked direct-method row by the fixed sort: `direct/issue63_empirical_linearization` with `curve_mae_mean = 0.03163` and `overall_quality_loss_mae_mean = 1.52185`; status = `diagnostic-only`.
+- Best still-parity-valid direct-method row: `direct/issue29_anchored_hf_psd` with `curve_mae_mean = 0.03679` and `overall_quality_loss_mae_mean = 1.22150`.
+- Explicit archived / exhausted lines in the current scoreboard: `direct/issue65_chart_prior_inverse_linearization`, `direct/issue67_readout_policy`, `direct/issue56_empirical_frequency_scale`, `direct/issue54_observable_bins`, `release/legacy_linear`.
+
+The machine-readable companion artifact at `artifacts/canonical_parity_scoreboard.json` keeps the full status reasons, per-preset values, and provenance paths for later issues to cite directly.

--- a/tests/test_build_canonical_parity_scoreboard.py
+++ b/tests/test_build_canonical_parity_scoreboard.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import unittest
+
+from algo.build_canonical_parity_scoreboard import build_scoreboard, render_markdown
+
+
+class BuildCanonicalParityScoreboardTest(unittest.TestCase):
+    def test_scoreboard_contains_expected_rows_and_statuses(self) -> None:
+        scoreboard = build_scoreboard(repo_root=self.repo_root())
+        by_id = {row["family_id"]: row for row in scoreboard["rows"]}
+
+        self.assertIn("release_parity_fit", by_id)
+        self.assertIn("release_parity_gray_texture_shape", by_id)
+        self.assertIn("direct_issue29_anchored_hf_psd", by_id)
+        self.assertIn("direct_issue67_readout_policy", by_id)
+
+        self.assertEqual(by_id["release_parity_fit"]["status"], "parity-valid")
+        self.assertEqual(
+            by_id["direct_issue67_readout_policy"]["status"],
+            "archived / exhausted",
+        )
+        self.assertAlmostEqual(
+            by_id["direct_issue29_anchored_hf_psd"]["overall_quality_loss_mae_mean"],
+            1.2214989544377113,
+        )
+
+    def test_trend_ranking_prefers_direction_match_then_series_error(self) -> None:
+        scoreboard = build_scoreboard(repo_root=self.repo_root())
+        rank_by_id = {row["family_id"]: row["rank"] for row in scoreboard["rows"]}
+
+        self.assertLess(
+            rank_by_id["release_parity_gray_texture_shape"],
+            rank_by_id["release_experimental_shape"],
+        )
+        self.assertLess(
+            rank_by_id["release_experimental_shape"],
+            rank_by_id["release_parity_fit"],
+        )
+        self.assertLess(
+            rank_by_id["release_parity_gray_texture_shape_freq105"],
+            rank_by_id["release_parity_fit"],
+        )
+
+    def test_markdown_mentions_required_sections(self) -> None:
+        scoreboard = build_scoreboard(repo_root=self.repo_root())
+        markdown = render_markdown(scoreboard)
+
+        self.assertIn("# Canonical Parity Scoreboard", markdown)
+        self.assertIn("| Rank | Family | Type | Status | Trend match |", markdown)
+        self.assertIn("release/parity_gray_texture_shape", markdown)
+        self.assertIn("direct/issue29_anchored_hf_psd", markdown)
+        self.assertIn("archived / exhausted", markdown)
+
+    @staticmethod
+    def repo_root():
+        from pathlib import Path
+
+        return Path(__file__).resolve().parents[1]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a deterministic scoreboard builder that synthesizes the current release-profile trend artifacts and direct-method parity artifacts into one ranked surface
- add the checked-in canonical scoreboard outputs at `docs/canonical_parity_scoreboard.md` and `artifacts/canonical_parity_scoreboard.json`
- add a focused test that locks the expected row coverage, status tagging, and trend-first ranking behavior

## Validation
- `python3 -m pytest tests/test_build_canonical_parity_scoreboard.py`
- `python3 -m algo.build_canonical_parity_scoreboard`

Refs #69
Refs #29
Context from #67
Context from #68
