### PR TITLE
Issue #81: isolate phase-retained intrinsic quality loss

### DIFF
--- a/algo/benchmark_parity_acutance_quality_loss.py
+++ b/algo/benchmark_parity_acutance_quality_loss.py
@@ -682,7 +682,11 @@ def summarize_profile(
                 raise ValueError(
                     f"Unsupported intrinsic full-reference mode: {profile.intrinsic_full_reference_mode}"
                 )
-            if profile.intrinsic_full_reference_scope not in {"replace_all", "acutance_only"}:
+            if profile.intrinsic_full_reference_scope not in {
+                "replace_all",
+                "acutance_only",
+                "quality_loss_isolation",
+            }:
                 raise ValueError(
                     f"Unsupported intrinsic full-reference scope: {profile.intrinsic_full_reference_scope}"
                 )
@@ -915,7 +919,8 @@ def summarize_profile(
         )
         if (
             profile.intrinsic_full_reference_mode != "none"
-            and profile.intrinsic_full_reference_scope == "acutance_only"
+            and profile.intrinsic_full_reference_scope
+            in {"acutance_only", "quality_loss_isolation"}
         ):
             quality_loss_curve = acutance_curve_from_mtf(
                 quality_loss_scaled_frequencies,

--- a/algo/benchmark_parity_psd_mtf.py
+++ b/algo/benchmark_parity_psd_mtf.py
@@ -445,7 +445,11 @@ def profile_payload(
                 raise ValueError(
                     f"Unsupported intrinsic full-reference mode: {profile.intrinsic_full_reference_mode}"
                 )
-            if profile.intrinsic_full_reference_scope not in {"replace_all", "acutance_only"}:
+            if profile.intrinsic_full_reference_scope not in {
+                "replace_all",
+                "acutance_only",
+                "quality_loss_isolation",
+            }:
                 raise ValueError(
                     f"Unsupported intrinsic full-reference scope: {profile.intrinsic_full_reference_scope}"
                 )

--- a/algo/build_intrinsic_phase_retained_quality_loss_isolation_followup.py
+++ b/algo/build_intrinsic_phase_retained_quality_loss_isolation_followup.py
@@ -1,0 +1,393 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+CURRENT_BEST_LABEL = "current_best_pr30_branch"
+ISSUE34_LABEL = "issue34_intrinsic_full_reference"
+ISSUE47_LABEL = "issue47_phase_retained_replace_all"
+CANDIDATE_LABEL = "issue81_quality_loss_isolation_candidate"
+SUMMARY_KIND = "intrinsic_phase_retained_quality_loss_isolation_followup"
+GOLDEN_REFERENCE_ROOTS = (
+    "20260318_deadleaf_13b10",
+    "release/deadleaf_13b10_release/data/20260318_deadleaf_13b10",
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build the issue-81 phase-retained quality-loss isolation summary."
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Repository root. Defaults to the parent of this script.",
+    )
+    parser.add_argument(
+        "--psd-artifact",
+        type=Path,
+        default=Path("artifacts/issue81_intrinsic_phase_retained_quality_loss_isolation_psd_benchmark.json"),
+        help="Repo-relative PSD benchmark artifact path.",
+    )
+    parser.add_argument(
+        "--acutance-artifact",
+        type=Path,
+        default=Path("artifacts/issue81_intrinsic_phase_retained_quality_loss_isolation_acutance_benchmark.json"),
+        help="Repo-relative acutance/quality-loss benchmark artifact path.",
+    )
+    parser.add_argument(
+        "--output-json",
+        type=Path,
+        default=Path("artifacts/intrinsic_phase_retained_quality_loss_isolation_benchmark.json"),
+        help="Repo-relative output path for the machine-readable issue artifact.",
+    )
+    parser.add_argument(
+        "--output-md",
+        type=Path,
+        default=Path("docs/intrinsic_phase_retained_quality_loss_isolation_followup.md"),
+        help="Repo-relative output path for the Markdown note.",
+    )
+    return parser
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def resolve_output(path: Path, repo_root: Path) -> Path:
+    return path if path.is_absolute() else repo_root / path
+
+
+def select_profile(payload: dict[str, Any], expected_profile_path: str) -> dict[str, Any]:
+    for profile in payload["profiles"]:
+        if profile["profile_path"] == expected_profile_path:
+            return profile
+    available = ", ".join(profile["profile_path"] for profile in payload["profiles"])
+    raise ValueError(
+        f"Profile {expected_profile_path!r} not found in artifact. Available: {available}"
+    )
+
+
+def summarize_profile(
+    *,
+    label: str,
+    psd_payload: dict[str, Any],
+    acutance_payload: dict[str, Any],
+    profile_path: str,
+) -> dict[str, Any]:
+    psd_profile = select_profile(psd_payload, profile_path)
+    acutance_profile = select_profile(acutance_payload, profile_path)
+    psd_overall = psd_profile["overall"]
+    acutance_overall = acutance_profile["overall"]
+    return {
+        "label": label,
+        "profile_path": profile_path,
+        "analysis_pipeline": acutance_profile["analysis_pipeline"],
+        "curve_mae_mean": float(acutance_overall["curve_mae_mean"]),
+        "focus_preset_acutance_mae_mean": float(acutance_overall["acutance_focus_preset_mae_mean"]),
+        "overall_quality_loss_mae_mean": float(acutance_overall["overall_quality_loss_mae_mean"]),
+        "mtf_abs_signed_rel_mean": float(psd_overall["mtf_abs_signed_rel_mean"]),
+        "mtf_threshold_mae": {
+            key: float(value) for key, value in psd_overall["mtf_threshold_mae"].items()
+        },
+    }
+
+
+def delta_map(candidate: dict[str, Any], baseline: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "curve_mae_mean": float(candidate["curve_mae_mean"] - baseline["curve_mae_mean"]),
+        "focus_preset_acutance_mae_mean": float(
+            candidate["focus_preset_acutance_mae_mean"]
+            - baseline["focus_preset_acutance_mae_mean"]
+        ),
+        "overall_quality_loss_mae_mean": float(
+            candidate["overall_quality_loss_mae_mean"]
+            - baseline["overall_quality_loss_mae_mean"]
+        ),
+        "mtf_abs_signed_rel_mean": float(
+            candidate["mtf_abs_signed_rel_mean"] - baseline["mtf_abs_signed_rel_mean"]
+        ),
+        "mtf_threshold_mae": {
+            key: float(candidate["mtf_threshold_mae"][key] - baseline["mtf_threshold_mae"][key])
+            for key in ("mtf20", "mtf30", "mtf50")
+        },
+    }
+
+
+def assert_storage_separation(payload: dict[str, Any]) -> None:
+    for path in payload["storage"]["new_fitted_artifact_paths"]:
+        for root in GOLDEN_REFERENCE_ROOTS:
+            if path.startswith(root):
+                raise ValueError(f"Path {path} leaks into golden/reference root {root}")
+
+
+def build_payload(
+    repo_root: Path,
+    *,
+    psd_artifact_path: Path,
+    acutance_artifact_path: Path,
+) -> dict[str, Any]:
+    psd_artifact = resolve_output(psd_artifact_path, repo_root)
+    acutance_artifact = resolve_output(acutance_artifact_path, repo_root)
+    psd_payload = load_json(psd_artifact)
+    acutance_payload = load_json(acutance_artifact)
+    historical_psd = load_json(
+        resolve_output(Path("artifacts/issue46_intrinsic_phase_retention_psd_benchmark.json"), repo_root)
+    )
+    historical_acutance = load_json(
+        resolve_output(Path("artifacts/issue46_intrinsic_phase_retention_acutance_benchmark.json"), repo_root)
+    )
+    current_best_psd = load_json(
+        resolve_output(Path("artifacts/issue77_measured_oecf_psd_benchmark.json"), repo_root)
+    )
+    current_best_acutance = load_json(
+        resolve_output(Path("artifacts/issue77_measured_oecf_acutance_benchmark.json"), repo_root)
+    )
+
+    profiles = {
+        CURRENT_BEST_LABEL: summarize_profile(
+            label=CURRENT_BEST_LABEL,
+            psd_payload=current_best_psd,
+            acutance_payload=current_best_acutance,
+            profile_path="algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_profile.json",
+        ),
+        ISSUE34_LABEL: summarize_profile(
+            label=ISSUE34_LABEL,
+            psd_payload=historical_psd,
+            acutance_payload=historical_acutance,
+            profile_path="algo/deadleaf_13b10_imatest_intrinsic_full_reference_profile.json",
+        ),
+        ISSUE47_LABEL: summarize_profile(
+            label=ISSUE47_LABEL,
+            psd_payload=historical_psd,
+            acutance_payload=historical_acutance,
+            profile_path="algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_profile.json",
+        ),
+        CANDIDATE_LABEL: summarize_profile(
+            label=CANDIDATE_LABEL,
+            psd_payload=psd_payload,
+            acutance_payload=acutance_payload,
+            profile_path="algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_quality_loss_isolation_profile.json",
+        ),
+    }
+
+    current_best = profiles[CURRENT_BEST_LABEL]
+    issue34 = profiles[ISSUE34_LABEL]
+    issue47 = profiles[ISSUE47_LABEL]
+    candidate = profiles[CANDIDATE_LABEL]
+    comparisons = {
+        "candidate_vs_issue47": {
+            "delta": delta_map(candidate, issue47),
+            "curve_mae_non_worse_than_issue47": candidate["curve_mae_mean"] <= issue47["curve_mae_mean"],
+            "focus_preset_acutance_non_worse_than_issue47": (
+                candidate["focus_preset_acutance_mae_mean"]
+                <= issue47["focus_preset_acutance_mae_mean"]
+            ),
+            "overall_quality_loss_improved": (
+                candidate["overall_quality_loss_mae_mean"]
+                < issue47["overall_quality_loss_mae_mean"]
+            ),
+        },
+        "candidate_vs_issue34": {
+            "delta": delta_map(candidate, issue34),
+            "curve_mae_non_worse_than_issue34": candidate["curve_mae_mean"] <= issue34["curve_mae_mean"],
+            "focus_preset_acutance_non_worse_than_issue34": (
+                candidate["focus_preset_acutance_mae_mean"]
+                <= issue34["focus_preset_acutance_mae_mean"]
+            ),
+        },
+        "candidate_vs_current_best_pr30": {
+            "delta": delta_map(candidate, current_best),
+        },
+    }
+    acceptance = {
+        "curve_mae_non_worse_than_issue34": comparisons["candidate_vs_issue34"][
+            "curve_mae_non_worse_than_issue34"
+        ],
+        "focus_preset_acutance_non_worse_than_issue34": comparisons["candidate_vs_issue34"][
+            "focus_preset_acutance_non_worse_than_issue34"
+        ],
+        "overall_quality_loss_improved_vs_issue47": comparisons["candidate_vs_issue47"][
+            "overall_quality_loss_improved"
+        ],
+    }
+    acceptance["all_issue81_gates_pass"] = all(acceptance.values())
+
+    payload = {
+        "issue": 81,
+        "summary_kind": SUMMARY_KIND,
+        "dataset_root": psd_payload["dataset_root"],
+        "profiles": profiles,
+        "comparisons": comparisons,
+        "acceptance": acceptance,
+        "implementation_change": {
+            "selected_slice_id": "phase_retained_intrinsic_quality_loss_isolation",
+            "scope_name": "quality_loss_isolation",
+            "basis_profile_path": issue47["profile_path"],
+            "candidate_profile_path": candidate["profile_path"],
+            "change": (
+                "Keep the phase-retained intrinsic transfer active for PSD and Acutance evaluation, "
+                "but route Quality Loss through the non-intrinsic compensated MTF path."
+            ),
+            "scope_difference": {
+                "replace_all": (
+                    "Intrinsic transfer feeds both reported PSD/MTF and downstream Quality Loss."
+                ),
+                "acutance_only": (
+                    "Intrinsic transfer is limited to the acutance-side path under the older naming."
+                ),
+                "quality_loss_isolation": (
+                    "Intrinsic transfer remains active for PSD and Acutance evaluation, while "
+                    "Quality Loss is isolated to the non-intrinsic compensated MTF path."
+                ),
+            },
+        },
+        "conclusion": {
+            "status": (
+                "issue81_acceptance_passed_but_not_current_best"
+                if acceptance["all_issue81_gates_pass"]
+                else "bounded_negative"
+            ),
+            "summary": (
+                "The new scope is a real improvement over the old phase-retained replace_all path: "
+                "it preserves the intrinsic curve / focus-preset Acutance gains while materially "
+                "reducing overall Quality Loss. It still remains worse than the current PR #30 "
+                "main line on overall Quality Loss and MTF-threshold readouts."
+            ),
+            "next_step": (
+                "Keep this scope as the new bounded intrinsic record and evaluate whether a later "
+                "follow-up can reduce the remaining gap to the current best branch without "
+                "reopening unrelated families."
+            ),
+        },
+        "storage": {
+            "golden_reference_roots": list(GOLDEN_REFERENCE_ROOTS),
+            "new_fitted_artifact_paths": [
+                "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_quality_loss_isolation_profile.json",
+                "artifacts/issue81_intrinsic_phase_retained_quality_loss_isolation_psd_benchmark.json",
+                "artifacts/issue81_intrinsic_phase_retained_quality_loss_isolation_acutance_benchmark.json",
+                "artifacts/intrinsic_phase_retained_quality_loss_isolation_benchmark.json",
+            ],
+            "release_config_paths": [],
+            "rules": [
+                "Do not write fitted intrinsic profiles or benchmark outputs under the golden/reference roots.",
+                "Keep issue-81 fitted artifacts under `algo/` and `artifacts/` only.",
+                "Do not promote a release-facing config until the intrinsic route beats the tracked current-best guardrails.",
+            ],
+        },
+        "sources": {
+            "psd_artifact_path": str(psd_artifact.relative_to(repo_root)),
+            "acutance_artifact_path": str(acutance_artifact.relative_to(repo_root)),
+            "issue79_record": "docs/intrinsic_literal_next_slice.md",
+        },
+    }
+    assert_storage_separation(payload)
+    return payload
+
+
+def format_metric(value: float) -> str:
+    return f"{value:.5f}"
+
+
+def format_delta(value: float) -> str:
+    return f"{value:+.5f}"
+
+
+def render_markdown(payload: dict[str, Any]) -> str:
+    candidate = payload["profiles"][CANDIDATE_LABEL]
+    issue47 = payload["profiles"][ISSUE47_LABEL]
+    issue34 = payload["profiles"][ISSUE34_LABEL]
+    current_best = payload["profiles"][CURRENT_BEST_LABEL]
+    lines = [
+        "# Intrinsic Phase-Retained Quality-Loss Isolation Follow-up",
+        "",
+        "Issue `#81` implements the bounded slice selected in issue `#79` / PR `#80`: keep the phase-retained intrinsic transfer, but isolate downstream Quality Loss from the intrinsic path.",
+        "",
+        "## Scope",
+        "",
+        "- New intrinsic scope: `quality_loss_isolation`",
+        "- Basis profile: `algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_profile.json`",
+        "- Candidate profile: `algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_quality_loss_isolation_profile.json`",
+        "- Difference from `replace_all`: Quality Loss no longer consumes the intrinsic compensated MTF path.",
+        "- Difference from `acutance_only`: this issue names the narrower downstream-isolation intent explicitly on top of the stronger phase-retained intrinsic branch.",
+        "",
+        "## Result",
+        "",
+        "Current PR `#30` branch:",
+        "",
+        f"- `curve_mae_mean = {format_metric(current_best['curve_mae_mean'])}`",
+        f"- `focus_preset_acutance_mae_mean = {format_metric(current_best['focus_preset_acutance_mae_mean'])}`",
+        f"- `overall_quality_loss_mae_mean = {format_metric(current_best['overall_quality_loss_mae_mean'])}`",
+        "",
+        "PR `#34` intrinsic baseline:",
+        "",
+        f"- `curve_mae_mean = {format_metric(issue34['curve_mae_mean'])}`",
+        f"- `focus_preset_acutance_mae_mean = {format_metric(issue34['focus_preset_acutance_mae_mean'])}`",
+        f"- `overall_quality_loss_mae_mean = {format_metric(issue34['overall_quality_loss_mae_mean'])}`",
+        "",
+        "PR `#47` phase-retained intrinsic baseline:",
+        "",
+        f"- `curve_mae_mean = {format_metric(issue47['curve_mae_mean'])}`",
+        f"- `focus_preset_acutance_mae_mean = {format_metric(issue47['focus_preset_acutance_mae_mean'])}`",
+        f"- `overall_quality_loss_mae_mean = {format_metric(issue47['overall_quality_loss_mae_mean'])}`",
+        "",
+        "Issue `#81` quality-loss-isolated candidate:",
+        "",
+        f"- `curve_mae_mean = {format_metric(candidate['curve_mae_mean'])}`",
+        f"- `focus_preset_acutance_mae_mean = {format_metric(candidate['focus_preset_acutance_mae_mean'])}`",
+        f"- `overall_quality_loss_mae_mean = {format_metric(candidate['overall_quality_loss_mae_mean'])}`",
+        "",
+        "## Comparison",
+        "",
+        f"- Versus PR `#47`, `overall_quality_loss_mae_mean` changes by `{format_delta(payload['comparisons']['candidate_vs_issue47']['delta']['overall_quality_loss_mae_mean'])}`.",
+        f"- Versus PR `#34`, `curve_mae_mean` changes by `{format_delta(payload['comparisons']['candidate_vs_issue34']['delta']['curve_mae_mean'])}` and `focus_preset_acutance_mae_mean` changes by `{format_delta(payload['comparisons']['candidate_vs_issue34']['delta']['focus_preset_acutance_mae_mean'])}`.",
+        f"- Versus current PR `#30`, `curve_mae_mean` changes by `{format_delta(payload['comparisons']['candidate_vs_current_best_pr30']['delta']['curve_mae_mean'])}` and `overall_quality_loss_mae_mean` changes by `{format_delta(payload['comparisons']['candidate_vs_current_best_pr30']['delta']['overall_quality_loss_mae_mean'])}`.",
+        "",
+        "## Acceptance",
+        "",
+        f"- `curve_mae_mean` no worse than issue `#34`: `{payload['acceptance']['curve_mae_non_worse_than_issue34']}`",
+        f"- `focus_preset_acutance_mae_mean` no worse than issue `#34`: `{payload['acceptance']['focus_preset_acutance_non_worse_than_issue34']}`",
+        f"- `overall_quality_loss_mae_mean` improved versus issue `#47`: `{payload['acceptance']['overall_quality_loss_improved_vs_issue47']}`",
+        f"- All issue-81 gates pass: `{payload['acceptance']['all_issue81_gates_pass']}`",
+        "",
+        "## Conclusion",
+        "",
+        f"- Status: `{payload['conclusion']['status']}`",
+        f"- Summary: {payload['conclusion']['summary']}",
+        f"- Next step: {payload['conclusion']['next_step']}",
+        "",
+        "## Storage Separation",
+        "",
+        f"- Golden/reference roots: `{GOLDEN_REFERENCE_ROOTS[0]}`, `{GOLDEN_REFERENCE_ROOTS[1]}`",
+        "- Fitted outputs for this issue stay under `algo/` and `artifacts/` only.",
+        "- No release-facing config is promoted in this issue.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    repo_root = args.repo_root.resolve()
+    payload = build_payload(
+        repo_root,
+        psd_artifact_path=args.psd_artifact,
+        acutance_artifact_path=args.acutance_artifact,
+    )
+    output_json = resolve_output(args.output_json, repo_root)
+    output_md = resolve_output(args.output_md, repo_root)
+    write_text(output_json, json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    write_text(output_md, render_markdown(payload))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_quality_loss_isolation_profile.json
+++ b/algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_quality_loss_isolation_profile.json
@@ -1,0 +1,101 @@
+{
+  "name": "deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_quality_loss_isolation",
+  "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+  "gamma": 0.5,
+  "linearization_mode": "toe_power",
+  "linearization_toe": 0.12,
+  "bayer_pattern": "RGGB",
+  "bayer_mode": "demosaic_red",
+  "roi_source": "reference_refined",
+  "roi_width": 1655,
+  "roi_height": 1673,
+  "roi_refine_percentile": 45.0,
+  "roi_refine_sigma": 5.0,
+  "roi_refine_min_border_margin": 8,
+  "roi_refine_search_radius": 4,
+  "roi_refine_step": 2,
+  "roi_refine_area_tolerance": 0.98,
+  "intrinsic_full_reference_mode": "paired_ori_transfer",
+  "intrinsic_full_reference_scope": "quality_loss_isolation",
+  "intrinsic_full_reference_clip_lo": 0.5,
+  "intrinsic_full_reference_clip_hi": 1.5,
+  "intrinsic_full_reference_registration_mode": "phase_correlation",
+  "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+  "frequency_scale": 1.0,
+  "normalization_band_lo": 0.01,
+  "normalization_band_hi": 0.03,
+  "normalization_mode": "max",
+  "acutance_band_lo": 0.017,
+  "acutance_band_hi": 0.035,
+  "acutance_band_mode": "mean",
+  "noise_psd_model": "empirical",
+  "noise_psd_scale": 1.0,
+  "quality_loss_om_ceiling": 0.8851,
+  "quality_loss_coefficients": [
+    37.240228358776136,
+    26.54550669779819,
+    0.4538662637619741
+  ],
+  "quality_loss_preset_overrides": {
+    "Computer Monitor Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        5677361.198044325,
+        -16715685.9524707,
+        20317567.326582585,
+        -13046703.33912079,
+        4667794.619228022,
+        -882296.9160375095,
+        68863.59709647154
+      ]
+    },
+    "5.5\" Phone Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        -110912321.41149135,
+        50461107.51563171,
+        -9079490.127807735,
+        815148.8697247265,
+        -37712.984407641874,
+        854.6941149036079,
+        -6.261149027919645
+      ]
+    },
+    "UHDTV Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        1783462.6221675149,
+        -3813432.5606394163,
+        3326218.4642961356,
+        -1514886.1959663907,
+        380334.163146246,
+        -49956.87092015135,
+        2692.9566508574017
+      ]
+    },
+    "Small Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        6690980.837239251,
+        -12955277.716404187,
+        10300283.291740375,
+        -4303759.200708971,
+        996904.2653558743,
+        -121409.71509269004,
+        6084.6471373306085
+      ]
+    },
+    "Large Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        2355074.475971866,
+        -5276146.244338096,
+        4846781.143787682,
+        -2336594.295523967,
+        623766.4933095274,
+        -87476.30712136331,
+        5049.882965558553
+      ]
+    }
+  }
+}

