### PR TITLE
Issue #87: narrow the post-issue85 intrinsic next slice

### DIFF
--- a/algo/build_intrinsic_after_issue85_next_slice.py
+++ b/algo/build_intrinsic_after_issue85_next_slice.py
@@ -1,0 +1,692 @@
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+
+SUMMARY_KIND = "intrinsic_after_issue85_next_slice"
+CURRENT_BEST_LABEL = "current_best_pr30_branch"
+ISSUE47_LABEL = "issue47_phase_retained_replace_all"
+ISSUE81_LABEL = "issue81_quality_loss_isolation_candidate"
+ISSUE85_LABEL = "issue85_readout_reconnect_quality_loss_isolation_candidate"
+SELECTED_SLICE_ID = (
+    "phase_retained_intrinsic_matched_ori_correction_graft_with_quality_loss_isolation"
+)
+GOLDEN_REFERENCE_ROOTS = (
+    "20260318_deadleaf_13b10",
+    "release/deadleaf_13b10_release/data/20260318_deadleaf_13b10",
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build the issue-87 intrinsic post-issue85 next-slice record."
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Repository root. Defaults to the parent of this script.",
+    )
+    parser.add_argument(
+        "--issue83-artifact",
+        type=Path,
+        default=Path("artifacts/intrinsic_after_issue81_next_slice_benchmark.json"),
+        help="Repo-relative issue-83 discovery artifact path.",
+    )
+    parser.add_argument(
+        "--issue85-artifact",
+        type=Path,
+        default=Path("artifacts/intrinsic_phase_retained_readout_reconnect_benchmark.json"),
+        help="Repo-relative issue-85 summary artifact path.",
+    )
+    parser.add_argument(
+        "--issue47-psd-artifact",
+        type=Path,
+        default=Path("artifacts/issue46_intrinsic_phase_retention_psd_benchmark.json"),
+        help="Repo-relative issue-47 PSD benchmark artifact path.",
+    )
+    parser.add_argument(
+        "--issue47-acutance-artifact",
+        type=Path,
+        default=Path("artifacts/issue46_intrinsic_phase_retention_acutance_benchmark.json"),
+        help="Repo-relative issue-47 acutance/quality-loss benchmark artifact path.",
+    )
+    parser.add_argument(
+        "--issue81-psd-artifact",
+        type=Path,
+        default=Path("artifacts/issue81_intrinsic_phase_retained_quality_loss_isolation_psd_benchmark.json"),
+        help="Repo-relative issue-81 PSD benchmark artifact path.",
+    )
+    parser.add_argument(
+        "--issue81-acutance-artifact",
+        type=Path,
+        default=Path("artifacts/issue81_intrinsic_phase_retained_quality_loss_isolation_acutance_benchmark.json"),
+        help="Repo-relative issue-81 acutance/quality-loss benchmark artifact path.",
+    )
+    parser.add_argument(
+        "--issue85-psd-artifact",
+        type=Path,
+        default=Path("artifacts/issue85_intrinsic_phase_retained_readout_reconnect_psd_benchmark.json"),
+        help="Repo-relative issue-85 PSD benchmark artifact path.",
+    )
+    parser.add_argument(
+        "--issue85-acutance-artifact",
+        type=Path,
+        default=Path("artifacts/issue85_intrinsic_phase_retained_readout_reconnect_acutance_benchmark.json"),
+        help="Repo-relative issue-85 acutance/quality-loss benchmark artifact path.",
+    )
+    parser.add_argument(
+        "--current-best-psd-artifact",
+        type=Path,
+        default=Path("artifacts/issue77_measured_oecf_psd_benchmark.json"),
+        help="Repo-relative current-best PSD benchmark artifact path.",
+    )
+    parser.add_argument(
+        "--current-best-acutance-artifact",
+        type=Path,
+        default=Path("artifacts/issue77_measured_oecf_acutance_benchmark.json"),
+        help="Repo-relative current-best acutance/quality-loss benchmark artifact path.",
+    )
+    parser.add_argument(
+        "--output-json",
+        type=Path,
+        default=Path("artifacts/intrinsic_after_issue85_next_slice_benchmark.json"),
+        help="Repo-relative output path for the machine-readable artifact.",
+    )
+    parser.add_argument(
+        "--output-md",
+        type=Path,
+        default=Path("docs/intrinsic_after_issue85_next_slice.md"),
+        help="Repo-relative output path for the Markdown note.",
+    )
+    return parser
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def resolve_path(repo_root: Path, path: Path) -> Path:
+    return path if path.is_absolute() else repo_root / path
+
+
+def format_metric(value: float) -> str:
+    return f"{value:.5f}"
+
+
+def format_paths(paths: list[str]) -> str:
+    return ", ".join(f"`{path}`" for path in paths)
+
+
+def select_profile(payload: dict[str, Any], expected_profile_path: str) -> dict[str, Any]:
+    for profile in payload["profiles"]:
+        if profile["profile_path"] == expected_profile_path:
+            return profile
+    available = ", ".join(profile["profile_path"] for profile in payload["profiles"])
+    raise ValueError(
+        f"Profile {expected_profile_path!r} not found in artifact. Available: {available}"
+    )
+
+
+def profile_detail(
+    *,
+    psd_payload: dict[str, Any],
+    acutance_payload: dict[str, Any],
+    profile_path: str,
+) -> dict[str, Any]:
+    psd_profile = select_profile(psd_payload, profile_path)
+    acutance_profile = select_profile(acutance_payload, profile_path)
+    return {
+        "mtf_band_mae": {
+            key: float(value["mae_mean"])
+            for key, value in psd_profile["overall"]["mtf_bands"].items()
+        },
+        "acutance_preset_mae": {
+            key: float(value)
+            for key, value in acutance_profile["overall"]["acutance_preset_mae"].items()
+        },
+        "quality_loss_preset_mae": {
+            key: float(value)
+            for key, value in acutance_profile["overall"]["quality_loss_preset_mae"].items()
+        },
+        "quality_loss_focus_preset_mae_mean": float(
+            acutance_profile["overall"]["quality_loss_focus_preset_mae_mean"]
+        ),
+    }
+
+
+def delta_map(candidate: dict[str, Any], baseline: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "curve_mae_mean": float(candidate["curve_mae_mean"] - baseline["curve_mae_mean"]),
+        "focus_preset_acutance_mae_mean": float(
+            candidate["focus_preset_acutance_mae_mean"]
+            - baseline["focus_preset_acutance_mae_mean"]
+        ),
+        "overall_quality_loss_mae_mean": float(
+            candidate["overall_quality_loss_mae_mean"] - baseline["overall_quality_loss_mae_mean"]
+        ),
+        "mtf_abs_signed_rel_mean": float(
+            candidate["mtf_abs_signed_rel_mean"] - baseline["mtf_abs_signed_rel_mean"]
+        ),
+        "mtf_threshold_mae": {
+            key: float(candidate["mtf_threshold_mae"][key] - baseline["mtf_threshold_mae"][key])
+            for key in ("mtf20", "mtf30", "mtf50")
+        },
+    }
+
+
+def is_close(a: float, b: float) -> bool:
+    return math.isclose(a, b, rel_tol=0.0, abs_tol=1e-12)
+
+
+def maps_match(lhs: dict[str, float], rhs: dict[str, float]) -> bool:
+    return lhs.keys() == rhs.keys() and all(is_close(lhs[key], rhs[key]) for key in lhs)
+
+
+def pipeline_gap_summary(current_best: dict[str, Any], issue85: dict[str, Any]) -> dict[str, Any]:
+    current_pipeline = current_best["analysis_pipeline"]
+    issue85_pipeline = issue85["analysis_pipeline"]
+    keys = [
+        "matched_ori_reference_anchor",
+        "matched_ori_strength_curve_frequencies",
+        "matched_ori_strength_curve_values",
+        "matched_ori_acutance_reference_anchor",
+        "matched_ori_acutance_strength_curve_relative_scales",
+        "matched_ori_acutance_strength_curve_values",
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales",
+        "matched_ori_acutance_curve_correction_clip_hi_values",
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales",
+        "matched_ori_acutance_preset_correction_delta_power_values",
+        "matched_ori_acutance_preset_strength_curve_relative_scales",
+        "matched_ori_acutance_preset_strength_curve_values",
+    ]
+    return {
+        key: {
+            "current_best_pr30_branch": current_pipeline.get(key),
+            "issue85_readout_reconnect_quality_loss_isolation_candidate": issue85_pipeline.get(key),
+        }
+        for key in keys
+    }
+
+
+def assert_storage_separation(payload: dict[str, Any]) -> None:
+    for path in payload["storage_policy"]["new_fitted_artifact_paths"]:
+        for root in GOLDEN_REFERENCE_ROOTS:
+            if path.startswith(root):
+                raise ValueError(f"Path {path} leaks into golden/reference root {root}")
+
+
+def build_payload(
+    repo_root: Path,
+    *,
+    issue83_artifact_path: Path,
+    issue85_artifact_path: Path,
+    issue47_psd_artifact_path: Path,
+    issue47_acutance_artifact_path: Path,
+    issue81_psd_artifact_path: Path,
+    issue81_acutance_artifact_path: Path,
+    issue85_psd_artifact_path: Path,
+    issue85_acutance_artifact_path: Path,
+    current_best_psd_artifact_path: Path,
+    current_best_acutance_artifact_path: Path,
+) -> dict[str, Any]:
+    issue83_artifact = load_json(resolve_path(repo_root, issue83_artifact_path))
+    issue85_artifact = load_json(resolve_path(repo_root, issue85_artifact_path))
+
+    comparison_records = {
+        CURRENT_BEST_LABEL: issue85_artifact["profiles"][CURRENT_BEST_LABEL],
+        ISSUE47_LABEL: issue85_artifact["profiles"][ISSUE47_LABEL],
+        ISSUE81_LABEL: issue85_artifact["profiles"][ISSUE81_LABEL],
+        ISSUE85_LABEL: issue85_artifact["profiles"][ISSUE85_LABEL],
+    }
+
+    current_best_details = profile_detail(
+        psd_payload=load_json(resolve_path(repo_root, current_best_psd_artifact_path)),
+        acutance_payload=load_json(resolve_path(repo_root, current_best_acutance_artifact_path)),
+        profile_path=comparison_records[CURRENT_BEST_LABEL]["profile_path"],
+    )
+    issue47_details = profile_detail(
+        psd_payload=load_json(resolve_path(repo_root, issue47_psd_artifact_path)),
+        acutance_payload=load_json(resolve_path(repo_root, issue47_acutance_artifact_path)),
+        profile_path=comparison_records[ISSUE47_LABEL]["profile_path"],
+    )
+    issue81_details = profile_detail(
+        psd_payload=load_json(resolve_path(repo_root, issue81_psd_artifact_path)),
+        acutance_payload=load_json(resolve_path(repo_root, issue81_acutance_artifact_path)),
+        profile_path=comparison_records[ISSUE81_LABEL]["profile_path"],
+    )
+    issue85_details = profile_detail(
+        psd_payload=load_json(resolve_path(repo_root, issue85_psd_artifact_path)),
+        acutance_payload=load_json(resolve_path(repo_root, issue85_acutance_artifact_path)),
+        profile_path=comparison_records[ISSUE85_LABEL]["profile_path"],
+    )
+    detail_records = {
+        CURRENT_BEST_LABEL: current_best_details,
+        ISSUE47_LABEL: issue47_details,
+        ISSUE81_LABEL: issue81_details,
+        ISSUE85_LABEL: issue85_details,
+    }
+
+    issue85 = comparison_records[ISSUE85_LABEL]
+    issue81 = comparison_records[ISSUE81_LABEL]
+    issue47 = comparison_records[ISSUE47_LABEL]
+    current_best = comparison_records[CURRENT_BEST_LABEL]
+
+    residual_alignment = {
+        "issue85_quality_loss_matches_issue81": {
+            "overall_quality_loss_mae_mean": is_close(
+                issue85["overall_quality_loss_mae_mean"],
+                issue81["overall_quality_loss_mae_mean"],
+            ),
+            "quality_loss_focus_preset_mae_mean": is_close(
+                issue85_details["quality_loss_focus_preset_mae_mean"],
+                issue81_details["quality_loss_focus_preset_mae_mean"],
+            ),
+            "quality_loss_preset_mae": maps_match(
+                issue85_details["quality_loss_preset_mae"],
+                issue81_details["quality_loss_preset_mae"],
+            ),
+        },
+        "issue85_readout_matches_issue47": {
+            "mtf_abs_signed_rel_mean": is_close(
+                issue85["mtf_abs_signed_rel_mean"],
+                issue47["mtf_abs_signed_rel_mean"],
+            ),
+            "mtf_threshold_mae": maps_match(
+                issue85["mtf_threshold_mae"],
+                issue47["mtf_threshold_mae"],
+            ),
+            "mtf_band_mae": maps_match(
+                issue85_details["mtf_band_mae"],
+                issue47_details["mtf_band_mae"],
+            ),
+        },
+    }
+
+    candidate_slices = [
+        {
+            "slice_id": SELECTED_SLICE_ID,
+            "label": "graft the current-best PR30 matched-ori correction and acutance-anchor family onto issue-85's split topology",
+            "decision": "advance",
+            "technical_narrowing_point": (
+                "issue85_left_two_residuals_that_map_to_existing_downstream_correction_boundaries_"
+                "rather_than_to_new_intrinsic_transfer_or_registration_families"
+            ),
+            "selected_summary": (
+                "Keep issue #85's phase-retained intrinsic transfer, readout reconnect, and "
+                "downstream Quality Loss isolation, but graft the current-best PR30 matched-ori "
+                "correction / acutance-anchor family onto the readout path and the isolated "
+                "Quality Loss branch."
+            ),
+            "repo_evidence": [
+                "Issue #85's `overall_quality_loss_mae_mean` is exactly equal to issue #81, including the per-preset Quality Loss errors, so the remaining overall Quality Loss gap did not move when readout reconnect landed.",
+                "Issue #85's `mtf_abs_signed_rel_mean`, threshold errors, and MTF band errors are exactly equal to issue #47, so the residual `mtf20` gap also predates issue #85's split and stays on the readout side.",
+                "The current-best PR30 branch carries a tuned matched-ori reference-correction family and acutance-anchor family that issue #85 does not enable, which is the largest still-untried downstream boundary shared by the remaining `overall_quality_loss_mae_mean` and `mtf20` gaps.",
+                "The low-band MTF MAE on issue #85 is already better than PR30, yet `mtf20` is still farther away. That points to threshold-crossing / correction-shape behavior rather than to a missing wholesale intrinsic transfer family.",
+            ],
+            "comparison_basis": {
+                "issue85_vs_current_best_pr30": {
+                    "delta": delta_map(issue85, current_best),
+                },
+                "issue85_vs_issue47": {
+                    "delta": delta_map(issue85, issue47),
+                    "readout_metrics_match_issue47": residual_alignment[
+                        "issue85_readout_matches_issue47"
+                    ],
+                },
+                "issue85_vs_issue81": {
+                    "delta": delta_map(issue85, issue81),
+                    "quality_loss_metrics_match_issue81": residual_alignment[
+                        "issue85_quality_loss_matches_issue81"
+                    ],
+                },
+                "issue83_selected_slice_id": issue83_artifact["selected_slice_id"],
+            },
+            "runtime_boundary_evidence": [
+                {
+                    "file_path": "algo/benchmark_parity_psd_mtf.py",
+                    "line_range": "502-508, 509-653, 654-659",
+                    "observations": [
+                        "Issue #85 already reconnects the phase-retained intrinsic branch into `compensated_mtf` when the scope is `readout_reconnect_quality_loss_isolation`.",
+                        "The matched-ori reference correction then applies directly to both `compensated_mtf` and `compensated_mtf_for_acutance`, so the next bounded slice can target readout correction without touching the intrinsic transfer derivation.",
+                        "`compute_mtf_metrics(...)` still reads thresholds from the corrected `compensated_mtf`, which makes this the narrowest live boundary for the residual `mtf20` gap.",
+                    ],
+                },
+                {
+                    "file_path": "algo/benchmark_parity_acutance_quality_loss.py",
+                    "line_range": "329-337, 745-869, 921-948, 1003-1008",
+                    "observations": [
+                        "`maybe_anchor_acutance_results(...)` is gated by `matched_ori_acutance_reference_anchor`, and it runs on both the main acutance path and the isolated Quality Loss acutance path.",
+                        "The matched-ori reference correction also applies to `quality_loss_compensated_mtf_for_acutance`, which means one bounded graft can influence both the residual overall Quality Loss gap and the readout-side threshold shape.",
+                        "`quality_loss_presets_from_acutance(...)` consumes that isolated downstream acutance path after correction and anchoring, so the next issue can stay bounded to downstream correction/anchor behavior rather than reopening intrinsic transfer or OECF work.",
+                    ],
+                },
+            ],
+            "minimum_implementation_boundary": [
+                "Keep issue #85's `readout_reconnect_quality_loss_isolation` topology and `radial_real_mean` / `phase_correlation` intrinsic path unchanged.",
+                "Add one bounded mode or profile family that grafts PR30's matched-ori reference correction onto the issue-85 readout path, including the `matched_ori_reference_anchor` strength-curve settings used around `compensated_mtf`.",
+                "Apply the same bounded graft to the isolated downstream Quality Loss path, including the `matched_ori_acutance_reference_anchor` family that runs through `maybe_anchor_acutance_results(...)`.",
+                "Keep downstream Quality Loss isolated off the non-intrinsic branch; do not collapse back to `replace_all`.",
+            ],
+            "explicitly_do_not_change": [
+                "Do not change intrinsic transfer mode, registration mode, or restart a wider intrinsic-family sweep.",
+                "Do not reopen measured OECF or affine-registration branches.",
+                "Do not retune release-facing PR30 coefficients directly or promote any fitted intrinsic profile into release-facing config in this issue.",
+                "Do not write fitted profiles, transfer tables, or generated outputs under `20260318_deadleaf_13b10` or `release/deadleaf_13b10_release/data/20260318_deadleaf_13b10`.",
+            ],
+            "acceptance_criteria_for_next_issue": [
+                "The new bounded graft preserves issue #85's curve and focus-preset Acutance gains closely enough that `curve_mae_mean` and `focus_preset_acutance_mae_mean` are no worse than issue #85.",
+                "The same implementation improves `overall_quality_loss_mae_mean` versus issue #85 while keeping the isolated downstream Quality Loss routing intact.",
+                "The same implementation improves `mtf20` toward the current PR #30 branch versus issue #85 and does not give back the issue-85 `mtf_abs_signed_rel_mean` improvement.",
+                "All new fitted outputs remain under `algo/` or `artifacts/`, not under golden/reference roots or release-facing config roots.",
+            ],
+            "validation_plan_for_next_issue": [
+                "Run `python3 -m algo.benchmark_parity_psd_mtf ...` on an issue-85-based profile that enables the bounded matched-ori correction graft, then compare thresholds and `mtf_abs_signed_rel_mean` against issue #85 and PR #30.",
+                "Run `python3 -m algo.benchmark_parity_acutance_quality_loss ...` on the same profile/scope pair to confirm `overall_quality_loss_mae_mean` improves without collapsing the isolated downstream branch.",
+                "Add focused tests that cover the graft across `compensated_mtf`, `compensated_mtf_for_acutance`, `quality_loss_compensated_mtf_for_acutance`, and `maybe_anchor_acutance_results(...)`.",
+            ],
+        },
+        {
+            "slice_id": "promote_issue85_as_is",
+            "label": "promote issue-85 scope as-is",
+            "decision": "exclude",
+            "exclusion_reasons": [
+                "Issue #85 is a real bounded positive, but it still trails PR #30 materially on `overall_quality_loss_mae_mean` and does not improve `mtf20` toward the current best branch.",
+                "Promoting it without another narrowing pass would skip the exact residual gaps this issue was created to isolate.",
+            ],
+        },
+        {
+            "slice_id": "reopen_measured_oecf_family",
+            "label": "reopen measured OECF",
+            "decision": "exclude",
+            "exclusion_reasons": [
+                "Measured OECF already closed as a bounded negative in issue #77 / PR #78.",
+                "Issue #87 is downstream of issue #85's intrinsic split result, and the surviving gap maps to correction / anchor boundaries that already exist in the repo.",
+            ],
+        },
+        {
+            "slice_id": "rerun_affine_registration_intrinsic",
+            "label": "rerun affine-registration intrinsic variant",
+            "decision": "exclude",
+            "exclusion_reasons": [
+                "Affine registration was already dominated by the phase-correlation intrinsic path and is still explicitly out of scope for this narrowing pass.",
+                "The issue-85 residuals match earlier branches exactly, which points to post-transfer downstream correction rather than to registration choice.",
+            ],
+        },
+        {
+            "slice_id": "restart_unbounded_intrinsic_inventory",
+            "label": "restart an unbounded intrinsic family search",
+            "decision": "exclude",
+            "exclusion_reasons": [
+                "Issue #87 is a developer-discovery narrowing pass, not a license to reopen the full intrinsic search tree.",
+                "The repo already contains one implementable next slice with code-level boundary evidence, so broader family churn would be workflow regress rather than progress.",
+            ],
+        },
+    ]
+
+    payload = {
+        "issue": 87,
+        "summary_kind": SUMMARY_KIND,
+        "selected_slice_id": SELECTED_SLICE_ID,
+        "selected_summary": candidate_slices[0]["selected_summary"],
+        "source_artifacts": {
+            "issue83_summary_artifact": str(issue83_artifact_path),
+            "issue83_selected_slice_id": issue83_artifact["selected_slice_id"],
+            "issue85_summary_artifact": str(issue85_artifact_path),
+            "issue85_conclusion_status": issue85_artifact["conclusion"]["status"],
+        },
+        "comparison_records": comparison_records,
+        "detail_records": detail_records,
+        "residual_alignment_evidence": residual_alignment,
+        "pipeline_gap_summary": pipeline_gap_summary(current_best, issue85),
+        "candidate_slices": candidate_slices,
+        "storage_policy": {
+            "golden_reference_roots": list(GOLDEN_REFERENCE_ROOTS),
+            "fitted_artifact_roots": ["algo/*.json", "artifacts/*.json"],
+            "release_config_roots": ["release/deadleaf_13b10_release/config/*.json"],
+            "new_fitted_artifact_paths": [
+                "artifacts/intrinsic_after_issue85_next_slice_benchmark.json",
+            ],
+            "rules": [
+                "Keep this issue's discovery outputs under `docs/` and `artifacts/` only.",
+                "Do not write new fitted intrinsic profiles, transfer tables, or benchmark outputs under the golden/reference roots.",
+                "Do not touch release-facing configs until a later bounded implementation actually clears the current README-facing guardrails.",
+            ],
+        },
+    }
+    assert_storage_separation(payload)
+    return payload
+
+
+def render_markdown(payload: dict[str, Any]) -> str:
+    selected = next(
+        row for row in payload["candidate_slices"] if row["slice_id"] == payload["selected_slice_id"]
+    )
+    issue83_selected = payload["source_artifacts"]["issue83_selected_slice_id"]
+    records = payload["comparison_records"]
+    details = payload["detail_records"]
+
+    lines = [
+        "# Intrinsic After Issue 85 Next Slice",
+        "",
+        "This note records the issue `#87` developer-discovery pass after issue `#85` / PR `#86` proved that the intrinsic line can reconnect the readout path without giving back the issue-81 downstream Quality Loss isolation gains.",
+        "",
+        "## Selected Slice",
+        "",
+        f"- Selected slice: `{payload['selected_slice_id']}`",
+        f"- Summary: {payload['selected_summary']}",
+        f"- Prior narrowing lineage: issue `#83` selected `{issue83_selected}`, and issue `#85` implemented it successfully.",
+        "- Remaining gap location: the surviving `overall_quality_loss_mae_mean` and `mtf20` gaps now point to the still-missing matched-ori downstream correction / anchor family, not to a new intrinsic transfer family.",
+        "",
+        "## Comparison Table",
+        "",
+        "| Record | Curve MAE | Focus Acu MAE | Overall QL | MTF20 | MTF30 | MTF50 | Abs Signed Rel | Quality Loss |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+    ]
+
+    readouts = {
+        CURRENT_BEST_LABEL: "Current best branch; already carries the matched-ori downstream correction stack.",
+        ISSUE47_LABEL: "Phase-retained intrinsic baseline; its readout metrics exactly match issue #85.",
+        ISSUE81_LABEL: "Quality Loss isolation landed; its overall Quality Loss metrics exactly match issue #85.",
+        ISSUE85_LABEL: "Readout reconnect landed; residual `mtf20` / overall Quality Loss gap still remains.",
+    }
+    order = [CURRENT_BEST_LABEL, ISSUE47_LABEL, ISSUE81_LABEL, ISSUE85_LABEL]
+    for key in order:
+        record = records[key]
+        mtf = record["mtf_threshold_mae"]
+        lines.append(
+            f"| {key} | "
+            f"{format_metric(record['curve_mae_mean'])} | "
+            f"{format_metric(record['focus_preset_acutance_mae_mean'])} | "
+            f"{format_metric(record['overall_quality_loss_mae_mean'])} | "
+            f"{format_metric(mtf['mtf20'])} | "
+            f"{format_metric(mtf['mtf30'])} | "
+            f"{format_metric(mtf['mtf50'])} | "
+            f"{format_metric(record['mtf_abs_signed_rel_mean'])} | "
+            f"{readouts[key]} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Why The Gap Still Remains After Issue 85",
+            "",
+        ]
+    )
+    for reason in selected["repo_evidence"]:
+        lines.append(f"- {reason}")
+
+    lines.extend(
+        [
+            "",
+            "## Residual Alignment Evidence",
+            "",
+            f"- Issue `#85` and issue `#81` have identical overall Quality Loss MAE: `{format_metric(records[ISSUE85_LABEL]['overall_quality_loss_mae_mean'])}`.",
+            f"- Issue `#85` and issue `#47` have identical `mtf_abs_signed_rel_mean`: `{format_metric(records[ISSUE85_LABEL]['mtf_abs_signed_rel_mean'])}`.",
+            f"- Issue `#85` Quality Loss focus-preset MAE mean also matches issue `#81`: `{format_metric(details[ISSUE85_LABEL]['quality_loss_focus_preset_mae_mean'])}`.",
+            "",
+            "### Issue 85 Quality Loss Preset Errors",
+            "",
+            "| Preset | PR30 | Issue47 | Issue81 | Issue85 |",
+            "| --- | --- | --- | --- | --- |",
+        ]
+    )
+    for preset in details[CURRENT_BEST_LABEL]["quality_loss_preset_mae"]:
+        lines.append(
+            f"| {preset} | "
+            f"{format_metric(details[CURRENT_BEST_LABEL]['quality_loss_preset_mae'][preset])} | "
+            f"{format_metric(details[ISSUE47_LABEL]['quality_loss_preset_mae'][preset])} | "
+            f"{format_metric(details[ISSUE81_LABEL]['quality_loss_preset_mae'][preset])} | "
+            f"{format_metric(details[ISSUE85_LABEL]['quality_loss_preset_mae'][preset])} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "### Issue 85 MTF Band Errors",
+            "",
+            "| Band | PR30 | Issue47 | Issue81 | Issue85 |",
+            "| --- | --- | --- | --- | --- |",
+        ]
+    )
+    for band in ("low", "mid", "high", "top"):
+        lines.append(
+            f"| {band} | "
+            f"{format_metric(details[CURRENT_BEST_LABEL]['mtf_band_mae'][band])} | "
+            f"{format_metric(details[ISSUE47_LABEL]['mtf_band_mae'][band])} | "
+            f"{format_metric(details[ISSUE81_LABEL]['mtf_band_mae'][band])} | "
+            f"{format_metric(details[ISSUE85_LABEL]['mtf_band_mae'][band])} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Pipeline Gap Versus PR30",
+            "",
+            "The current-best PR30 branch still carries the matched-ori correction / anchor family that issue `#85` does not enable:",
+            "",
+        ]
+    )
+    for key, values in payload["pipeline_gap_summary"].items():
+        lines.append(
+            f"- `{key}`: PR30={values['current_best_pr30_branch']!r}, issue85={values['issue85_readout_reconnect_quality_loss_isolation_candidate']!r}"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Runtime Boundary Evidence",
+            "",
+        ]
+    )
+    for row in selected["runtime_boundary_evidence"]:
+        lines.append(f"### `{row['file_path']}` ({row['line_range']})")
+        lines.append("")
+        for observation in row["observations"]:
+            lines.append(f"- {observation}")
+        lines.append("")
+
+    lines.extend(
+        [
+            "## Excluded Routes",
+            "",
+        ]
+    )
+    for row in payload["candidate_slices"]:
+        if row["decision"] == "advance":
+            continue
+        lines.append(f"### {row['label']}")
+        lines.append("")
+        for reason in row["exclusion_reasons"]:
+            lines.append(f"- {reason}")
+        lines.append("")
+
+    lines.extend(
+        [
+            "## Implementation Boundary",
+            "",
+        ]
+    )
+    for step in selected["minimum_implementation_boundary"]:
+        lines.append(f"- {step}")
+
+    lines.extend(
+        [
+            "",
+            "## Explicit Non-Changes",
+            "",
+        ]
+    )
+    for item in selected["explicitly_do_not_change"]:
+        lines.append(f"- {item}")
+
+    lines.extend(
+        [
+            "",
+            "## Storage Separation",
+            "",
+            f"- Golden/reference roots: {format_paths(payload['storage_policy']['golden_reference_roots'])}",
+            f"- Fitted artifact roots: {format_paths(payload['storage_policy']['fitted_artifact_roots'])}",
+            f"- Release config roots: {format_paths(payload['storage_policy']['release_config_roots'])}",
+        ]
+    )
+    for rule in payload["storage_policy"]["rules"]:
+        lines.append(f"- {rule}")
+
+    lines.extend(
+        [
+            "",
+            "## Acceptance For The Next Implementation Issue",
+            "",
+        ]
+    )
+    for item in selected["acceptance_criteria_for_next_issue"]:
+        lines.append(f"- {item}")
+
+    lines.extend(
+        [
+            "",
+            "## Validation Plan For The Next Implementation Issue",
+            "",
+        ]
+    )
+    for item in selected["validation_plan_for_next_issue"]:
+        lines.append(f"- {item}")
+
+    return "\n".join(lines) + "\n"
+
+
+def write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    repo_root = args.repo_root.resolve()
+    payload = build_payload(
+        repo_root,
+        issue83_artifact_path=args.issue83_artifact,
+        issue85_artifact_path=args.issue85_artifact,
+        issue47_psd_artifact_path=args.issue47_psd_artifact,
+        issue47_acutance_artifact_path=args.issue47_acutance_artifact,
+        issue81_psd_artifact_path=args.issue81_psd_artifact,
+        issue81_acutance_artifact_path=args.issue81_acutance_artifact,
+        issue85_psd_artifact_path=args.issue85_psd_artifact,
+        issue85_acutance_artifact_path=args.issue85_acutance_artifact,
+        current_best_psd_artifact_path=args.current_best_psd_artifact,
+        current_best_acutance_artifact_path=args.current_best_acutance_artifact,
+    )
+    output_json = resolve_path(repo_root, args.output_json)
+    output_md = resolve_path(repo_root, args.output_md)
+    write_text(output_json, json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    write_text(output_md, render_markdown(payload))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/artifacts/intrinsic_after_issue85_next_slice_benchmark.json
+++ b/artifacts/intrinsic_after_issue85_next_slice_benchmark.json
@@ -1,0 +1,1087 @@
+{
+  "candidate_slices": [
+    {
+      "acceptance_criteria_for_next_issue": [
+        "The new bounded graft preserves issue #85's curve and focus-preset Acutance gains closely enough that `curve_mae_mean` and `focus_preset_acutance_mae_mean` are no worse than issue #85.",
+        "The same implementation improves `overall_quality_loss_mae_mean` versus issue #85 while keeping the isolated downstream Quality Loss routing intact.",
+        "The same implementation improves `mtf20` toward the current PR #30 branch versus issue #85 and does not give back the issue-85 `mtf_abs_signed_rel_mean` improvement.",
+        "All new fitted outputs remain under `algo/` or `artifacts/`, not under golden/reference roots or release-facing config roots."
+      ],
+      "comparison_basis": {
+        "issue83_selected_slice_id": "phase_retained_intrinsic_readout_reconnect_with_quality_loss_isolation",
+        "issue85_vs_current_best_pr30": {
+          "delta": {
+            "curve_mae_mean": -0.0039872260971888646,
+            "focus_preset_acutance_mae_mean": -0.013566304809976663,
+            "mtf_abs_signed_rel_mean": 0.05322361665695152,
+            "mtf_threshold_mae": {
+              "mtf20": 0.05275557930482774,
+              "mtf30": -0.019044846884588542,
+              "mtf50": -0.0021365280254645085
+            },
+            "overall_quality_loss_mae_mean": 6.799042218904894
+          }
+        },
+        "issue85_vs_issue47": {
+          "delta": {
+            "curve_mae_mean": 0.0,
+            "focus_preset_acutance_mae_mean": 0.0,
+            "mtf_abs_signed_rel_mean": 0.0,
+            "mtf_threshold_mae": {
+              "mtf20": 0.0,
+              "mtf30": 0.0,
+              "mtf50": 0.0
+            },
+            "overall_quality_loss_mae_mean": -6.455217672689061
+          },
+          "readout_metrics_match_issue47": {
+            "mtf_abs_signed_rel_mean": true,
+            "mtf_band_mae": true,
+            "mtf_threshold_mae": true
+          }
+        },
+        "issue85_vs_issue81": {
+          "delta": {
+            "curve_mae_mean": 0.0,
+            "focus_preset_acutance_mae_mean": 0.0,
+            "mtf_abs_signed_rel_mean": -0.23923621156787914,
+            "mtf_threshold_mae": {
+              "mtf20": 0.011209288393153813,
+              "mtf30": -0.057804834625092644,
+              "mtf50": -0.027423184663686383
+            },
+            "overall_quality_loss_mae_mean": 0.0
+          },
+          "quality_loss_metrics_match_issue81": {
+            "overall_quality_loss_mae_mean": true,
+            "quality_loss_focus_preset_mae_mean": true,
+            "quality_loss_preset_mae": true
+          }
+        }
+      },
+      "decision": "advance",
+      "explicitly_do_not_change": [
+        "Do not change intrinsic transfer mode, registration mode, or restart a wider intrinsic-family sweep.",
+        "Do not reopen measured OECF or affine-registration branches.",
+        "Do not retune release-facing PR30 coefficients directly or promote any fitted intrinsic profile into release-facing config in this issue.",
+        "Do not write fitted profiles, transfer tables, or generated outputs under `20260318_deadleaf_13b10` or `release/deadleaf_13b10_release/data/20260318_deadleaf_13b10`."
+      ],
+      "label": "graft the current-best PR30 matched-ori correction and acutance-anchor family onto issue-85's split topology",
+      "minimum_implementation_boundary": [
+        "Keep issue #85's `readout_reconnect_quality_loss_isolation` topology and `radial_real_mean` / `phase_correlation` intrinsic path unchanged.",
+        "Add one bounded mode or profile family that grafts PR30's matched-ori reference correction onto the issue-85 readout path, including the `matched_ori_reference_anchor` strength-curve settings used around `compensated_mtf`.",
+        "Apply the same bounded graft to the isolated downstream Quality Loss path, including the `matched_ori_acutance_reference_anchor` family that runs through `maybe_anchor_acutance_results(...)`.",
+        "Keep downstream Quality Loss isolated off the non-intrinsic branch; do not collapse back to `replace_all`."
+      ],
+      "repo_evidence": [
+        "Issue #85's `overall_quality_loss_mae_mean` is exactly equal to issue #81, including the per-preset Quality Loss errors, so the remaining overall Quality Loss gap did not move when readout reconnect landed.",
+        "Issue #85's `mtf_abs_signed_rel_mean`, threshold errors, and MTF band errors are exactly equal to issue #47, so the residual `mtf20` gap also predates issue #85's split and stays on the readout side.",
+        "The current-best PR30 branch carries a tuned matched-ori reference-correction family and acutance-anchor family that issue #85 does not enable, which is the largest still-untried downstream boundary shared by the remaining `overall_quality_loss_mae_mean` and `mtf20` gaps.",
+        "The low-band MTF MAE on issue #85 is already better than PR30, yet `mtf20` is still farther away. That points to threshold-crossing / correction-shape behavior rather than to a missing wholesale intrinsic transfer family."
+      ],
+      "runtime_boundary_evidence": [
+        {
+          "file_path": "algo/benchmark_parity_psd_mtf.py",
+          "line_range": "502-508, 509-653, 654-659",
+          "observations": [
+            "Issue #85 already reconnects the phase-retained intrinsic branch into `compensated_mtf` when the scope is `readout_reconnect_quality_loss_isolation`.",
+            "The matched-ori reference correction then applies directly to both `compensated_mtf` and `compensated_mtf_for_acutance`, so the next bounded slice can target readout correction without touching the intrinsic transfer derivation.",
+            "`compute_mtf_metrics(...)` still reads thresholds from the corrected `compensated_mtf`, which makes this the narrowest live boundary for the residual `mtf20` gap."
+          ]
+        },
+        {
+          "file_path": "algo/benchmark_parity_acutance_quality_loss.py",
+          "line_range": "329-337, 745-869, 921-948, 1003-1008",
+          "observations": [
+            "`maybe_anchor_acutance_results(...)` is gated by `matched_ori_acutance_reference_anchor`, and it runs on both the main acutance path and the isolated Quality Loss acutance path.",
+            "The matched-ori reference correction also applies to `quality_loss_compensated_mtf_for_acutance`, which means one bounded graft can influence both the residual overall Quality Loss gap and the readout-side threshold shape.",
+            "`quality_loss_presets_from_acutance(...)` consumes that isolated downstream acutance path after correction and anchoring, so the next issue can stay bounded to downstream correction/anchor behavior rather than reopening intrinsic transfer or OECF work."
+          ]
+        }
+      ],
+      "selected_summary": "Keep issue #85's phase-retained intrinsic transfer, readout reconnect, and downstream Quality Loss isolation, but graft the current-best PR30 matched-ori correction / acutance-anchor family onto the readout path and the isolated Quality Loss branch.",
+      "slice_id": "phase_retained_intrinsic_matched_ori_correction_graft_with_quality_loss_isolation",
+      "technical_narrowing_point": "issue85_left_two_residuals_that_map_to_existing_downstream_correction_boundaries_rather_than_to_new_intrinsic_transfer_or_registration_families",
+      "validation_plan_for_next_issue": [
+        "Run `python3 -m algo.benchmark_parity_psd_mtf ...` on an issue-85-based profile that enables the bounded matched-ori correction graft, then compare thresholds and `mtf_abs_signed_rel_mean` against issue #85 and PR #30.",
+        "Run `python3 -m algo.benchmark_parity_acutance_quality_loss ...` on the same profile/scope pair to confirm `overall_quality_loss_mae_mean` improves without collapsing the isolated downstream branch.",
+        "Add focused tests that cover the graft across `compensated_mtf`, `compensated_mtf_for_acutance`, `quality_loss_compensated_mtf_for_acutance`, and `maybe_anchor_acutance_results(...)`."
+      ]
+    },
+    {
+      "decision": "exclude",
+      "exclusion_reasons": [
+        "Issue #85 is a real bounded positive, but it still trails PR #30 materially on `overall_quality_loss_mae_mean` and does not improve `mtf20` toward the current best branch.",
+        "Promoting it without another narrowing pass would skip the exact residual gaps this issue was created to isolate."
+      ],
+      "label": "promote issue-85 scope as-is",
+      "slice_id": "promote_issue85_as_is"
+    },
+    {
+      "decision": "exclude",
+      "exclusion_reasons": [
+        "Measured OECF already closed as a bounded negative in issue #77 / PR #78.",
+        "Issue #87 is downstream of issue #85's intrinsic split result, and the surviving gap maps to correction / anchor boundaries that already exist in the repo."
+      ],
+      "label": "reopen measured OECF",
+      "slice_id": "reopen_measured_oecf_family"
+    },
+    {
+      "decision": "exclude",
+      "exclusion_reasons": [
+        "Affine registration was already dominated by the phase-correlation intrinsic path and is still explicitly out of scope for this narrowing pass.",
+        "The issue-85 residuals match earlier branches exactly, which points to post-transfer downstream correction rather than to registration choice."
+      ],
+      "label": "rerun affine-registration intrinsic variant",
+      "slice_id": "rerun_affine_registration_intrinsic"
+    },
+    {
+      "decision": "exclude",
+      "exclusion_reasons": [
+        "Issue #87 is a developer-discovery narrowing pass, not a license to reopen the full intrinsic search tree.",
+        "The repo already contains one implementable next slice with code-level boundary evidence, so broader family churn would be workflow regress rather than progress."
+      ],
+      "label": "restart an unbounded intrinsic family search",
+      "slice_id": "restart_unbounded_intrinsic_inventory"
+    }
+  ],
+  "comparison_records": {
+    "current_best_pr30_branch": {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "readout_interpolation": "linear",
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": true
+      },
+      "curve_mae_mean": 0.03678903166100513,
+      "focus_preset_acutance_mae_mean": 0.042486831218701795,
+      "label": "current_best_pr30_branch",
+      "mtf_abs_signed_rel_mean": 0.08671416893394165,
+      "mtf_threshold_mae": {
+        "mtf20": 0.03301077142967389,
+        "mtf30": 0.03693639342667963,
+        "mtf50": 0.009332615436071163
+      },
+      "overall_quality_loss_mae_mean": 1.2214989544377113,
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_profile.json"
+    },
+    "issue47_phase_retained_replace_all": {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": null,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": null,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_hi_values": null,
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": null,
+        "matched_ori_acutance_preset_correction_delta_power_values": null,
+        "matched_ori_acutance_preset_strength_curve_relative_scales": null,
+        "matched_ori_acutance_preset_strength_curve_values": null,
+        "matched_ori_acutance_reference_anchor": false,
+        "matched_ori_acutance_strength_curve_relative_scales": null,
+        "matched_ori_acutance_strength_curve_values": null,
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": false,
+        "matched_ori_strength_curve_frequencies": null,
+        "matched_ori_strength_curve_values": null,
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "none",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.0,
+        "texture_support_scale": false
+      },
+      "curve_mae_mean": 0.03280180556381627,
+      "focus_preset_acutance_mae_mean": 0.028920526408725132,
+      "label": "issue47_phase_retained_replace_all",
+      "mtf_abs_signed_rel_mean": 0.13993778559089318,
+      "mtf_threshold_mae": {
+        "mtf20": 0.08576635073450163,
+        "mtf30": 0.017891546542091085,
+        "mtf50": 0.007196087410606654
+      },
+      "overall_quality_loss_mae_mean": 14.475758846031667,
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_profile.json"
+    },
+    "issue81_quality_loss_isolation_candidate": {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": null,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "quality_loss_isolation",
+        "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": null,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_hi_values": null,
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": null,
+        "matched_ori_acutance_preset_correction_delta_power_values": null,
+        "matched_ori_acutance_preset_strength_curve_relative_scales": null,
+        "matched_ori_acutance_preset_strength_curve_values": null,
+        "matched_ori_acutance_reference_anchor": false,
+        "matched_ori_acutance_strength_curve_relative_scales": null,
+        "matched_ori_acutance_strength_curve_values": null,
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": false,
+        "matched_ori_strength_curve_frequencies": null,
+        "matched_ori_strength_curve_values": null,
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "none",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "readout_interpolation": "linear",
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.0,
+        "texture_support_scale": false
+      },
+      "curve_mae_mean": 0.03280180556381627,
+      "focus_preset_acutance_mae_mean": 0.028920526408725132,
+      "label": "issue81_quality_loss_isolation_candidate",
+      "mtf_abs_signed_rel_mean": 0.3791739971587723,
+      "mtf_threshold_mae": {
+        "mtf20": 0.07455706234134782,
+        "mtf30": 0.07569638116718373,
+        "mtf50": 0.03461927207429304
+      },
+      "overall_quality_loss_mae_mean": 8.020541173342606,
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_quality_loss_isolation_profile.json"
+    },
+    "issue85_readout_reconnect_quality_loss_isolation_candidate": {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": null,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "readout_reconnect_quality_loss_isolation",
+        "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": null,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_hi_values": null,
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": null,
+        "matched_ori_acutance_preset_correction_delta_power_values": null,
+        "matched_ori_acutance_preset_strength_curve_relative_scales": null,
+        "matched_ori_acutance_preset_strength_curve_values": null,
+        "matched_ori_acutance_reference_anchor": false,
+        "matched_ori_acutance_strength_curve_relative_scales": null,
+        "matched_ori_acutance_strength_curve_values": null,
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": false,
+        "matched_ori_strength_curve_frequencies": null,
+        "matched_ori_strength_curve_values": null,
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "none",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "readout_interpolation": "linear",
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.0,
+        "texture_support_scale": false
+      },
+      "curve_mae_mean": 0.03280180556381627,
+      "focus_preset_acutance_mae_mean": 0.028920526408725132,
+      "label": "issue85_readout_reconnect_quality_loss_isolation_candidate",
+      "mtf_abs_signed_rel_mean": 0.13993778559089318,
+      "mtf_threshold_mae": {
+        "mtf20": 0.08576635073450163,
+        "mtf30": 0.017891546542091085,
+        "mtf50": 0.007196087410606654
+      },
+      "overall_quality_loss_mae_mean": 8.020541173342606,
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_readout_reconnect_quality_loss_isolation_profile.json"
+    }
+  },
+  "detail_records": {
+    "current_best_pr30_branch": {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": 0.013802247905288301,
+        "Computer Monitor Acutance": 0.052665183748573804,
+        "Large Print Acutance": 0.05132586418527154,
+        "Small Print Acutance": 0.046702107662187464,
+        "UHDTV Display Acutance": 0.04793875259218785
+      },
+      "mtf_band_mae": {
+        "high": 0.01764835359892083,
+        "low": 0.03704553941403868,
+        "mid": 0.03898616152003224,
+        "top": 0.07374065223652229
+      },
+      "quality_loss_focus_preset_mae_mean": 1.2214989544377113,
+      "quality_loss_preset_mae": {
+        "5.5\" Phone Display Quality Loss": 0.14297991495607307,
+        "Computer Monitor Quality Loss": 2.902905846061304,
+        "Large Print Quality Loss": 0.9548172583377941,
+        "Small Print Quality Loss": 0.6076935256225349,
+        "UHDTV Display Quality Loss": 1.4990982272108502
+      }
+    },
+    "issue47_phase_retained_replace_all": {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": 0.035256377739795786,
+        "Computer Monitor Acutance": 0.024146307932311834,
+        "Large Print Acutance": 0.028624302638652583,
+        "Small Print Acutance": 0.031726251556383624,
+        "UHDTV Display Acutance": 0.024849392176481848
+      },
+      "mtf_band_mae": {
+        "high": 0.046538330006884135,
+        "low": 0.009354903091206065,
+        "mid": 0.04532695609684774,
+        "top": 0.045570940534890705
+      },
+      "quality_loss_focus_preset_mae_mean": 14.475758846031667,
+      "quality_loss_preset_mae": {
+        "5.5\" Phone Display Quality Loss": 60.77410532227128,
+        "Computer Monitor Quality Loss": 5.980201776489433,
+        "Large Print Quality Loss": 1.759265006038341,
+        "Small Print Quality Loss": 1.5336822926986944,
+        "UHDTV Display Quality Loss": 2.331539832660566
+      }
+    },
+    "issue81_quality_loss_isolation_candidate": {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": 0.035256377739795786,
+        "Computer Monitor Acutance": 0.024146307932311834,
+        "Large Print Acutance": 0.028624302638652583,
+        "Small Print Acutance": 0.031726251556383624,
+        "UHDTV Display Acutance": 0.024849392176481848
+      },
+      "mtf_band_mae": {
+        "high": 0.09586956686463888,
+        "low": 0.07904481493140933,
+        "mid": 0.1151839806867104,
+        "top": 0.2603454312156407
+      },
+      "quality_loss_focus_preset_mae_mean": 8.020541173342606,
+      "quality_loss_preset_mae": {
+        "5.5\" Phone Display Quality Loss": 0.5469559580621024,
+        "Computer Monitor Quality Loss": 20.18457562486098,
+        "Large Print Quality Loss": 5.958175861662376,
+        "Small Print Quality Loss": 8.667190883803439,
+        "UHDTV Display Quality Loss": 4.745807538324134
+      }
+    },
+    "issue85_readout_reconnect_quality_loss_isolation_candidate": {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": 0.035256377739795786,
+        "Computer Monitor Acutance": 0.024146307932311834,
+        "Large Print Acutance": 0.028624302638652583,
+        "Small Print Acutance": 0.031726251556383624,
+        "UHDTV Display Acutance": 0.024849392176481848
+      },
+      "mtf_band_mae": {
+        "high": 0.046538330006884135,
+        "low": 0.009354903091206065,
+        "mid": 0.04532695609684774,
+        "top": 0.045570940534890705
+      },
+      "quality_loss_focus_preset_mae_mean": 8.020541173342606,
+      "quality_loss_preset_mae": {
+        "5.5\" Phone Display Quality Loss": 0.5469559580621024,
+        "Computer Monitor Quality Loss": 20.18457562486098,
+        "Large Print Quality Loss": 5.958175861662376,
+        "Small Print Quality Loss": 8.667190883803439,
+        "UHDTV Display Quality Loss": 4.745807538324134
+      }
+    }
+  },
+  "issue": 87,
+  "pipeline_gap_summary": {
+    "matched_ori_acutance_curve_correction_clip_hi_relative_scales": {
+      "current_best_pr30_branch": [
+        0.0,
+        0.25,
+        0.6,
+        0.8,
+        1.6,
+        2.5
+      ],
+      "issue85_readout_reconnect_quality_loss_isolation_candidate": null
+    },
+    "matched_ori_acutance_curve_correction_clip_hi_values": {
+      "current_best_pr30_branch": [
+        1.02,
+        1.03,
+        0.895,
+        0.895,
+        1.05,
+        1.06
+      ],
+      "issue85_readout_reconnect_quality_loss_isolation_candidate": null
+    },
+    "matched_ori_acutance_preset_correction_delta_power_relative_scales": {
+      "current_best_pr30_branch": [
+        0.0,
+        4.5,
+        5.8,
+        6.2
+      ],
+      "issue85_readout_reconnect_quality_loss_isolation_candidate": null
+    },
+    "matched_ori_acutance_preset_correction_delta_power_values": {
+      "current_best_pr30_branch": [
+        1.05,
+        1.05,
+        1.85,
+        1.85
+      ],
+      "issue85_readout_reconnect_quality_loss_isolation_candidate": null
+    },
+    "matched_ori_acutance_preset_strength_curve_relative_scales": {
+      "current_best_pr30_branch": [
+        0.0,
+        3.0,
+        4.5,
+        5.8,
+        6.2
+      ],
+      "issue85_readout_reconnect_quality_loss_isolation_candidate": null
+    },
+    "matched_ori_acutance_preset_strength_curve_values": {
+      "current_best_pr30_branch": [
+        1.0,
+        1.0,
+        0.85,
+        0.45,
+        0.45
+      ],
+      "issue85_readout_reconnect_quality_loss_isolation_candidate": null
+    },
+    "matched_ori_acutance_reference_anchor": {
+      "current_best_pr30_branch": true,
+      "issue85_readout_reconnect_quality_loss_isolation_candidate": false
+    },
+    "matched_ori_acutance_strength_curve_relative_scales": {
+      "current_best_pr30_branch": [
+        0.0,
+        0.2,
+        0.8,
+        1.6,
+        2.5
+      ],
+      "issue85_readout_reconnect_quality_loss_isolation_candidate": null
+    },
+    "matched_ori_acutance_strength_curve_values": {
+      "current_best_pr30_branch": [
+        0.7,
+        0.69,
+        0.64,
+        0.62,
+        0.6
+      ],
+      "issue85_readout_reconnect_quality_loss_isolation_candidate": null
+    },
+    "matched_ori_reference_anchor": {
+      "current_best_pr30_branch": true,
+      "issue85_readout_reconnect_quality_loss_isolation_candidate": false
+    },
+    "matched_ori_strength_curve_frequencies": {
+      "current_best_pr30_branch": [
+        0.0,
+        0.12,
+        0.22,
+        0.35,
+        0.5
+      ],
+      "issue85_readout_reconnect_quality_loss_isolation_candidate": null
+    },
+    "matched_ori_strength_curve_values": {
+      "current_best_pr30_branch": [
+        1.0,
+        1.0,
+        0.82,
+        0.95,
+        1.0
+      ],
+      "issue85_readout_reconnect_quality_loss_isolation_candidate": null
+    }
+  },
+  "residual_alignment_evidence": {
+    "issue85_quality_loss_matches_issue81": {
+      "overall_quality_loss_mae_mean": true,
+      "quality_loss_focus_preset_mae_mean": true,
+      "quality_loss_preset_mae": true
+    },
+    "issue85_readout_matches_issue47": {
+      "mtf_abs_signed_rel_mean": true,
+      "mtf_band_mae": true,
+      "mtf_threshold_mae": true
+    }
+  },
+  "selected_slice_id": "phase_retained_intrinsic_matched_ori_correction_graft_with_quality_loss_isolation",
+  "selected_summary": "Keep issue #85's phase-retained intrinsic transfer, readout reconnect, and downstream Quality Loss isolation, but graft the current-best PR30 matched-ori correction / acutance-anchor family onto the readout path and the isolated Quality Loss branch.",
+  "source_artifacts": {
+    "issue83_selected_slice_id": "phase_retained_intrinsic_readout_reconnect_with_quality_loss_isolation",
+    "issue83_summary_artifact": "artifacts/intrinsic_after_issue81_next_slice_benchmark.json",
+    "issue85_conclusion_status": "issue85_acceptance_passed_but_not_current_best",
+    "issue85_summary_artifact": "artifacts/intrinsic_phase_retained_readout_reconnect_benchmark.json"
+  },
+  "storage_policy": {
+    "fitted_artifact_roots": [
+      "algo/*.json",
+      "artifacts/*.json"
+    ],
+    "golden_reference_roots": [
+      "20260318_deadleaf_13b10",
+      "release/deadleaf_13b10_release/data/20260318_deadleaf_13b10"
+    ],
+    "new_fitted_artifact_paths": [
+      "artifacts/intrinsic_after_issue85_next_slice_benchmark.json"
+    ],
+    "release_config_roots": [
+      "release/deadleaf_13b10_release/config/*.json"
+    ],
+    "rules": [
+      "Keep this issue's discovery outputs under `docs/` and `artifacts/` only.",
+      "Do not write new fitted intrinsic profiles, transfer tables, or benchmark outputs under the golden/reference roots.",
+      "Do not touch release-facing configs until a later bounded implementation actually clears the current README-facing guardrails."
+    ]
+  },
+  "summary_kind": "intrinsic_after_issue85_next_slice"
+}

