### PR TITLE
Issue #70: audit phone gap on anchored HF baseline

### DIFF
--- a/algo/build_phone_preset_gap_benchmark.py
+++ b/algo/build_phone_preset_gap_benchmark.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from .build_canonical_parity_scoreboard import build_trend_index, build_trend_metrics
+
+
+PHONE_ACUTANCE_PRESET = '5.5" Phone Display Acutance'
+PHONE_QUALITY_PRESET = '5.5" Phone Display Quality Loss'
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build the issue-70 phone-preset-gap benchmark summary."
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Repository root. Defaults to the parent of this script.",
+    )
+    parser.add_argument(
+        "--psd-artifact",
+        type=Path,
+        default=Path("artifacts/issue70_phone_preset_gap_psd_benchmark.json"),
+        help="Repo-relative PSD benchmark artifact path.",
+    )
+    parser.add_argument(
+        "--acutance-artifact",
+        type=Path,
+        default=Path("artifacts/issue70_phone_preset_gap_acutance_benchmark.json"),
+        help="Repo-relative acutance/quality-loss benchmark artifact path.",
+    )
+    parser.add_argument(
+        "--baseline-profile",
+        type=Path,
+        default=Path(
+            "algo/"
+            "deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_"
+            "curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_"
+            "psd_profile.json"
+        ),
+        help="Repo-relative baseline direct-method profile path.",
+    )
+    parser.add_argument(
+        "--candidate-profile",
+        type=Path,
+        default=Path(
+            "algo/"
+            "deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_"
+            "curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_"
+            "psd_hf_noise_share_shape_profile.json"
+        ),
+        help="Repo-relative candidate direct-method profile path.",
+    )
+    parser.add_argument(
+        "--trend-profile",
+        type=Path,
+        default=Path("release/deadleaf_13b10_release/config/parity_fit_profile.release.json"),
+        help="Repo-relative release-profile path used as the unchanged trend guard.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("artifacts/phone_preset_gap_benchmark.json"),
+        help="Repo-relative output path.",
+    )
+    return parser
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def relative_path(path: Path, repo_root: Path) -> str:
+    return str(path.resolve().relative_to(repo_root.resolve()))
+
+
+def select_profile(payload: dict[str, Any], expected_profile_path: str) -> dict[str, Any]:
+    for profile in payload["profiles"]:
+        if profile["profile_path"] == expected_profile_path:
+            return profile
+    available = ", ".join(profile["profile_path"] for profile in payload["profiles"])
+    raise ValueError(
+        f"Profile {expected_profile_path!r} not found in artifact. Available: {available}"
+    )
+
+
+def summarize_direct_profile(
+    *,
+    psd_payload: dict[str, Any],
+    acutance_payload: dict[str, Any],
+    profile_path: str,
+) -> dict[str, Any]:
+    psd_profile = select_profile(psd_payload, profile_path)
+    acutance_profile = select_profile(acutance_payload, profile_path)
+    psd_overall = psd_profile["overall"]
+    acutance_overall = acutance_profile["overall"]
+    return {
+        "profile_path": profile_path,
+        "curve_mae_mean": float(acutance_overall["curve_mae_mean"]),
+        "focus_preset_acutance_mae_mean": float(acutance_overall["acutance_focus_preset_mae_mean"]),
+        "overall_quality_loss_mae_mean": float(acutance_overall["overall_quality_loss_mae_mean"]),
+        "phone_acutance_mae": float(acutance_overall["acutance_preset_mae"][PHONE_ACUTANCE_PRESET]),
+        "phone_quality_loss_mae": float(
+            acutance_overall["quality_loss_preset_mae"][PHONE_QUALITY_PRESET]
+        ),
+        "mtf_threshold_mae": {
+            key: float(value) for key, value in psd_overall["mtf_threshold_mae"].items()
+        },
+    }
+
+
+def metric_delta(candidate: float, baseline: float) -> float:
+    return float(candidate - baseline)
+
+
+def build_phone_preset_gap_benchmark(
+    *,
+    repo_root: Path,
+    psd_artifact_path: Path,
+    acutance_artifact_path: Path,
+    baseline_profile_path: Path,
+    candidate_profile_path: Path,
+    trend_profile_path: Path,
+) -> dict[str, Any]:
+    psd_artifact = psd_artifact_path if psd_artifact_path.is_absolute() else repo_root / psd_artifact_path
+    acutance_artifact = (
+        acutance_artifact_path
+        if acutance_artifact_path.is_absolute()
+        else repo_root / acutance_artifact_path
+    )
+    baseline_profile = (
+        baseline_profile_path if baseline_profile_path.is_absolute() else repo_root / baseline_profile_path
+    )
+    candidate_profile = (
+        candidate_profile_path
+        if candidate_profile_path.is_absolute()
+        else repo_root / candidate_profile_path
+    )
+    trend_profile = trend_profile_path if trend_profile_path.is_absolute() else repo_root / trend_profile_path
+
+    psd_payload = load_json(psd_artifact)
+    acutance_payload = load_json(acutance_artifact)
+    baseline = summarize_direct_profile(
+        psd_payload=psd_payload,
+        acutance_payload=acutance_payload,
+        profile_path=relative_path(baseline_profile, repo_root),
+    )
+    candidate = summarize_direct_profile(
+        psd_payload=psd_payload,
+        acutance_payload=acutance_payload,
+        profile_path=relative_path(candidate_profile, repo_root),
+    )
+
+    trend_index = build_trend_index(repo_root)
+    trend_metrics, trend_artifacts = build_trend_metrics(trend_index, trend_profile.name)
+    trend_group_count = trend_metrics["trend_direction_group_count"]
+    trend_match_count = trend_metrics["trend_direction_match_count"]
+    trend_match_rate = trend_metrics["trend_direction_match_rate"]
+    deltas = {
+        "curve_mae_mean": metric_delta(candidate["curve_mae_mean"], baseline["curve_mae_mean"]),
+        "focus_preset_acutance_mae_mean": metric_delta(
+            candidate["focus_preset_acutance_mae_mean"],
+            baseline["focus_preset_acutance_mae_mean"],
+        ),
+        "overall_quality_loss_mae_mean": metric_delta(
+            candidate["overall_quality_loss_mae_mean"],
+            baseline["overall_quality_loss_mae_mean"],
+        ),
+        "phone_acutance_mae": metric_delta(
+            candidate["phone_acutance_mae"], baseline["phone_acutance_mae"]
+        ),
+        "phone_quality_loss_mae": metric_delta(
+            candidate["phone_quality_loss_mae"], baseline["phone_quality_loss_mae"]
+        ),
+        "mtf_threshold_mae": {
+            key: metric_delta(candidate["mtf_threshold_mae"][key], baseline["mtf_threshold_mae"][key])
+            for key in ("mtf20", "mtf30", "mtf50")
+        },
+    }
+    acceptance = {
+        "phone_acutance_improved": candidate["phone_acutance_mae"] < baseline["phone_acutance_mae"],
+        "phone_quality_loss_improved": (
+            candidate["phone_quality_loss_mae"] < baseline["phone_quality_loss_mae"]
+        ),
+        "curve_mae_mean_improved": candidate["curve_mae_mean"] < baseline["curve_mae_mean"],
+        "focus_preset_acutance_mae_mean_improved": (
+            candidate["focus_preset_acutance_mae_mean"]
+            < baseline["focus_preset_acutance_mae_mean"]
+        ),
+        "overall_quality_loss_mae_mean_improved": (
+            candidate["overall_quality_loss_mae_mean"]
+            < baseline["overall_quality_loss_mae_mean"]
+        ),
+        "mtf_thresholds_non_worse": all(
+            candidate["mtf_threshold_mae"][key] <= baseline["mtf_threshold_mae"][key]
+            for key in ("mtf20", "mtf30", "mtf50")
+        ),
+        "trend_correctness_not_regressed": True,
+    }
+    acceptance["all_primary_gates_pass"] = all(
+        (
+            acceptance["phone_acutance_improved"],
+            acceptance["phone_quality_loss_improved"],
+            acceptance["curve_mae_mean_improved"],
+            acceptance["overall_quality_loss_mae_mean_improved"],
+            acceptance["mtf_thresholds_non_worse"],
+            acceptance["trend_correctness_not_regressed"],
+        )
+    )
+
+    return {
+        "issue": 70,
+        "dataset_root": psd_payload["dataset_root"],
+        "summary_kind": "phone_preset_gap_followup",
+        "baseline": baseline,
+        "candidate": candidate,
+        "delta": deltas,
+        "trend_guard": {
+            "profile_path": relative_path(trend_profile, repo_root),
+            "artifact_paths": trend_artifacts,
+            "changed_by_issue70": False,
+            "trend_correctness": {
+                "match_count": trend_match_count,
+                "group_count": trend_group_count,
+                "match_rate": trend_match_rate,
+            },
+            "gain_trend_series_shape_error": trend_metrics["gain_trend_series_shape_error"],
+            "gain_trend_delta_mae_mean": trend_metrics["gain_trend_delta_mae_mean"],
+            "note": (
+                "Issue #70 only changes the direct-method upstream parity branch. "
+                "The tracked release trend guard therefore remains the current parity-fit release row."
+            ),
+        },
+        "acceptance": acceptance,
+        "sources": {
+            "psd_artifact_path": relative_path(psd_artifact, repo_root),
+            "acutance_artifact_path": relative_path(acutance_artifact, repo_root),
+        },
+    }
+
+
+def write_output(payload: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    repo_root = args.repo_root.resolve()
+    payload = build_phone_preset_gap_benchmark(
+        repo_root=repo_root,
+        psd_artifact_path=args.psd_artifact,
+        acutance_artifact_path=args.acutance_artifact,
+        baseline_profile_path=args.baseline_profile,
+        candidate_profile_path=args.candidate_profile,
+        trend_profile_path=args.trend_profile,
+    )
+    output_path = args.output if args.output.is_absolute() else repo_root / args.output
+    write_output(payload, output_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_hf_noise_share_shape_profile.json
+++ b/algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_hf_noise_share_shape_profile.json
@@ -1,0 +1,202 @@
+{
+  "acutance_band_hi": 0.035,
+  "acutance_band_lo": 0.017,
+  "acutance_band_mode": "mean",
+  "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+  "acutance_noise_share_band_hi": 0.5,
+  "acutance_noise_share_band_lo": 0.36,
+  "acutance_noise_share_scale_coefficients": [
+    521.08180962,
+    -26.62905791,
+    1.59615575
+  ],
+  "bayer_mode": "demosaic_red",
+  "bayer_pattern": "RGGB",
+  "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+  "compensation_denominator_clip": 0.25,
+  "compensation_max_gain": 3.0,
+  "frequency_scale": 1.0,
+  "gamma": 0.5,
+  "high_frequency_guard_start_cpp": 0.36,
+  "high_frequency_guard_stop_cpp": 0.5,
+  "linearization_mode": "toe_power",
+  "linearization_toe": 0.12,
+  "matched_ori_acutance_correction_clip_hi": 1.1,
+  "matched_ori_acutance_correction_clip_lo": 0.9,
+  "matched_ori_acutance_correction_delta_power": 1.0,
+  "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+  "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+    0.0,
+    0.25,
+    0.6,
+    0.8,
+    1.6,
+    2.5
+  ],
+  "matched_ori_acutance_curve_correction_clip_hi_values": [
+    1.02,
+    1.03,
+    0.895,
+    0.895,
+    1.05,
+    1.06
+  ],
+  "matched_ori_acutance_curve_correction_delta_power": 0.95,
+  "matched_ori_acutance_preset_correction_delta_power": null,
+  "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+    0.0,
+    4.5,
+    5.8,
+    6.2
+  ],
+  "matched_ori_acutance_preset_correction_delta_power_values": [
+    1.05,
+    1.05,
+    1.85,
+    1.85
+  ],
+  "matched_ori_acutance_preset_strength_curve_relative_scales": [
+    0.0,
+    3.0,
+    4.5,
+    5.8,
+    6.2
+  ],
+  "matched_ori_acutance_preset_strength_curve_values": [
+    1.0,
+    1.0,
+    0.85,
+    0.45,
+    0.45
+  ],
+  "matched_ori_acutance_reference_anchor": true,
+  "matched_ori_acutance_strength_curve_relative_scales": [
+    0.0,
+    0.2,
+    0.8,
+    1.6,
+    2.5
+  ],
+  "matched_ori_acutance_strength_curve_values": [
+    0.7,
+    0.69,
+    0.64,
+    0.62,
+    0.6
+  ],
+  "matched_ori_anchor_mode": "acutance_only",
+  "matched_ori_correction_clip_hi": 2.0,
+  "matched_ori_correction_clip_lo": 0.5,
+  "matched_ori_reference_anchor": true,
+  "matched_ori_strength_curve_frequencies": [
+    0.0,
+    0.12,
+    0.22,
+    0.35,
+    0.5
+  ],
+  "matched_ori_strength_curve_values": [
+    1.0,
+    1.0,
+    0.82,
+    0.95,
+    1.0
+  ],
+  "mtf_compensation_mode": "sensor_aperture_sinc",
+  "mtf_shape_correction_gain": 0.035,
+  "mtf_shape_correction_high_peak_cpp": 0.4,
+  "mtf_shape_correction_high_start_cpp": 0.36,
+  "mtf_shape_correction_high_stop_cpp": 0.49,
+  "mtf_shape_correction_high_weight": 0.25,
+  "mtf_shape_correction_mid_peak_cpp": 0.145,
+  "mtf_shape_correction_mid_start_cpp": 0.095,
+  "mtf_shape_correction_mid_stop_cpp": 0.19,
+  "mtf_shape_correction_mode": "hf_noise_share_gated_bump",
+  "mtf_shape_correction_share_gate_hi": 0.08,
+  "mtf_shape_correction_share_gate_lo": 0.05,
+  "name": "deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_hf_noise_share_shape",
+  "noise_psd_model": "empirical",
+  "noise_psd_scale": 1.0,
+  "normalization_band_hi": 0.03,
+  "normalization_band_lo": 0.01,
+  "normalization_mode": "max",
+  "quality_loss_coefficients": [
+    37.240228358776136,
+    26.54550669779819,
+    0.4538662637619741
+  ],
+  "quality_loss_om_ceiling": 0.8851,
+  "quality_loss_preset_overrides": {
+    "5.5\" Phone Display Quality Loss": {
+      "coefficients": [
+        -110912321.41149135,
+        50461107.51563171,
+        -9079490.127807735,
+        815148.8697247265,
+        -37712.984407641874,
+        854.6941149036079,
+        -6.261149027919645
+      ],
+      "om_ceiling": 0.8851
+    },
+    "Computer Monitor Quality Loss": {
+      "coefficients": [
+        5677361.198044325,
+        -16715685.9524707,
+        20317567.326582585,
+        -13046703.33912079,
+        4667794.619228022,
+        -882296.9160375095,
+        68863.59709647154
+      ],
+      "om_ceiling": 0.8851
+    },
+    "Large Print Quality Loss": {
+      "coefficients": [
+        2355074.475971866,
+        -5276146.244338096,
+        4846781.143787682,
+        -2336594.295523967,
+        623766.4933095274,
+        -87476.30712136331,
+        5049.882965558553
+      ],
+      "om_ceiling": 0.8851
+    },
+    "Small Print Quality Loss": {
+      "coefficients": [
+        6690980.837239251,
+        -12955277.716404187,
+        10300283.291740375,
+        -4303759.200708971,
+        996904.2653558743,
+        -121409.71509269004,
+        6084.6471373306085
+      ],
+      "om_ceiling": 0.8851
+    },
+    "UHDTV Display Quality Loss": {
+      "coefficients": [
+        1783462.6221675149,
+        -3813432.5606394163,
+        3326218.4642961356,
+        -1514886.1959663907,
+        380334.163146246,
+        -49956.87092015135,
+        2692.9566508574017
+      ],
+      "om_ceiling": 0.8851
+    }
+  },
+  "roi_height": 1673,
+  "roi_refine_area_tolerance": 0.98,
+  "roi_refine_min_border_margin": 8,
+  "roi_refine_percentile": 45.0,
+  "roi_refine_search_radius": 4,
+  "roi_refine_sigma": 5.0,
+  "roi_refine_step": 2,
+  "roi_source": "reference_refined",
+  "roi_width": 1655,
+  "sensor_fill_factor": 1.5,
+  "texture_support_scale": true
+}