--- a/artifacts/intrinsic_phase_retained_quality_loss_isolation_benchmark.json
+++ b/artifacts/intrinsic_phase_retained_quality_loss_isolation_benchmark.json
@@ -1,0 +1,787 @@
+{
+  "acceptance": {
+    "all_issue81_gates_pass": true,
+    "curve_mae_non_worse_than_issue34": true,
+    "focus_preset_acutance_non_worse_than_issue34": true,
+    "overall_quality_loss_improved_vs_issue47": true
+  },
+  "comparisons": {
+    "candidate_vs_current_best_pr30": {
+      "delta": {
+        "curve_mae_mean": -0.0039872260971888646,
+        "focus_preset_acutance_mae_mean": -0.013566304809976663,
+        "mtf_abs_signed_rel_mean": 0.29245982822483063,
+        "mtf_threshold_mae": {
+          "mtf20": 0.04154629091167393,
+          "mtf30": 0.038759987740504105,
+          "mtf50": 0.025286656638221876
+        },
+        "overall_quality_loss_mae_mean": 6.799042218904894
+      }
+    },
+    "candidate_vs_issue34": {
+      "curve_mae_non_worse_than_issue34": true,
+      "delta": {
+        "curve_mae_mean": -0.003071652990807701,
+        "focus_preset_acutance_mae_mean": -0.002731701180414395,
+        "mtf_abs_signed_rel_mean": 0.17286071204786402,
+        "mtf_threshold_mae": {
+          "mtf20": -0.008282371132811162,
+          "mtf30": 0.03775732272357057,
+          "mtf50": 0.029590344350634352
+        },
+        "overall_quality_loss_mae_mean": 3.4525320176690215
+      },
+      "focus_preset_acutance_non_worse_than_issue34": true
+    },
+    "candidate_vs_issue47": {
+      "curve_mae_non_worse_than_issue47": true,
+      "delta": {
+        "curve_mae_mean": 0.0,
+        "focus_preset_acutance_mae_mean": 0.0,
+        "mtf_abs_signed_rel_mean": 0.23923621156787914,
+        "mtf_threshold_mae": {
+          "mtf20": -0.011209288393153813,
+          "mtf30": 0.057804834625092644,
+          "mtf50": 0.027423184663686383
+        },
+        "overall_quality_loss_mae_mean": -6.455217672689061
+      },
+      "focus_preset_acutance_non_worse_than_issue47": true,
+      "overall_quality_loss_improved": true
+    }
+  },
+  "conclusion": {
+    "next_step": "Keep this scope as the new bounded intrinsic record and evaluate whether a later follow-up can reduce the remaining gap to the current best branch without reopening unrelated families.",
+    "status": "issue81_acceptance_passed_but_not_current_best",
+    "summary": "The new scope is a real improvement over the old phase-retained replace_all path: it preserves the intrinsic curve / focus-preset Acutance gains while materially reducing overall Quality Loss. It still remains worse than the current PR #30 main line on overall Quality Loss and MTF-threshold readouts."
+  },
+  "dataset_root": "20260318_deadleaf_13b10",
+  "implementation_change": {
+    "basis_profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_profile.json",
+    "candidate_profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_quality_loss_isolation_profile.json",
+    "change": "Keep the phase-retained intrinsic transfer active for PSD and Acutance evaluation, but route Quality Loss through the non-intrinsic compensated MTF path.",
+    "scope_difference": {
+      "acutance_only": "Intrinsic transfer is limited to the acutance-side path under the older naming.",
+      "quality_loss_isolation": "Intrinsic transfer remains active for PSD and Acutance evaluation, while Quality Loss is isolated to the non-intrinsic compensated MTF path.",
+      "replace_all": "Intrinsic transfer feeds both reported PSD/MTF and downstream Quality Loss."
+    },
+    "scope_name": "quality_loss_isolation",
+    "selected_slice_id": "phase_retained_intrinsic_quality_loss_isolation"
+  },
+  "issue": 81,
+  "profiles": {
+    "current_best_pr30_branch": {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "readout_interpolation": "linear",
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": true
+      },
+      "curve_mae_mean": 0.03678903166100513,
+      "focus_preset_acutance_mae_mean": 0.042486831218701795,
+      "label": "current_best_pr30_branch",
+      "mtf_abs_signed_rel_mean": 0.08671416893394165,
+      "mtf_threshold_mae": {
+        "mtf20": 0.03301077142967389,
+        "mtf30": 0.03693639342667963,
+        "mtf50": 0.009332615436071163
+      },
+      "overall_quality_loss_mae_mean": 1.2214989544377113,
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_profile.json"
+    },
+    "issue34_intrinsic_full_reference": {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": null,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": null,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_hi_values": null,
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": null,
+        "matched_ori_acutance_preset_correction_delta_power_values": null,
+        "matched_ori_acutance_preset_strength_curve_relative_scales": null,
+        "matched_ori_acutance_preset_strength_curve_values": null,
+        "matched_ori_acutance_reference_anchor": false,
+        "matched_ori_acutance_strength_curve_relative_scales": null,
+        "matched_ori_acutance_strength_curve_values": null,
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": false,
+        "matched_ori_strength_curve_frequencies": null,
+        "matched_ori_strength_curve_values": null,
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "none",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.0,
+        "texture_support_scale": false
+      },
+      "curve_mae_mean": 0.03587345855462397,
+      "focus_preset_acutance_mae_mean": 0.03165222758913953,
+      "label": "issue34_intrinsic_full_reference",
+      "mtf_abs_signed_rel_mean": 0.2063132851109083,
+      "mtf_threshold_mae": {
+        "mtf20": 0.08283943347415898,
+        "mtf30": 0.037939058443613165,
+        "mtf50": 0.005028927723658685
+      },
+      "overall_quality_loss_mae_mean": 4.568009155673584,
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_profile.json"
+    },
+    "issue47_phase_retained_replace_all": {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": null,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": null,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_hi_values": null,
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": null,
+        "matched_ori_acutance_preset_correction_delta_power_values": null,
+        "matched_ori_acutance_preset_strength_curve_relative_scales": null,
+        "matched_ori_acutance_preset_strength_curve_values": null,
+        "matched_ori_acutance_reference_anchor": false,
+        "matched_ori_acutance_strength_curve_relative_scales": null,
+        "matched_ori_acutance_strength_curve_values": null,
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": false,
+        "matched_ori_strength_curve_frequencies": null,
+        "matched_ori_strength_curve_values": null,
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "none",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.0,
+        "texture_support_scale": false
+      },
+      "curve_mae_mean": 0.03280180556381627,
+      "focus_preset_acutance_mae_mean": 0.028920526408725132,
+      "label": "issue47_phase_retained_replace_all",
+      "mtf_abs_signed_rel_mean": 0.13993778559089318,
+      "mtf_threshold_mae": {
+        "mtf20": 0.08576635073450163,
+        "mtf30": 0.017891546542091085,
+        "mtf50": 0.007196087410606654
+      },
+      "overall_quality_loss_mae_mean": 14.475758846031667,
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_profile.json"
+    },
+    "issue81_quality_loss_isolation_candidate": {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": null,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "quality_loss_isolation",
+        "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": null,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_hi_values": null,
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": null,
+        "matched_ori_acutance_preset_correction_delta_power_values": null,
+        "matched_ori_acutance_preset_strength_curve_relative_scales": null,
+        "matched_ori_acutance_preset_strength_curve_values": null,
+        "matched_ori_acutance_reference_anchor": false,
+        "matched_ori_acutance_strength_curve_relative_scales": null,
+        "matched_ori_acutance_strength_curve_values": null,
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": false,
+        "matched_ori_strength_curve_frequencies": null,
+        "matched_ori_strength_curve_values": null,
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "none",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "readout_interpolation": "linear",
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.0,
+        "texture_support_scale": false
+      },
+      "curve_mae_mean": 0.03280180556381627,
+      "focus_preset_acutance_mae_mean": 0.028920526408725132,
+      "label": "issue81_quality_loss_isolation_candidate",
+      "mtf_abs_signed_rel_mean": 0.3791739971587723,
+      "mtf_threshold_mae": {
+        "mtf20": 0.07455706234134782,
+        "mtf30": 0.07569638116718373,
+        "mtf50": 0.03461927207429304
+      },
+      "overall_quality_loss_mae_mean": 8.020541173342606,
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_quality_loss_isolation_profile.json"
+    }
+  },
+  "sources": {
+    "acutance_artifact_path": "artifacts/issue81_intrinsic_phase_retained_quality_loss_isolation_acutance_benchmark.json",
+    "issue79_record": "docs/intrinsic_literal_next_slice.md",
+    "psd_artifact_path": "artifacts/issue81_intrinsic_phase_retained_quality_loss_isolation_psd_benchmark.json"
+  },
+  "storage": {
+    "golden_reference_roots": [
+      "20260318_deadleaf_13b10",
+      "release/deadleaf_13b10_release/data/20260318_deadleaf_13b10"
+    ],
+    "new_fitted_artifact_paths": [
+      "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_quality_loss_isolation_profile.json",
+      "artifacts/issue81_intrinsic_phase_retained_quality_loss_isolation_psd_benchmark.json",
+      "artifacts/issue81_intrinsic_phase_retained_quality_loss_isolation_acutance_benchmark.json",
+      "artifacts/intrinsic_phase_retained_quality_loss_isolation_benchmark.json"
+    ],
+    "release_config_paths": [],
+    "rules": [
+      "Do not write fitted intrinsic profiles or benchmark outputs under the golden/reference roots.",
+      "Keep issue-81 fitted artifacts under `algo/` and `artifacts/` only.",
+      "Do not promote a release-facing config until the intrinsic route beats the tracked current-best guardrails."
+    ]
+  },
+  "summary_kind": "intrinsic_phase_retained_quality_loss_isolation_followup"
+}