--- a/docs/intrinsic_after_issue85_next_slice.md
+++ b/docs/intrinsic_after_issue85_next_slice.md
@@ -1,0 +1,140 @@
+# Intrinsic After Issue 85 Next Slice
+
+This note records the issue `#87` developer-discovery pass after issue `#85` / PR `#86` proved that the intrinsic line can reconnect the readout path without giving back the issue-81 downstream Quality Loss isolation gains.
+
+## Selected Slice
+
+- Selected slice: `phase_retained_intrinsic_matched_ori_correction_graft_with_quality_loss_isolation`
+- Summary: Keep issue #85's phase-retained intrinsic transfer, readout reconnect, and downstream Quality Loss isolation, but graft the current-best PR30 matched-ori correction / acutance-anchor family onto the readout path and the isolated Quality Loss branch.
+- Prior narrowing lineage: issue `#83` selected `phase_retained_intrinsic_readout_reconnect_with_quality_loss_isolation`, and issue `#85` implemented it successfully.
+- Remaining gap location: the surviving `overall_quality_loss_mae_mean` and `mtf20` gaps now point to the still-missing matched-ori downstream correction / anchor family, not to a new intrinsic transfer family.
+
+## Comparison Table
+
+| Record | Curve MAE | Focus Acu MAE | Overall QL | MTF20 | MTF30 | MTF50 | Abs Signed Rel | Quality Loss |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| current_best_pr30_branch | 0.03679 | 0.04249 | 1.22150 | 0.03301 | 0.03694 | 0.00933 | 0.08671 | Current best branch; already carries the matched-ori downstream correction stack. |
+| issue47_phase_retained_replace_all | 0.03280 | 0.02892 | 14.47576 | 0.08577 | 0.01789 | 0.00720 | 0.13994 | Phase-retained intrinsic baseline; its readout metrics exactly match issue #85. |
+| issue81_quality_loss_isolation_candidate | 0.03280 | 0.02892 | 8.02054 | 0.07456 | 0.07570 | 0.03462 | 0.37917 | Quality Loss isolation landed; its overall Quality Loss metrics exactly match issue #85. |
+| issue85_readout_reconnect_quality_loss_isolation_candidate | 0.03280 | 0.02892 | 8.02054 | 0.08577 | 0.01789 | 0.00720 | 0.13994 | Readout reconnect landed; residual `mtf20` / overall Quality Loss gap still remains. |
+
+## Why The Gap Still Remains After Issue 85
+
+- Issue #85's `overall_quality_loss_mae_mean` is exactly equal to issue #81, including the per-preset Quality Loss errors, so the remaining overall Quality Loss gap did not move when readout reconnect landed.
+- Issue #85's `mtf_abs_signed_rel_mean`, threshold errors, and MTF band errors are exactly equal to issue #47, so the residual `mtf20` gap also predates issue #85's split and stays on the readout side.
+- The current-best PR30 branch carries a tuned matched-ori reference-correction family and acutance-anchor family that issue #85 does not enable, which is the largest still-untried downstream boundary shared by the remaining `overall_quality_loss_mae_mean` and `mtf20` gaps.
+- The low-band MTF MAE on issue #85 is already better than PR30, yet `mtf20` is still farther away. That points to threshold-crossing / correction-shape behavior rather than to a missing wholesale intrinsic transfer family.
+
+## Residual Alignment Evidence
+
+- Issue `#85` and issue `#81` have identical overall Quality Loss MAE: `8.02054`.
+- Issue `#85` and issue `#47` have identical `mtf_abs_signed_rel_mean`: `0.13994`.
+- Issue `#85` Quality Loss focus-preset MAE mean also matches issue `#81`: `8.02054`.
+
+### Issue 85 Quality Loss Preset Errors
+
+| Preset | PR30 | Issue47 | Issue81 | Issue85 |
+| --- | --- | --- | --- | --- |
+| 5.5" Phone Display Quality Loss | 0.14298 | 60.77411 | 0.54696 | 0.54696 |
+| Computer Monitor Quality Loss | 2.90291 | 5.98020 | 20.18458 | 20.18458 |
+| Large Print Quality Loss | 0.95482 | 1.75927 | 5.95818 | 5.95818 |
+| Small Print Quality Loss | 0.60769 | 1.53368 | 8.66719 | 8.66719 |
+| UHDTV Display Quality Loss | 1.49910 | 2.33154 | 4.74581 | 4.74581 |
+
+### Issue 85 MTF Band Errors
+
+| Band | PR30 | Issue47 | Issue81 | Issue85 |
+| --- | --- | --- | --- | --- |
+| low | 0.03705 | 0.00935 | 0.07904 | 0.00935 |
+| mid | 0.03899 | 0.04533 | 0.11518 | 0.04533 |
+| high | 0.01765 | 0.04654 | 0.09587 | 0.04654 |
+| top | 0.07374 | 0.04557 | 0.26035 | 0.04557 |
+
+## Pipeline Gap Versus PR30
+
+The current-best PR30 branch still carries the matched-ori correction / anchor family that issue `#85` does not enable:
+
+- `matched_ori_reference_anchor`: PR30=True, issue85=False
+- `matched_ori_strength_curve_frequencies`: PR30=[0.0, 0.12, 0.22, 0.35, 0.5], issue85=None
+- `matched_ori_strength_curve_values`: PR30=[1.0, 1.0, 0.82, 0.95, 1.0], issue85=None
+- `matched_ori_acutance_reference_anchor`: PR30=True, issue85=False
+- `matched_ori_acutance_strength_curve_relative_scales`: PR30=[0.0, 0.2, 0.8, 1.6, 2.5], issue85=None
+- `matched_ori_acutance_strength_curve_values`: PR30=[0.7, 0.69, 0.64, 0.62, 0.6], issue85=None
+- `matched_ori_acutance_curve_correction_clip_hi_relative_scales`: PR30=[0.0, 0.25, 0.6, 0.8, 1.6, 2.5], issue85=None
+- `matched_ori_acutance_curve_correction_clip_hi_values`: PR30=[1.02, 1.03, 0.895, 0.895, 1.05, 1.06], issue85=None
+- `matched_ori_acutance_preset_correction_delta_power_relative_scales`: PR30=[0.0, 4.5, 5.8, 6.2], issue85=None
+- `matched_ori_acutance_preset_correction_delta_power_values`: PR30=[1.05, 1.05, 1.85, 1.85], issue85=None
+- `matched_ori_acutance_preset_strength_curve_relative_scales`: PR30=[0.0, 3.0, 4.5, 5.8, 6.2], issue85=None
+- `matched_ori_acutance_preset_strength_curve_values`: PR30=[1.0, 1.0, 0.85, 0.45, 0.45], issue85=None
+
+## Runtime Boundary Evidence
+
+### `algo/benchmark_parity_psd_mtf.py` (502-508, 509-653, 654-659)
+
+- Issue #85 already reconnects the phase-retained intrinsic branch into `compensated_mtf` when the scope is `readout_reconnect_quality_loss_isolation`.
+- The matched-ori reference correction then applies directly to both `compensated_mtf` and `compensated_mtf_for_acutance`, so the next bounded slice can target readout correction without touching the intrinsic transfer derivation.
+- `compute_mtf_metrics(...)` still reads thresholds from the corrected `compensated_mtf`, which makes this the narrowest live boundary for the residual `mtf20` gap.
+
+### `algo/benchmark_parity_acutance_quality_loss.py` (329-337, 745-869, 921-948, 1003-1008)
+
+- `maybe_anchor_acutance_results(...)` is gated by `matched_ori_acutance_reference_anchor`, and it runs on both the main acutance path and the isolated Quality Loss acutance path.
+- The matched-ori reference correction also applies to `quality_loss_compensated_mtf_for_acutance`, which means one bounded graft can influence both the residual overall Quality Loss gap and the readout-side threshold shape.
+- `quality_loss_presets_from_acutance(...)` consumes that isolated downstream acutance path after correction and anchoring, so the next issue can stay bounded to downstream correction/anchor behavior rather than reopening intrinsic transfer or OECF work.
+
+## Excluded Routes
+
+### promote issue-85 scope as-is
+
+- Issue #85 is a real bounded positive, but it still trails PR #30 materially on `overall_quality_loss_mae_mean` and does not improve `mtf20` toward the current best branch.
+- Promoting it without another narrowing pass would skip the exact residual gaps this issue was created to isolate.
+
+### reopen measured OECF
+
+- Measured OECF already closed as a bounded negative in issue #77 / PR #78.
+- Issue #87 is downstream of issue #85's intrinsic split result, and the surviving gap maps to correction / anchor boundaries that already exist in the repo.
+
+### rerun affine-registration intrinsic variant
+
+- Affine registration was already dominated by the phase-correlation intrinsic path and is still explicitly out of scope for this narrowing pass.
+- The issue-85 residuals match earlier branches exactly, which points to post-transfer downstream correction rather than to registration choice.
+
+### restart an unbounded intrinsic family search
+
+- Issue #87 is a developer-discovery narrowing pass, not a license to reopen the full intrinsic search tree.
+- The repo already contains one implementable next slice with code-level boundary evidence, so broader family churn would be workflow regress rather than progress.
+
+## Implementation Boundary
+
+- Keep issue #85's `readout_reconnect_quality_loss_isolation` topology and `radial_real_mean` / `phase_correlation` intrinsic path unchanged.
+- Add one bounded mode or profile family that grafts PR30's matched-ori reference correction onto the issue-85 readout path, including the `matched_ori_reference_anchor` strength-curve settings used around `compensated_mtf`.
+- Apply the same bounded graft to the isolated downstream Quality Loss path, including the `matched_ori_acutance_reference_anchor` family that runs through `maybe_anchor_acutance_results(...)`.
+- Keep downstream Quality Loss isolated off the non-intrinsic branch; do not collapse back to `replace_all`.
+
+## Explicit Non-Changes
+
+- Do not change intrinsic transfer mode, registration mode, or restart a wider intrinsic-family sweep.
+- Do not reopen measured OECF or affine-registration branches.
+- Do not retune release-facing PR30 coefficients directly or promote any fitted intrinsic profile into release-facing config in this issue.
+- Do not write fitted profiles, transfer tables, or generated outputs under `20260318_deadleaf_13b10` or `release/deadleaf_13b10_release/data/20260318_deadleaf_13b10`.
+
+## Storage Separation
+
+- Golden/reference roots: `20260318_deadleaf_13b10`, `release/deadleaf_13b10_release/data/20260318_deadleaf_13b10`
+- Fitted artifact roots: `algo/*.json`, `artifacts/*.json`
+- Release config roots: `release/deadleaf_13b10_release/config/*.json`
+- Keep this issue's discovery outputs under `docs/` and `artifacts/` only.
+- Do not write new fitted intrinsic profiles, transfer tables, or benchmark outputs under the golden/reference roots.
+- Do not touch release-facing configs until a later bounded implementation actually clears the current README-facing guardrails.
+
+## Acceptance For The Next Implementation Issue
+
+- The new bounded graft preserves issue #85's curve and focus-preset Acutance gains closely enough that `curve_mae_mean` and `focus_preset_acutance_mae_mean` are no worse than issue #85.
+- The same implementation improves `overall_quality_loss_mae_mean` versus issue #85 while keeping the isolated downstream Quality Loss routing intact.
+- The same implementation improves `mtf20` toward the current PR #30 branch versus issue #85 and does not give back the issue-85 `mtf_abs_signed_rel_mean` improvement.
+- All new fitted outputs remain under `algo/` or `artifacts/`, not under golden/reference roots or release-facing config roots.
+
+## Validation Plan For The Next Implementation Issue
+
+- Run `python3 -m algo.benchmark_parity_psd_mtf ...` on an issue-85-based profile that enables the bounded matched-ori correction graft, then compare thresholds and `mtf_abs_signed_rel_mean` against issue #85 and PR #30.
+- Run `python3 -m algo.benchmark_parity_acutance_quality_loss ...` on the same profile/scope pair to confirm `overall_quality_loss_mae_mean` improves without collapsing the isolated downstream branch.
+- Add focused tests that cover the graft across `compensated_mtf`, `compensated_mtf_for_acutance`, `quality_loss_compensated_mtf_for_acutance`, and `maybe_anchor_acutance_results(...)`.