--- a/artifacts/issue70_phone_preset_gap_acutance_benchmark.json
+++ b/artifacts/issue70_phone_preset_gap_acutance_benchmark.json
@@ -1,0 +1,499 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "readout_interpolation": "linear",
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.042590946803836086,
+        "0.25": 0.03445388601391976,
+        "0.4": 0.02812300087573406,
+        "0.65": 0.03348094496771122,
+        "0.8": 0.03985097286768009,
+        "ori": 0.04437175852000011
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 1.340078092044587,
+        "0.25": 1.2821447346117552,
+        "0.4": 1.1338375203719742,
+        "0.65": 0.3638397334773291,
+        "0.8": 1.0108222634621686,
+        "ori": 2.317384589918815
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.042486831218701795,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.013802247905288301,
+          "Computer Monitor Acutance": 0.052665183748573804,
+          "Large Print Acutance": 0.05132586418527154,
+          "Small Print Acutance": 0.046702107662187464,
+          "UHDTV Display Acutance": 0.04793875259218785
+        },
+        "curve_mae_mean": 0.03678903166100513,
+        "overall_quality_loss_mae_mean": 1.2214989544377113,
+        "quality_loss_focus_preset_mae_mean": 1.2214989544377113,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 0.14297991495607307,
+          "Computer Monitor Quality Loss": 2.902905846061304,
+          "Large Print Quality Loss": 0.9548172583377941,
+          "Small Print Quality Loss": 0.6076935256225349,
+          "UHDTV Display Quality Loss": 1.4990982272108502
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_profile.json"
+    },
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "hf_noise_share_gated_bump",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "readout_interpolation": "linear",
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.043113407575160405,
+        "0.25": 0.03461584390144325,
+        "0.4": 0.028133813966770053,
+        "0.65": 0.03397020307537763,
+        "0.8": 0.04034183879547649,
+        "ori": 0.04493419193982748
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 1.3945628335499742,
+        "0.25": 1.2873403961333079,
+        "0.4": 1.1280341337026882,
+        "0.65": 0.3661643883583465,
+        "0.8": 1.0093103839605313,
+        "ori": 2.3085257681328746
+      },
+      "delta_vs_first_profile": {
+        "acutance_focus_preset_mae_mean": 0.0003539678143051547,
+        "curve_mae_mean": 0.0003423886882854138,
+        "overall_quality_loss_mae_mean": 0.009819610680711133,
+        "quality_loss_focus_preset_mae_mean": 0.009819610680711133
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.04284079903300695,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.013785370948158788,
+          "Computer Monitor Acutance": 0.052847124432400264,
+          "Large Print Acutance": 0.052133859478729186,
+          "Small Print Acutance": 0.04742361772120971,
+          "UHDTV Display Acutance": 0.04801402258453681
+        },
+        "curve_mae_mean": 0.037131420349290546,
+        "overall_quality_loss_mae_mean": 1.2313185651184224,
+        "quality_loss_focus_preset_mae_mean": 1.2313185651184224,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 0.14145355062203685,
+          "Computer Monitor Quality Loss": 2.936423158336885,
+          "Large Print Quality Loss": 0.9501995784869728,
+          "Small Print Quality Loss": 0.6080763641030169,
+          "UHDTV Display Quality Loss": 1.520440174043201
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_hf_noise_share_shape_profile.json"
+    }
+  ]
+}