--- a/artifacts/issue81_intrinsic_phase_retained_quality_loss_isolation_acutance_benchmark.json
+++ b/artifacts/issue81_intrinsic_phase_retained_quality_loss_isolation_acutance_benchmark.json
@@ -1,0 +1,189 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": null,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "quality_loss_isolation",
+        "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": null,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_hi_values": null,
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": null,
+        "matched_ori_acutance_preset_correction_delta_power_values": null,
+        "matched_ori_acutance_preset_strength_curve_relative_scales": null,
+        "matched_ori_acutance_preset_strength_curve_values": null,
+        "matched_ori_acutance_reference_anchor": false,
+        "matched_ori_acutance_strength_curve_relative_scales": null,
+        "matched_ori_acutance_strength_curve_values": null,
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": false,
+        "matched_ori_strength_curve_frequencies": null,
+        "matched_ori_strength_curve_values": null,
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "none",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "readout_interpolation": "linear",
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.0,
+        "texture_support_scale": false
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.029378599163150443,
+        "0.25": 0.02479729017929424,
+        "0.4": 0.019363342842858032,
+        "0.65": 0.011953815251775047,
+        "0.8": 0.04482380483621107,
+        "ori": 0.07933816634336006
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 23.001576017236243,
+        "0.25": 8.19118064755327,
+        "0.4": 4.187031954182734,
+        "0.65": 2.75236276844477,
+        "0.8": 2.062036035175922,
+        "ori": 2.569399656684951
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.028920526408725132,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.035256377739795786,
+          "Computer Monitor Acutance": 0.024146307932311834,
+          "Large Print Acutance": 0.028624302638652583,
+          "Small Print Acutance": 0.031726251556383624,
+          "UHDTV Display Acutance": 0.024849392176481848
+        },
+        "curve_mae_mean": 0.03280180556381627,
+        "overall_quality_loss_mae_mean": 8.020541173342606,
+        "quality_loss_focus_preset_mae_mean": 8.020541173342606,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 0.5469559580621024,
+          "Computer Monitor Quality Loss": 20.18457562486098,
+          "Large Print Quality Loss": 5.958175861662376,
+          "Small Print Quality Loss": 8.667190883803439,
+          "UHDTV Display Quality Loss": 4.745807538324134
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_quality_loss_isolation_profile.json"
+    }
+  ]
+}

