### PR TITLE
Issue #70: fix phone gap acceptance gating

### DIFF
--- a/algo/build_phone_preset_gap_benchmark.py
+++ b/algo/build_phone_preset_gap_benchmark.py
@@ -118,6 +118,20 @@ def metric_delta(candidate: float, baseline: float) -> float:
     return float(candidate - baseline)
 
 
+def primary_gates_pass(acceptance: dict[str, bool]) -> bool:
+    return all(
+        (
+            acceptance["phone_acutance_improved"],
+            acceptance["phone_quality_loss_improved"],
+            acceptance["curve_mae_mean_improved"],
+            acceptance["focus_preset_acutance_mae_mean_improved"],
+            acceptance["overall_quality_loss_mae_mean_improved"],
+            acceptance["mtf_thresholds_non_worse"],
+            acceptance["trend_correctness_not_regressed"],
+        )
+    )
+
+
 def build_phone_preset_gap_benchmark(
     *,
     repo_root: Path,
@@ -202,16 +216,7 @@ def build_phone_preset_gap_benchmark(
         ),
         "trend_correctness_not_regressed": True,
     }
-    acceptance["all_primary_gates_pass"] = all(
-        (
-            acceptance["phone_acutance_improved"],
-            acceptance["phone_quality_loss_improved"],
-            acceptance["curve_mae_mean_improved"],
-            acceptance["overall_quality_loss_mae_mean_improved"],
-            acceptance["mtf_thresholds_non_worse"],
-            acceptance["trend_correctness_not_regressed"],
-        )
-    )
+    acceptance["all_primary_gates_pass"] = primary_gates_pass(acceptance)
 
     return {
         "issue": 70,

--- a/tests/test_build_phone_preset_gap_benchmark.py
+++ b/tests/test_build_phone_preset_gap_benchmark.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import unittest
 from pathlib import Path
 
-from algo.build_phone_preset_gap_benchmark import build_phone_preset_gap_benchmark
+from algo.build_phone_preset_gap_benchmark import (
+    build_phone_preset_gap_benchmark,
+    primary_gates_pass,
+)
 
 
 class BuildPhonePresetGapBenchmarkTest(unittest.TestCase):
@@ -47,6 +50,19 @@ class BuildPhonePresetGapBenchmarkTest(unittest.TestCase):
         self.assertFalse(payload["acceptance"]["curve_mae_mean_improved"])
         self.assertTrue(payload["acceptance"]["mtf_thresholds_non_worse"])
         self.assertFalse(payload["acceptance"]["all_primary_gates_pass"])
+
+    def test_primary_gates_fail_when_only_focus_preset_acutance_regresses(self) -> None:
+        acceptance = {
+            "phone_acutance_improved": True,
+            "phone_quality_loss_improved": True,
+            "curve_mae_mean_improved": True,
+            "focus_preset_acutance_mae_mean_improved": False,
+            "overall_quality_loss_mae_mean_improved": True,
+            "mtf_thresholds_non_worse": True,
+            "trend_correctness_not_regressed": True,
+        }
+
+        self.assertFalse(primary_gates_pass(acceptance))
 
     @staticmethod
     def repo_root() -> Path:


### PR DESCRIPTION
## Summary
- include the focus-preset Acutance MAE gate in `all_primary_gates_pass` for the issue-70 benchmark builder
- factor the primary acceptance conjunction into a helper so the gate set is explicit and testable
- add a regression test for the masked case where only the focus-preset Acutance metric regresses

## Validation
- python3 -m pytest tests/test_build_phone_preset_gap_benchmark.py
- python3 -m algo.build_phone_preset_gap_benchmark

Refs #70