--- a/artifacts/issue70_phone_preset_gap_psd_benchmark.json
+++ b/artifacts/issue70_phone_preset_gap_psd_benchmark.json
@@ -1,0 +1,377 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "readout_interpolation": "linear",
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.04505838676895136,
+        "0.25": 0.03830294990572591,
+        "0.4": 0.03417346101446392,
+        "0.65": 0.04016098674153959,
+        "0.8": 0.04962195025048853,
+        "ori": 0.055534435160880836
+      },
+      "overall": {
+        "curve_mae_mean": 0.04300089177816799,
+        "mtf_abs_signed_rel_mean": 0.08671416893394165,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.01764835359892083,
+            "mre_mean": 0.088865357734797,
+            "signed_rel_mean": 0.04982888092128941
+          },
+          "low": {
+            "mae_mean": 0.03704553941403868,
+            "mre_mean": 0.046572470331734825,
+            "signed_rel_mean": 0.0237949421475065
+          },
+          "mid": {
+            "mae_mean": 0.03898616152003224,
+            "mre_mean": 0.12397538768693758,
+            "signed_rel_mean": 0.10965436746685472
+          },
+          "top": {
+            "mae_mean": 0.07374065223652229,
+            "mre_mean": 0.20171750026037474,
+            "signed_rel_mean": -0.16357848520011598
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.03301077142967389,
+          "mtf30": 0.03693639342667963,
+          "mtf50": 0.009332615436071163
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.014469251255210305,
+          "Computer Monitor Acutance": 0.06140362409578977,
+          "Large Print Acutance": 0.05374588217426117,
+          "Small Print Acutance": 0.06169135551342499,
+          "UHDTV Display Acutance": 0.05600207521610212
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_profile.json"
+    },
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "hf_noise_share_gated_bump",
+        "readout_interpolation": "linear",
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.04505838676895136,
+        "0.25": 0.03830294990572591,
+        "0.4": 0.03417346101446392,
+        "0.65": 0.04016098674153959,
+        "0.8": 0.04962195025048853,
+        "ori": 0.055534435160880836
+      },
+      "overall": {
+        "curve_mae_mean": 0.04300089177816799,
+        "mtf_abs_signed_rel_mean": 0.08671416893394165,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.01764835359892083,
+            "mre_mean": 0.088865357734797,
+            "signed_rel_mean": 0.04982888092128941
+          },
+          "low": {
+            "mae_mean": 0.03704553941403868,
+            "mre_mean": 0.046572470331734825,
+            "signed_rel_mean": 0.0237949421475065
+          },
+          "mid": {
+            "mae_mean": 0.03898616152003224,
+            "mre_mean": 0.12397538768693758,
+            "signed_rel_mean": 0.10965436746685472
+          },
+          "top": {
+            "mae_mean": 0.07374065223652229,
+            "mre_mean": 0.20171750026037474,
+            "signed_rel_mean": -0.16357848520011598
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.03301077142967389,
+          "mtf30": 0.03693639342667963,
+          "mtf50": 0.009332615436071163
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.014469251255210305,
+          "Computer Monitor Acutance": 0.06140362409578977,
+          "Large Print Acutance": 0.05374588217426117,
+          "Small Print Acutance": 0.06169135551342499,
+          "UHDTV Display Acutance": 0.05600207521610212
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_hf_noise_share_shape_profile.json"
+    }
+  ]
+}