--- a/tests/test_build_intrinsic_after_issue85_next_slice.py
+++ b/tests/test_build_intrinsic_after_issue85_next_slice.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from algo.build_intrinsic_after_issue85_next_slice import (
+    ISSUE81_LABEL,
+    ISSUE85_LABEL,
+    ISSUE47_LABEL,
+    SELECTED_SLICE_ID,
+    build_payload,
+    render_markdown,
+)
+
+
+class BuildIntrinsicAfterIssue85NextSliceTest(unittest.TestCase):
+    def test_payload_selects_matched_ori_graft_slice(self) -> None:
+        payload = build_payload(
+            self.repo_root(),
+            issue83_artifact_path=Path("artifacts/intrinsic_after_issue81_next_slice_benchmark.json"),
+            issue85_artifact_path=Path(
+                "artifacts/intrinsic_phase_retained_readout_reconnect_benchmark.json"
+            ),
+            issue47_psd_artifact_path=Path(
+                "artifacts/issue46_intrinsic_phase_retention_psd_benchmark.json"
+            ),
+            issue47_acutance_artifact_path=Path(
+                "artifacts/issue46_intrinsic_phase_retention_acutance_benchmark.json"
+            ),
+            issue81_psd_artifact_path=Path(
+                "artifacts/issue81_intrinsic_phase_retained_quality_loss_isolation_psd_benchmark.json"
+            ),
+            issue81_acutance_artifact_path=Path(
+                "artifacts/issue81_intrinsic_phase_retained_quality_loss_isolation_acutance_benchmark.json"
+            ),
+            issue85_psd_artifact_path=Path(
+                "artifacts/issue85_intrinsic_phase_retained_readout_reconnect_psd_benchmark.json"
+            ),
+            issue85_acutance_artifact_path=Path(
+                "artifacts/issue85_intrinsic_phase_retained_readout_reconnect_acutance_benchmark.json"
+            ),
+            current_best_psd_artifact_path=Path(
+                "artifacts/issue77_measured_oecf_psd_benchmark.json"
+            ),
+            current_best_acutance_artifact_path=Path(
+                "artifacts/issue77_measured_oecf_acutance_benchmark.json"
+            ),
+        )
+
+        self.assertEqual(payload["issue"], 87)
+        self.assertEqual(payload["summary_kind"], "intrinsic_after_issue85_next_slice")
+        self.assertEqual(payload["selected_slice_id"], SELECTED_SLICE_ID)
+        selected = next(
+            row for row in payload["candidate_slices"] if row["slice_id"] == SELECTED_SLICE_ID
+        )
+        self.assertIn("matched-ori reference correction", selected["minimum_implementation_boundary"][1])
+        self.assertEqual(len(selected["runtime_boundary_evidence"]), 2)
+        self.assertTrue(
+            payload["residual_alignment_evidence"]["issue85_quality_loss_matches_issue81"][
+                "quality_loss_preset_mae"
+            ]
+        )
+        self.assertTrue(
+            payload["residual_alignment_evidence"]["issue85_readout_matches_issue47"][
+                "mtf_threshold_mae"
+            ]
+        )
+        self.assertFalse(payload["pipeline_gap_summary"]["matched_ori_reference_anchor"][ISSUE85_LABEL])
+        self.assertTrue(payload["pipeline_gap_summary"]["matched_ori_reference_anchor"]["current_best_pr30_branch"])
+        for path in payload["storage_policy"]["new_fitted_artifact_paths"]:
+            self.assertFalse(path.startswith("20260318_deadleaf_13b10"))
+            self.assertFalse(
+                path.startswith("release/deadleaf_13b10_release/data/20260318_deadleaf_13b10")
+            )
+
+    def test_markdown_mentions_residual_alignment_and_pipeline_gap(self) -> None:
+        payload = build_payload(
+            self.repo_root(),
+            issue83_artifact_path=Path("artifacts/intrinsic_after_issue81_next_slice_benchmark.json"),
+            issue85_artifact_path=Path(
+                "artifacts/intrinsic_phase_retained_readout_reconnect_benchmark.json"
+            ),
+            issue47_psd_artifact_path=Path(
+                "artifacts/issue46_intrinsic_phase_retention_psd_benchmark.json"
+            ),
+            issue47_acutance_artifact_path=Path(
+                "artifacts/issue46_intrinsic_phase_retention_acutance_benchmark.json"
+            ),
+            issue81_psd_artifact_path=Path(
+                "artifacts/issue81_intrinsic_phase_retained_quality_loss_isolation_psd_benchmark.json"
+            ),
+            issue81_acutance_artifact_path=Path(
+                "artifacts/issue81_intrinsic_phase_retained_quality_loss_isolation_acutance_benchmark.json"
+            ),
+            issue85_psd_artifact_path=Path(
+                "artifacts/issue85_intrinsic_phase_retained_readout_reconnect_psd_benchmark.json"
+            ),
+            issue85_acutance_artifact_path=Path(
+                "artifacts/issue85_intrinsic_phase_retained_readout_reconnect_acutance_benchmark.json"
+            ),
+            current_best_psd_artifact_path=Path(
+                "artifacts/issue77_measured_oecf_psd_benchmark.json"
+            ),
+            current_best_acutance_artifact_path=Path(
+                "artifacts/issue77_measured_oecf_acutance_benchmark.json"
+            ),
+        )
+        markdown = render_markdown(payload)
+
+        self.assertIn("# Intrinsic After Issue 85 Next Slice", markdown)
+        self.assertIn("## Residual Alignment Evidence", markdown)
+        self.assertIn("matched_ori_reference_anchor", markdown)
+        self.assertIn("## Runtime Boundary Evidence", markdown)
+        self.assertIn("reopen measured OECF", markdown)
+        self.assertIn("Storage Separation", markdown)
+        self.assertIn("overall Quality Loss MAE", markdown)
+        self.assertIn("mtf20", markdown)
+
+    @staticmethod
+    def repo_root() -> Path:
+        return Path(__file__).resolve().parents[1]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add the issue-87 developer-discovery builder, artifact, and note for the post-issue85 intrinsic narrowing pass
- show that issue #85's remaining `overall_quality_loss_mae_mean` gap still matches issue #81 while its residual readout gap still matches issue #47
- select one bounded next implementation slice: graft the PR30 matched-ori downstream correction / acutance-anchor family onto issue-85's split topology

## Validation
- `python3 -m pytest tests/test_build_intrinsic_after_issue85_next_slice.py`
- `python3 -m algo.build_intrinsic_after_issue85_next_slice`

Refs #29
Refs #81
Refs #83
Refs #85
Refs #87