--- a/artifacts/issue81_intrinsic_phase_retained_quality_loss_isolation_psd_benchmark.json
+++ b/artifacts/issue81_intrinsic_phase_retained_quality_loss_isolation_psd_benchmark.json
@@ -1,0 +1,131 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": null,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "quality_loss_isolation",
+        "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": null,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_hi_values": null,
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": null,
+        "matched_ori_acutance_preset_correction_delta_power_values": null,
+        "matched_ori_acutance_preset_strength_curve_relative_scales": null,
+        "matched_ori_acutance_preset_strength_curve_values": null,
+        "matched_ori_acutance_reference_anchor": false,
+        "matched_ori_acutance_strength_curve_relative_scales": null,
+        "matched_ori_acutance_strength_curve_values": null,
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": false,
+        "matched_ori_strength_curve_frequencies": null,
+        "matched_ori_strength_curve_values": null,
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "none",
+        "mtf_shape_correction_mode": "none",
+        "readout_interpolation": "linear",
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.0,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": false
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.029378599163150443,
+        "0.25": 0.02479729017929424,
+        "0.4": 0.019363342842858032,
+        "0.65": 0.011953815251775047,
+        "0.8": 0.04482380483621107,
+        "ori": 0.07933816634336006
+      },
+      "overall": {
+        "curve_mae_mean": 0.03280180556381627,
+        "mtf_abs_signed_rel_mean": 0.3791739971587723,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.09586956686463888,
+            "mre_mean": 0.4205288803198794,
+            "signed_rel_mean": -0.4205288803198794
+          },
+          "low": {
+            "mae_mean": 0.07904481493140933,
+            "mre_mean": 0.0986536874480393,
+            "signed_rel_mean": -0.0986536874480393
+          },
+          "mid": {
+            "mae_mean": 0.1151839806867104,
+            "mre_mean": 0.28776508787153254,
+            "signed_rel_mean": -0.28776508787153254
+          },
+          "top": {
+            "mae_mean": 0.2603454312156407,
+            "mre_mean": 0.7097483329956381,
+            "signed_rel_mean": -0.7097483329956381
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.07455706234134782,
+          "mtf30": 0.07569638116718373,
+          "mtf50": 0.03461927207429304
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.035256377739795786,
+          "Computer Monitor Acutance": 0.024146307932311834,
+          "Large Print Acutance": 0.028624302638652583,
+          "Small Print Acutance": 0.031726251556383624,
+          "UHDTV Display Acutance": 0.024849392176481848
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_quality_loss_isolation_profile.json"
+    }
+  ]
+}