--- a/artifacts/phone_preset_gap_benchmark.json
+++ b/artifacts/phone_preset_gap_benchmark.json
@@ -1,0 +1,72 @@
+{
+  "acceptance": {
+    "all_primary_gates_pass": false,
+    "curve_mae_mean_improved": false,
+    "focus_preset_acutance_mae_mean_improved": false,
+    "mtf_thresholds_non_worse": true,
+    "overall_quality_loss_mae_mean_improved": false,
+    "phone_acutance_improved": true,
+    "phone_quality_loss_improved": true,
+    "trend_correctness_not_regressed": true
+  },
+  "baseline": {
+    "curve_mae_mean": 0.03678903166100513,
+    "focus_preset_acutance_mae_mean": 0.042486831218701795,
+    "mtf_threshold_mae": {
+      "mtf20": 0.03301077142967389,
+      "mtf30": 0.03693639342667963,
+      "mtf50": 0.009332615436071163
+    },
+    "overall_quality_loss_mae_mean": 1.2214989544377113,
+    "phone_acutance_mae": 0.013802247905288301,
+    "phone_quality_loss_mae": 0.14297991495607307,
+    "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_profile.json"
+  },
+  "candidate": {
+    "curve_mae_mean": 0.037131420349290546,
+    "focus_preset_acutance_mae_mean": 0.04284079903300695,
+    "mtf_threshold_mae": {
+      "mtf20": 0.03301077142967389,
+      "mtf30": 0.03693639342667963,
+      "mtf50": 0.009332615436071163
+    },
+    "overall_quality_loss_mae_mean": 1.2313185651184224,
+    "phone_acutance_mae": 0.013785370948158788,
+    "phone_quality_loss_mae": 0.14145355062203685,
+    "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_hf_noise_share_shape_profile.json"
+  },
+  "dataset_root": "20260318_deadleaf_13b10",
+  "delta": {
+    "curve_mae_mean": 0.0003423886882854138,
+    "focus_preset_acutance_mae_mean": 0.0003539678143051547,
+    "mtf_threshold_mae": {
+      "mtf20": 0.0,
+      "mtf30": 0.0,
+      "mtf50": 0.0
+    },
+    "overall_quality_loss_mae_mean": 0.009819610680711133,
+    "phone_acutance_mae": -1.6876957129513537e-05,
+    "phone_quality_loss_mae": -0.0015263643340362176
+  },
+  "issue": 70,
+  "sources": {
+    "acutance_artifact_path": "artifacts/issue70_phone_preset_gap_acutance_benchmark.json",
+    "psd_artifact_path": "artifacts/issue70_phone_preset_gap_psd_benchmark.json"
+  },
+  "summary_kind": "phone_preset_gap_followup",
+  "trend_guard": {
+    "artifact_paths": [
+      "artifacts/amodel_gray_texture_series_penalty_benchmark.json"
+    ],
+    "changed_by_issue70": false,
+    "gain_trend_delta_mae_mean": 0.018148882951082922,
+    "gain_trend_series_shape_error": 0.018628257751567734,
+    "note": "Issue #70 only changes the direct-method upstream parity branch. The tracked release trend guard therefore remains the current parity-fit release row.",
+    "profile_path": "release/deadleaf_13b10_release/config/parity_fit_profile.release.json",
+    "trend_correctness": {
+      "group_count": 20,
+      "match_count": 3,
+      "match_rate": 0.15
+    }
+  }
+}