--- a/docs/intrinsic_phase_retained_quality_loss_isolation_followup.md
+++ b/docs/intrinsic_phase_retained_quality_loss_isolation_followup.md
@@ -1,0 +1,62 @@
+# Intrinsic Phase-Retained Quality-Loss Isolation Follow-up
+
+Issue `#81` implements the bounded slice selected in issue `#79` / PR `#80`: keep the phase-retained intrinsic transfer, but isolate downstream Quality Loss from the intrinsic path.
+
+## Scope
+
+- New intrinsic scope: `quality_loss_isolation`
+- Basis profile: `algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_profile.json`
+- Candidate profile: `algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_quality_loss_isolation_profile.json`
+- Difference from `replace_all`: Quality Loss no longer consumes the intrinsic compensated MTF path.
+- Difference from `acutance_only`: this issue names the narrower downstream-isolation intent explicitly on top of the stronger phase-retained intrinsic branch.
+
+## Result
+
+Current PR `#30` branch:
+
+- `curve_mae_mean = 0.03679`
+- `focus_preset_acutance_mae_mean = 0.04249`
+- `overall_quality_loss_mae_mean = 1.22150`
+
+PR `#34` intrinsic baseline:
+
+- `curve_mae_mean = 0.03587`
+- `focus_preset_acutance_mae_mean = 0.03165`
+- `overall_quality_loss_mae_mean = 4.56801`
+
+PR `#47` phase-retained intrinsic baseline:
+
+- `curve_mae_mean = 0.03280`
+- `focus_preset_acutance_mae_mean = 0.02892`
+- `overall_quality_loss_mae_mean = 14.47576`
+
+Issue `#81` quality-loss-isolated candidate:
+
+- `curve_mae_mean = 0.03280`
+- `focus_preset_acutance_mae_mean = 0.02892`
+- `overall_quality_loss_mae_mean = 8.02054`
+
+## Comparison
+
+- Versus PR `#47`, `overall_quality_loss_mae_mean` changes by `-6.45522`.
+- Versus PR `#34`, `curve_mae_mean` changes by `-0.00307` and `focus_preset_acutance_mae_mean` changes by `-0.00273`.
+- Versus current PR `#30`, `curve_mae_mean` changes by `-0.00399` and `overall_quality_loss_mae_mean` changes by `+6.79904`.
+
+## Acceptance
+
+- `curve_mae_mean` no worse than issue `#34`: `True`
+- `focus_preset_acutance_mae_mean` no worse than issue `#34`: `True`
+- `overall_quality_loss_mae_mean` improved versus issue `#47`: `True`
+- All issue-81 gates pass: `True`
+
+## Conclusion
+
+- Status: `issue81_acceptance_passed_but_not_current_best`
+- Summary: The new scope is a real improvement over the old phase-retained replace_all path: it preserves the intrinsic curve / focus-preset Acutance gains while materially reducing overall Quality Loss. It still remains worse than the current PR #30 main line on overall Quality Loss and MTF-threshold readouts.
+- Next step: Keep this scope as the new bounded intrinsic record and evaluate whether a later follow-up can reduce the remaining gap to the current best branch without reopening unrelated families.
+
+## Storage Separation
+
+- Golden/reference roots: `20260318_deadleaf_13b10`, `release/deadleaf_13b10_release/data/20260318_deadleaf_13b10`
+- Fitted outputs for this issue stay under `algo/` and `artifacts/` only.
+- No release-facing config is promoted in this issue.

--- a/tests/test_benchmark_parity_acutance_quality_loss.py
+++ b/tests/test_benchmark_parity_acutance_quality_loss.py
@@ -1006,6 +1006,160 @@ class BenchmarkParityAcutanceQualityLossTest(unittest.TestCase):
                 1.0,
             )
 
+    def test_intrinsic_scope_can_isolate_quality_loss_with_phase_retained_path(self) -> None:
+        capture_key = "OV13b10_AG8_ET5500_deadleaf_12M_40"
+        preset_names = (
+            '5.5" Phone Display Acutance',
+            "Computer Monitor Acutance",
+            "UHDTV Display Acutance",
+            "Small Print Acutance",
+            "Large Print Acutance",
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dataset_root = Path(tmpdir)
+            variant_root = dataset_root / "OV13B10_AI_NR_OV13B10_ppqpkl_0.10"
+            results_dir = variant_root / "Results"
+            results_dir.mkdir(parents=True)
+            stem = f"{capture_key}_variantA"
+            (results_dir / f"{stem}_R_Random.csv").write_text("", encoding="utf-8")
+            (variant_root / f"{stem}.raw").write_bytes(b"")
+
+            reference = SimpleNamespace(
+                lrtb=RoiBounds(left=0, right=1, top=0, bottom=1),
+                frequencies_cpp=np.array([0.1, 0.2], dtype=np.float64),
+                acutance_table=[
+                    AcutancePoint(print_height_cm=40.0, viewing_distance_cm=10.0, acutance=1.0)
+                ],
+                reported_acutance={name: 1.0 for name in preset_names},
+                reported_quality_loss={
+                    name.replace("Acutance", "Quality Loss"): 0.0 for name in preset_names
+                },
+            )
+            ori_reference = SimpleNamespace(
+                lrtb=RoiBounds(left=0, right=1, top=0, bottom=1),
+                frequencies_cpp=np.array([0.1, 0.2], dtype=np.float64),
+                mtf=np.array([1.0, 1.0], dtype=np.float64),
+                acutance_table=reference.acutance_table,
+            )
+            estimate = SimpleNamespace(
+                roi=RoiBounds(left=0, right=1, top=0, bottom=1),
+                frequencies_cpp=np.array([0.1, 0.2], dtype=np.float64),
+                mtf_for_acutance=np.array([1.0, 1.0], dtype=np.float64),
+                acutance_high_frequency_noise_share=0.0,
+            )
+            profile = Profile(
+                name="test",
+                calibration_file="calibration.json",
+                roi_source="reference",
+                intrinsic_full_reference_mode="paired_ori_transfer",
+                intrinsic_full_reference_scope="quality_loss_isolation",
+            )
+
+            def parse_csv(path: Path):
+                return ori_reference if path.name == "ori.csv" else reference
+
+            def acutance_from_mtf(_freqs, mtf, **_kwargs):
+                value = float(np.asarray(mtf, dtype=np.float64)[0])
+                return {name: value for name in preset_names}
+
+            with (
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.load_ideal_psd_calibration",
+                    return_value=None,
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.build_ori_reference_map",
+                    return_value={capture_key: (dataset_root / "ori.csv", dataset_root / "ori.raw")},
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.parse_imatest_random_csv",
+                    side_effect=parse_csv,
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.load_raw_u16",
+                    side_effect=lambda path, width, height: np.zeros((height, width), dtype=np.uint16),
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.extract_analysis_plane",
+                    side_effect=lambda raw, **_: raw,
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.normalize_for_analysis",
+                    side_effect=lambda plane, **_: plane,
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.estimate_dead_leaves_mtf",
+                    return_value=estimate,
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.apply_mtf_compensation",
+                    side_effect=lambda mtf, freqs, **_: (
+                        np.asarray(mtf, dtype=np.float64),
+                        np.asarray(freqs, dtype=np.float64),
+                    ),
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.derive_intrinsic_transfer_curve",
+                    return_value=np.array([2.0, 2.0], dtype=np.float64),
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.apply_mtf_shape_correction",
+                    side_effect=lambda mtf, freqs, **_: (
+                        np.asarray(mtf, dtype=np.float64),
+                        np.asarray(freqs, dtype=np.float64),
+                    ),
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.acutance_curve_from_mtf",
+                    side_effect=lambda _freqs, mtf, **_kwargs: [
+                        AcutancePoint(
+                            print_height_cm=40.0,
+                            viewing_distance_cm=10.0,
+                            acutance=float(np.asarray(mtf, dtype=np.float64)[0]),
+                        )
+                    ],
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.acutance_presets_from_mtf",
+                    side_effect=acutance_from_mtf,
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.compare_acutance_curves",
+                    return_value={"count": 1, "mae": 0.0},
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.compare_acutance_presets",
+                    side_effect=lambda estimate_map, reference_map: {
+                        name: {
+                            "abs_error": abs(float(estimate_map[name]) - float(reference_map[name])),
+                            "estimate": float(estimate_map[name]),
+                            "reference": float(reference_map[name]),
+                        }
+                        for name in estimate_map
+                    },
+                ) as compare_presets,
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.quality_loss_presets_from_acutance",
+                    return_value=reference.reported_quality_loss,
+                ) as quality_loss_from_acutance,
+            ):
+                summarize_profile(
+                    dataset_root=dataset_root,
+                    profile_path=dataset_root / "profile.json",
+                    profile=profile,
+                    width=2,
+                    height=2,
+                )
+
+            self.assertEqual(
+                compare_presets.call_args.args[0]['5.5" Phone Display Acutance'],
+                2.0,
+            )
+            self.assertEqual(
+                quality_loss_from_acutance.call_args.args[0]['5.5" Phone Display Acutance'],
+                1.0,
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_benchmark_parity_psd_mtf.py
+++ b/tests/test_benchmark_parity_psd_mtf.py
@@ -396,6 +396,111 @@ class BenchmarkParityPsdMtfTest(unittest.TestCase):
             np.testing.assert_allclose(compute_metrics.call_args.args[1], [1.0, 1.0, 1.0, 1.0])
             np.testing.assert_allclose(acutance_from_mtf.call_args.args[1], [2.0, 2.0, 2.0, 2.0])
 
+    def test_intrinsic_scope_can_isolate_quality_loss_without_changing_psd_semantics(self) -> None:
+        capture_key = "OV13b10_AG8_ET5500_deadleaf_12M_40"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dataset_root = Path(tmpdir)
+            variant_root = dataset_root / "OV13B10_AI_NR_OV13B10_ppqpkl_0.10"
+            results_dir = variant_root / "Results"
+            results_dir.mkdir(parents=True)
+            stem = f"{capture_key}_variantA"
+            (results_dir / f"{stem}_R_Random.csv").write_text("", encoding="utf-8")
+            (variant_root / f"{stem}.raw").write_bytes(b"")
+
+            reference = SimpleNamespace(
+                lrtb=RoiBounds(left=0, right=1, top=0, bottom=1),
+                frequencies_cpp=np.array([0.02, 0.1, 0.25, 0.4], dtype=np.float64),
+                mtf=np.array([1.0, 1.0, 1.0, 1.0], dtype=np.float64),
+                acutance_table=[
+                    AcutancePoint(print_height_cm=40.0, viewing_distance_cm=10.0, acutance=1.0)
+                ],
+                reported_acutance={'5.5" Phone Display Acutance': 1.0},
+            )
+            ori_reference = SimpleNamespace(
+                lrtb=RoiBounds(left=0, right=1, top=0, bottom=1),
+                frequencies_cpp=np.array([0.02, 0.1, 0.25, 0.4], dtype=np.float64),
+                mtf=np.array([1.0, 1.0, 1.0, 1.0], dtype=np.float64),
+                acutance_table=reference.acutance_table,
+                reported_acutance=reference.reported_acutance,
+            )
+            estimate = SimpleNamespace(
+                roi=RoiBounds(left=0, right=1, top=0, bottom=1),
+                frequencies_cpp=np.array([0.02, 0.1, 0.25, 0.4], dtype=np.float64),
+                mtf=np.array([1.0, 1.0, 1.0, 1.0], dtype=np.float64),
+                mtf_for_acutance=np.array([1.0, 1.0, 1.0, 1.0], dtype=np.float64),
+            )
+            profile = Profile(
+                name="test",
+                calibration_file="calibration.json",
+                roi_source="reference",
+                intrinsic_full_reference_mode="paired_ori_transfer",
+                intrinsic_full_reference_scope="quality_loss_isolation",
+            )
+
+            def parse_csv(path: Path):
+                return ori_reference if path.name == "ori.csv" else reference
+
+            with (
+                patch("algo.benchmark_parity_psd_mtf.load_ideal_psd_calibration", return_value=None),
+                patch(
+                    "algo.benchmark_parity_psd_mtf.build_ori_reference_map",
+                    return_value={capture_key: (dataset_root / "ori.csv", dataset_root / "ori.raw")},
+                ),
+                patch(
+                    "algo.benchmark_parity_psd_mtf.parse_imatest_random_csv",
+                    side_effect=parse_csv,
+                ),
+                patch(
+                    "algo.benchmark_parity_psd_mtf.load_raw_u16",
+                    side_effect=lambda path, width, height: np.zeros((height, width), dtype=np.uint16),
+                ),
+                patch("algo.benchmark_parity_psd_mtf.extract_analysis_plane", side_effect=lambda raw, **_: raw),
+                patch("algo.benchmark_parity_psd_mtf.normalize_for_analysis", side_effect=lambda plane, **_: plane),
+                patch("algo.benchmark_parity_psd_mtf.estimate_dead_leaves_mtf", return_value=estimate),
+                patch(
+                    "algo.benchmark_parity_psd_mtf.apply_mtf_compensation",
+                    side_effect=lambda mtf, freqs, **_: (
+                        np.asarray(mtf, dtype=np.float64),
+                        np.asarray(freqs, dtype=np.float64),
+                    ),
+                ),
+                patch(
+                    "algo.benchmark_parity_psd_mtf.derive_intrinsic_transfer_curve",
+                    return_value=np.array([2.0, 2.0, 2.0, 2.0], dtype=np.float64),
+                ),
+                patch(
+                    "algo.benchmark_parity_psd_mtf.compute_mtf_metrics",
+                    return_value=SimpleNamespace(mtf50=0.1, mtf30=0.1, mtf20=0.1),
+                ) as compute_metrics,
+                patch("algo.benchmark_parity_psd_mtf.interpolate_threshold", return_value=0.1),
+                patch(
+                    "algo.benchmark_parity_psd_mtf.acutance_curve_from_mtf",
+                    return_value=reference.acutance_table,
+                ),
+                patch(
+                    "algo.benchmark_parity_psd_mtf.compare_acutance_curves",
+                    return_value={"count": 1, "mae": 0.0},
+                ),
+                patch(
+                    "algo.benchmark_parity_psd_mtf.acutance_presets_from_mtf",
+                    return_value=reference.reported_acutance,
+                ) as acutance_from_mtf,
+                patch(
+                    "algo.benchmark_parity_psd_mtf.compare_acutance_presets",
+                    return_value={'5.5" Phone Display Acutance': {"abs_error": 0.0}},
+                ),
+            ):
+                profile_payload(
+                    dataset_root=dataset_root,
+                    profile_path=dataset_root / "profile.json",
+                    profile=profile,
+                    width=2,
+                    height=2,
+                )
+
+            np.testing.assert_allclose(compute_metrics.call_args.args[1], [1.0, 1.0, 1.0, 1.0])
+            np.testing.assert_allclose(acutance_from_mtf.call_args.args[1], [2.0, 2.0, 2.0, 2.0])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_build_intrinsic_phase_retained_quality_loss_isolation_followup.py
+++ b/tests/test_build_intrinsic_phase_retained_quality_loss_isolation_followup.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from algo.build_intrinsic_phase_retained_quality_loss_isolation_followup import (
+    CANDIDATE_LABEL,
+    build_payload,
+    render_markdown,
+)
+
+
+class BuildIntrinsicPhaseRetainedQualityLossIsolationFollowupTest(unittest.TestCase):
+    def test_payload_uses_issue81_candidate_and_keeps_storage_separate(self) -> None:
+        payload = build_payload(
+            self.repo_root(),
+            psd_artifact_path=Path(
+                "artifacts/issue81_intrinsic_phase_retained_quality_loss_isolation_psd_benchmark.json"
+            ),
+            acutance_artifact_path=Path(
+                "artifacts/issue81_intrinsic_phase_retained_quality_loss_isolation_acutance_benchmark.json"
+            ),
+        )
+
+        self.assertEqual(payload["issue"], 81)
+        self.assertEqual(
+            payload["profiles"][CANDIDATE_LABEL]["profile_path"],
+            "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_quality_loss_isolation_profile.json",
+        )
+        self.assertEqual(
+            payload["implementation_change"]["scope_name"],
+            "quality_loss_isolation",
+        )
+        for path in payload["storage"]["new_fitted_artifact_paths"]:
+            self.assertFalse(path.startswith("20260318_deadleaf_13b10"))
+            self.assertFalse(
+                path.startswith("release/deadleaf_13b10_release/data/20260318_deadleaf_13b10")
+            )
+
+    def test_markdown_mentions_scope_and_acceptance(self) -> None:
+        payload = build_payload(
+            self.repo_root(),
+            psd_artifact_path=Path(
+                "artifacts/issue81_intrinsic_phase_retained_quality_loss_isolation_psd_benchmark.json"
+            ),
+            acutance_artifact_path=Path(
+                "artifacts/issue81_intrinsic_phase_retained_quality_loss_isolation_acutance_benchmark.json"
+            ),
+        )
+        markdown = render_markdown(payload)
+
+        self.assertIn("# Intrinsic Phase-Retained Quality-Loss Isolation Follow-up", markdown)
+        self.assertIn("quality_loss_isolation", markdown)
+        self.assertIn("PR `#30`", markdown)
+        self.assertIn("PR `#34`", markdown)
+        self.assertIn("PR `#47`", markdown)
+        self.assertIn("Storage Separation", markdown)
+
+    @staticmethod
+    def repo_root() -> Path:
+        return Path(__file__).resolve().parents[1]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add the `quality_loss_isolation` intrinsic scope for the paired-ori full-reference path
- add the phase-retained quality-loss-isolated profile, issue-81 benchmarks, and follow-up note/artifact
- record that the new scope preserves the issue-47 curve and focus-preset Acutance gains while materially reducing overall Quality Loss, but still does not beat the current PR #30 branch overall

## Validation
- `python3 -m pytest tests/test_benchmark_parity_psd_mtf.py tests/test_benchmark_parity_acutance_quality_loss.py`
- `python3 -m algo.benchmark_parity_psd_mtf 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_quality_loss_isolation_profile.json --output artifacts/issue81_intrinsic_phase_retained_quality_loss_isolation_psd_benchmark.json`
- `python3 -m algo.benchmark_parity_acutance_quality_loss 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_quality_loss_isolation_profile.json --output artifacts/issue81_intrinsic_phase_retained_quality_loss_isolation_acutance_benchmark.json`
- `python3 -m algo.build_intrinsic_phase_retained_quality_loss_isolation_followup`
- `python3 -m pytest tests/test_build_intrinsic_phase_retained_quality_loss_isolation_followup.py`

Refs #29
Refs #46
Refs #79

Context from #34
Context from #47
Context from #80