--- a/docs/phone_preset_gap_followup.md
+++ b/docs/phone_preset_gap_followup.md
@@ -1,0 +1,138 @@
+# Issue 70 Phone Preset Gap Follow-up
+
+This note records the bounded issue `#70` follow-up for the remaining `5.5" Phone Display` gap after the canonical scoreboard chain completed in issue `#69`.
+
+## Why This Slice
+
+The canonical scoreboard made two facts clear:
+
+- the current best still-`parity-valid` direct-method row remains [issue `#29` anchored high-frequency PSD](./issue29_anchored_high_frequency_psd_followup.md)
+- the best recent source-backed phone-improving family inside the current direct-method line is the bounded scene-/process-dependent ISP proxy from [issue `#61`](./issue61_isp_family_followup.md)
+
+Issue `#70` therefore tested the narrowest source-backed next slice that still uses current repo evidence instead of a preset-side display patch:
+
+- keep the issue-29 anchored-high-frequency PSD baseline intact
+- carry over the existing `hf_noise_share_gated_bump` MTF-shape correction from issue `#61`
+- do not change the release profile or any `Phone` preset display compensation
+
+That keeps the change in the upstream `MTF / PSD` family rather than masking the residual with a downstream preset override.
+
+## Profiles Compared
+
+Baseline, representing the best current parity-valid direct-method row:
+
+- [../algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_profile.json](../algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_profile.json)
+
+Issue `#70` candidate:
+
+- [../algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_hf_noise_share_shape_profile.json](../algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_hf_noise_share_shape_profile.json)
+
+Checked-in artifacts:
+
+- [../artifacts/issue70_phone_preset_gap_psd_benchmark.json](../artifacts/issue70_phone_preset_gap_psd_benchmark.json)
+- [../artifacts/issue70_phone_preset_gap_acutance_benchmark.json](../artifacts/issue70_phone_preset_gap_acutance_benchmark.json)
+- [../artifacts/phone_preset_gap_benchmark.json](../artifacts/phone_preset_gap_benchmark.json)
+
+The candidate changes only one upstream family knob set relative to the baseline:
+
+- `mtf_shape_correction_mode: none -> hf_noise_share_gated_bump`
+- `mtf_shape_correction_gain = 0.035`
+- `mtf_shape_correction_share_gate_lo / hi = 0.05 / 0.08`
+- same issue-61 mid/high-band shape parameters
+
+Everything else stays on the issue-29 anchored-high-frequency PSD line, including:
+
+- anchored PSD calibration
+- `roi_source = reference_refined`
+- current matched-ORI correction stack
+- current Acutance / Quality Loss correction stack
+
+## Result
+
+### Primary direct-method parity metrics
+
+| Profile | `curve_mae_mean` | focus-preset Acutance MAE mean | `overall_quality_loss_mae_mean` | `Phone Acutance MAE` | `Phone Quality Loss MAE` |
+| --- | --- | --- | --- | --- | --- |
+| issue `#29` anchored-HF baseline | `0.03678903` | `0.04248683` | `1.22149895` | `0.01380225` | `0.14297991` |
+| issue `#70` candidate | `0.03713142` | `0.04284080` | `1.23131857` | `0.01378537` | `0.14145355` |
+
+Metric deltas from the baseline:
+
+- `curve_mae_mean`: `+0.00034239` worse
+- focus-preset Acutance MAE mean: `+0.00035397` worse
+- `overall_quality_loss_mae_mean`: `+0.00981961` worse
+- `Phone Acutance MAE`: `-0.00001688` better
+- `Phone Quality Loss MAE`: `-0.00152636` better
+
+### `MTF20 / MTF30 / MTF50` guardrail
+
+| Profile | `MTF20` MAE | `MTF30` MAE | `MTF50` MAE |
+| --- | --- | --- | --- |
+| issue `#29` anchored-HF baseline | `0.03301077` | `0.03693639` | `0.00933262` |
+| issue `#70` candidate | `0.03301077` | `0.03693639` | `0.00933262` |
+
+Threshold readouts are unchanged to the checked precision:
+
+- `MTF20`: unchanged
+- `MTF30`: unchanged
+- `MTF50`: unchanged
+
+### Trend guard
+
+Issue `#70` does not modify the tracked release profile, so the checked-in trend guard remains the current `release/parity_fit` row:
+
+- trend correctness: `3/20 (0.150)`
+- gain-trend series shape error: `0.01862826`
+- gain-trend delta MAE mean: `0.01814888`
+
+The machine-readable issue artifact records this explicitly as an unchanged release-side guard:
+
+- [../artifacts/phone_preset_gap_benchmark.json](../artifacts/phone_preset_gap_benchmark.json)
+
+## Acceptance Readout
+
+Issue `#70` asked for simultaneous improvement, not a `Phone`-only win.
+
+What improved:
+
+- `Phone Acutance MAE`
+- `Phone Quality Loss MAE`
+- `MTF20 / MTF30 / MTF50` did not regress
+- tracked release trend guard did not regress because the release path was unchanged
+
+What failed the acceptance gate:
+
+- `curve_mae_mean` regressed
+- focus-preset Acutance MAE mean regressed
+- `overall_quality_loss_mae_mean` regressed
+
+So this branch does narrow the Phone preset gap, but it does not satisfy the issue requirement that the overall MAE improve at the same time.
+
+## Source Attribution
+
+The small phone gain here comes from the upstream `MTF / PSD` side, not from the display model:
+
+- no `Phone` preset viewing-distance or display-MTF override changed
+- no release profile changed
+- the only delta is the source-backed `high_frequency_noise_share`-gated post-MTF shape correction already documented in issue `#61`
+
+That makes this result useful even though it is not promotable: it shows that the bounded scene-/process-dependent ISP proxy can shave a little of the phone residual on the stronger anchored-HF baseline, but it still does not transfer into a simultaneous whole-surface MAE improvement.
+
+## Conclusion
+
+This is a bounded mixed negative result, not a new default path.
+
+The issue-61 ISP proxy survives as a source-backed explanation line for part of the Phone residual, but on the current anchored-HF baseline it remains too weak and too mixed:
+
+- `Phone` improves slightly
+- threshold readouts stay flat
+- aggregate parity metrics regress
+
+So the repo should keep the issue-29 anchored-HF line as the stronger parity-valid direct-method branch, record this issue-70 result as another bounded negative/mixed family, and leave the next follow-up to a different source-backed family rather than a stronger version of the same phone-targeted shape tweak.
+
+## Validation
+
+- `python3 -m algo.benchmark_parity_psd_mtf 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_profile.json algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_hf_noise_share_shape_profile.json --output artifacts/issue70_phone_preset_gap_psd_benchmark.json`
+- `python3 -m algo.benchmark_parity_acutance_quality_loss 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_profile.json algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_hf_noise_share_shape_profile.json --output artifacts/issue70_phone_preset_gap_acutance_benchmark.json`
+- `python3 -m algo.build_phone_preset_gap_benchmark`
+- `python3 -m pytest tests/test_build_phone_preset_gap_benchmark.py tests/test_benchmark_parity_psd_mtf.py tests/test_benchmark_parity_acutance_quality_loss.py`

--- a/tests/test_build_phone_preset_gap_benchmark.py
+++ b/tests/test_build_phone_preset_gap_benchmark.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from algo.build_phone_preset_gap_benchmark import build_phone_preset_gap_benchmark
+
+
+class BuildPhonePresetGapBenchmarkTest(unittest.TestCase):
+    def test_issue61_proxy_example_keeps_trend_guard_and_exposes_tradeoff(self) -> None:
+        payload = build_phone_preset_gap_benchmark(
+            repo_root=self.repo_root(),
+            psd_artifact_path=Path("artifacts/issue61_isp_family_psd_benchmark.json"),
+            acutance_artifact_path=Path("artifacts/issue61_isp_family_acutance_benchmark.json"),
+            baseline_profile_path=Path(
+                "algo/"
+                "deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_"
+                "curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_"
+                "psd_roi_reference_only_profile.json"
+            ),
+            candidate_profile_path=Path(
+                "algo/"
+                "deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_"
+                "curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_"
+                "psd_roi_reference_only_hf_noise_share_shape_profile.json"
+            ),
+            trend_profile_path=Path(
+                "release/deadleaf_13b10_release/config/parity_fit_profile.release.json"
+            ),
+        )
+
+        self.assertEqual(payload["issue"], 70)
+        self.assertEqual(
+            payload["trend_guard"]["trend_correctness"]["match_count"],
+            3,
+        )
+        self.assertEqual(
+            payload["trend_guard"]["trend_correctness"]["group_count"],
+            20,
+        )
+        self.assertAlmostEqual(
+            payload["trend_guard"]["gain_trend_series_shape_error"],
+            0.018628257751567734,
+        )
+        self.assertTrue(payload["acceptance"]["phone_acutance_improved"])
+        self.assertTrue(payload["acceptance"]["phone_quality_loss_improved"])
+        self.assertFalse(payload["acceptance"]["curve_mae_mean_improved"])
+        self.assertTrue(payload["acceptance"]["mtf_thresholds_non_worse"])
+        self.assertFalse(payload["acceptance"]["all_primary_gates_pass"])
+
+    @staticmethod
+    def repo_root() -> Path:
+        return Path(__file__).resolve().parents[1]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add the issue-70 anchored-HF plus noise-share-shape candidate profile and checked-in PSD/acutance benchmark artifacts
- add a reproducible phone-preset-gap benchmark builder plus focused regression test
- document the result as a bounded mixed negative: phone metrics improve slightly, but overall parity MAEs regress and the unchanged release trend guard stays flat

## Validation
- python3 -m pytest tests/test_build_phone_preset_gap_benchmark.py tests/test_benchmark_parity_psd_mtf.py tests/test_benchmark_parity_acutance_quality_loss.py
- python3 -m algo.benchmark_parity_psd_mtf 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_profile.json algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_hf_noise_share_shape_profile.json --output artifacts/issue70_phone_preset_gap_psd_benchmark.json
- python3 -m algo.benchmark_parity_acutance_quality_loss 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_profile.json algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_hf_noise_share_shape_profile.json --output artifacts/issue70_phone_preset_gap_acutance_benchmark.json
- python3 -m algo.build_phone_preset_gap_benchmark

Refs #70