### PR TITLE
Issue #97: disconnect reported-MTF thresholds from intrinsic reconnect

### DIFF
--- a/algo/benchmark_parity_acutance_quality_loss.py
+++ b/algo/benchmark_parity_acutance_quality_loss.py
@@ -689,6 +689,7 @@ def summarize_profile(
                 "readout_reconnect_quality_loss_isolation",
                 "readout_reconnect_quality_loss_isolation_matched_ori_graft",
                 "readout_reconnect_quality_loss_isolation_downstream_matched_ori_only",
+                "reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only",
             }:
                 raise ValueError(
                     f"Unsupported intrinsic full-reference scope: {profile.intrinsic_full_reference_scope}"
@@ -844,6 +845,7 @@ def summarize_profile(
                     not in {
                         "readout_reconnect_quality_loss_isolation_matched_ori_graft",
                         "readout_reconnect_quality_loss_isolation_downstream_matched_ori_only",
+                        "reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only",
                     }
                 ):
                     compensated_mtf_for_acutance = apply_reference_correction_curve(
@@ -926,6 +928,7 @@ def summarize_profile(
             not in {
                 "readout_reconnect_quality_loss_isolation_matched_ori_graft",
                 "readout_reconnect_quality_loss_isolation_downstream_matched_ori_only",
+                "reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only",
             }
         ):
             curve, acutance = maybe_anchor_acutance_results(
@@ -943,6 +946,7 @@ def summarize_profile(
                 "readout_reconnect_quality_loss_isolation",
                 "readout_reconnect_quality_loss_isolation_matched_ori_graft",
                 "readout_reconnect_quality_loss_isolation_downstream_matched_ori_only",
+                "reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only",
             }
         ):
             quality_loss_curve = acutance_curve_from_mtf(

--- a/algo/benchmark_parity_psd_mtf.py
+++ b/algo/benchmark_parity_psd_mtf.py
@@ -422,6 +422,8 @@ def profile_payload(
             estimate.frequencies_cpp,
             scale=effective_frequency_scale,
         )
+        readout_scaled_frequencies = np.asarray(scaled_frequencies, dtype=np.float64).copy()
+        acutance_scaled_frequencies = np.asarray(scaled_frequencies, dtype=np.float64).copy()
         compensated_mtf, _ = apply_mtf_compensation(
             estimate.mtf,
             scaled_frequencies,
@@ -452,6 +454,7 @@ def profile_payload(
                 "readout_reconnect_quality_loss_isolation",
                 "readout_reconnect_quality_loss_isolation_matched_ori_graft",
                 "readout_reconnect_quality_loss_isolation_downstream_matched_ori_only",
+                "reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only",
             }:
                 raise ValueError(
                     f"Unsupported intrinsic full-reference scope: {profile.intrinsic_full_reference_scope}"
@@ -500,7 +503,10 @@ def profile_payload(
                     registration_mode=profile.intrinsic_full_reference_registration_mode,
                     transfer_mode=profile.intrinsic_full_reference_transfer_mode,
                 )
-                scaled_frequencies = np.asarray(ori_reference.frequencies_cpp, dtype=np.float64)
+                intrinsic_scaled_frequencies = np.asarray(
+                    ori_reference.frequencies_cpp, dtype=np.float64
+                )
+                acutance_scaled_frequencies = intrinsic_scaled_frequencies
                 intrinsic_mtf = np.asarray(ori_reference.mtf, dtype=np.float64) * transfer_curve
                 compensated_mtf_for_acutance = intrinsic_mtf.copy()
                 if profile.intrinsic_full_reference_scope in {
@@ -509,6 +515,7 @@ def profile_payload(
                     "readout_reconnect_quality_loss_isolation_matched_ori_graft",
                     "readout_reconnect_quality_loss_isolation_downstream_matched_ori_only",
                 }:
+                    readout_scaled_frequencies = intrinsic_scaled_frequencies
                     compensated_mtf = intrinsic_mtf
         if profile.matched_ori_reference_anchor:
             if capture_key in ori_reference_map:
@@ -629,7 +636,10 @@ def profile_payload(
                     == "readout_reconnect_quality_loss_isolation_matched_ori_graft"
                     or (
                         profile.intrinsic_full_reference_scope
-                        != "readout_reconnect_quality_loss_isolation_downstream_matched_ori_only"
+                        not in {
+                            "readout_reconnect_quality_loss_isolation_downstream_matched_ori_only",
+                            "reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only",
+                        }
                         and profile.matched_ori_anchor_mode != "acutance_only"
                     )
                 )
@@ -638,11 +648,12 @@ def profile_payload(
                     not in {
                         "readout_reconnect_quality_loss_isolation_matched_ori_graft",
                         "readout_reconnect_quality_loss_isolation_downstream_matched_ori_only",
+                        "reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only",
                     }
                 )
                 if apply_readout_correction:
                     compensated_mtf = apply_reference_correction_curve(
-                        scaled_frequencies,
+                        readout_scaled_frequencies,
                         compensated_mtf,
                         correction_frequencies,
                         correction_curve,
@@ -658,7 +669,7 @@ def profile_payload(
                 )
                 if apply_acutance_correction:
                     compensated_mtf_for_acutance = apply_reference_correction_curve(
-                        scaled_frequencies,
+                        acutance_scaled_frequencies,
                         compensated_mtf_for_acutance,
                         correction_frequencies,
                         acutance_correction_curve,
@@ -673,7 +684,7 @@ def profile_payload(
                         strength_curve_values=profile.matched_ori_strength_curve_values,
                     )
         metrics = compute_mtf_metrics(
-            scaled_frequencies,
+            readout_scaled_frequencies,
             compensated_mtf,
             smoothing_window=profile.readout_smoothing_window,
             interpolation_mode=profile.readout_interpolation,
@@ -689,7 +700,7 @@ def profile_payload(
         )
 
         curve = acutance_curve_from_mtf(
-            scaled_frequencies,
+            acutance_scaled_frequencies,
             compensated_mtf_for_acutance,
             picture_height_cm=40.0,
             viewing_distances_cm=np.arange(1.0, 101.0, 1.0),
@@ -702,7 +713,7 @@ def profile_payload(
             by_mixup.setdefault(key, []).append(float(curve_cmp["mae"]))
 
         presets = acutance_presets_from_mtf(
-            scaled_frequencies,
+            acutance_scaled_frequencies,
             compensated_mtf_for_acutance,
             pixels_along_picture_height=estimate.roi.height,
         )
@@ -711,7 +722,7 @@ def profile_payload(
             preset_errors.setdefault(key, []).append(float(values["abs_error"]))
 
         estimate_on_reference = resample_curve(
-            scaled_frequencies,
+            readout_scaled_frequencies,
             compensated_mtf,
             reference.frequencies_cpp,
         )

--- a/algo/build_intrinsic_phase_retained_reported_mtf_disconnect_followup.py
+++ b/algo/build_intrinsic_phase_retained_reported_mtf_disconnect_followup.py
@@ -1,0 +1,409 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+CURRENT_BEST_LABEL = "current_best_pr30_branch"
+ISSUE93_LABEL = "issue93_downstream_matched_ori_only_candidate"
+CANDIDATE_LABEL = "issue97_reported_mtf_disconnect_candidate"
+SUMMARY_KIND = "intrinsic_phase_retained_reported_mtf_disconnect_followup"
+SELECTED_SLICE_ID = (
+    "issue93_topology_keep_downstream_quality_loss_branch_but_disconnect_reported_mtf_from_intrinsic_reconnect"
+)
+GOLDEN_REFERENCE_ROOTS = (
+    "20260318_deadleaf_13b10",
+    "release/deadleaf_13b10_release/data/20260318_deadleaf_13b10",
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build the issue-97 reported-MTF disconnect follow-up summary."
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Repository root. Defaults to the parent of this script.",
+    )
+    parser.add_argument(
+        "--psd-artifact",
+        type=Path,
+        default=Path("artifacts/issue97_intrinsic_phase_retained_reported_mtf_disconnect_psd_benchmark.json"),
+        help="Repo-relative PSD benchmark artifact path.",
+    )
+    parser.add_argument(
+        "--acutance-artifact",
+        type=Path,
+        default=Path("artifacts/issue97_intrinsic_phase_retained_reported_mtf_disconnect_acutance_benchmark.json"),
+        help="Repo-relative acutance/quality-loss benchmark artifact path.",
+    )
+    parser.add_argument(
+        "--output-json",
+        type=Path,
+        default=Path("artifacts/intrinsic_phase_retained_reported_mtf_disconnect_benchmark.json"),
+        help="Repo-relative output path for the machine-readable issue artifact.",
+    )
+    parser.add_argument(
+        "--output-md",
+        type=Path,
+        default=Path("docs/intrinsic_phase_retained_reported_mtf_disconnect_followup.md"),
+        help="Repo-relative output path for the Markdown note.",
+    )
+    return parser
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def resolve_output(path: Path, repo_root: Path) -> Path:
+    return path if path.is_absolute() else repo_root / path
+
+
+def select_profile(payload: dict[str, Any], expected_profile_path: str) -> dict[str, Any]:
+    for profile in payload["profiles"]:
+        if profile["profile_path"] == expected_profile_path:
+            return profile
+    available = ", ".join(profile["profile_path"] for profile in payload["profiles"])
+    raise ValueError(
+        f"Profile {expected_profile_path!r} not found in artifact. Available: {available}"
+    )
+
+
+def summarize_profile(
+    *,
+    label: str,
+    psd_payload: dict[str, Any],
+    acutance_payload: dict[str, Any],
+    profile_path: str,
+) -> dict[str, Any]:
+    psd_profile = select_profile(psd_payload, profile_path)
+    acutance_profile = select_profile(acutance_payload, profile_path)
+    psd_overall = psd_profile["overall"]
+    acutance_overall = acutance_profile["overall"]
+    return {
+        "label": label,
+        "profile_path": profile_path,
+        "analysis_pipeline": acutance_profile["analysis_pipeline"],
+        "curve_mae_mean": float(acutance_overall["curve_mae_mean"]),
+        "focus_preset_acutance_mae_mean": float(acutance_overall["acutance_focus_preset_mae_mean"]),
+        "overall_quality_loss_mae_mean": float(acutance_overall["overall_quality_loss_mae_mean"]),
+        "quality_loss_preset_mae": {
+            key: float(value) for key, value in acutance_overall["quality_loss_preset_mae"].items()
+        },
+        "acutance_preset_mae": {
+            key: float(value) for key, value in acutance_overall["acutance_preset_mae"].items()
+        },
+        "mtf_abs_signed_rel_mean": float(psd_overall["mtf_abs_signed_rel_mean"]),
+        "mtf_threshold_mae": {
+            key: float(value) for key, value in psd_overall["mtf_threshold_mae"].items()
+        },
+    }
+
+
+def delta_map(candidate: dict[str, Any], baseline: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "curve_mae_mean": float(candidate["curve_mae_mean"] - baseline["curve_mae_mean"]),
+        "focus_preset_acutance_mae_mean": float(
+            candidate["focus_preset_acutance_mae_mean"]
+            - baseline["focus_preset_acutance_mae_mean"]
+        ),
+        "overall_quality_loss_mae_mean": float(
+            candidate["overall_quality_loss_mae_mean"] - baseline["overall_quality_loss_mae_mean"]
+        ),
+        "mtf_abs_signed_rel_mean": float(
+            candidate["mtf_abs_signed_rel_mean"] - baseline["mtf_abs_signed_rel_mean"]
+        ),
+        "mtf_threshold_mae": {
+            key: float(candidate["mtf_threshold_mae"][key] - baseline["mtf_threshold_mae"][key])
+            for key in ("mtf20", "mtf30", "mtf50")
+        },
+    }
+
+
+def assert_storage_separation(payload: dict[str, Any]) -> None:
+    for path in payload["storage"]["new_fitted_artifact_paths"]:
+        for root in GOLDEN_REFERENCE_ROOTS:
+            if path.startswith(root):
+                raise ValueError(f"Path {path} leaks into golden/reference root {root}")
+
+
+def build_conclusion(
+    *,
+    acceptance: dict[str, bool],
+    candidate: dict[str, Any],
+    current_best: dict[str, Any],
+) -> dict[str, str]:
+    if acceptance["all_issue97_gates_pass"]:
+        if (
+            candidate["overall_quality_loss_mae_mean"] <= current_best["overall_quality_loss_mae_mean"]
+            and candidate["mtf_abs_signed_rel_mean"] <= current_best["mtf_abs_signed_rel_mean"]
+            and candidate["mtf_threshold_mae"]["mtf20"] <= current_best["mtf_threshold_mae"]["mtf20"]
+        ):
+            return {
+                "status": "issue97_acceptance_passed_and_current_best_candidate",
+                "summary": (
+                    "The reported-MTF disconnect preserves the issue-93 acutance and Quality Loss "
+                    "record while improving the readout metrics enough to clear the current-best "
+                    "PR #30 guardrails."
+                ),
+                "next_step": "Promote this branch for reviewer scrutiny against the current best branch.",
+            }
+        return {
+            "status": "issue97_acceptance_passed_but_not_current_best",
+            "summary": (
+                "The reported-MTF disconnect preserves the issue-93 acutance and Quality Loss "
+                "record while improving the readout metrics, but it still trails the current "
+                "PR #30 branch overall."
+            ),
+            "next_step": (
+                "Keep this branch as the bounded issue-97 implementation record and judge any "
+                "later promotion against the remaining PR #30 gap."
+            ),
+        }
+    return {
+        "status": "issue97_reported_mtf_disconnect_failed",
+        "summary": (
+            "Disconnecting reported-MTF thresholds from the intrinsic reconnect did not improve "
+            "the readout metrics enough while preserving the issue-93 acutance and Quality Loss "
+            "record, so this bounded slice closes as a negative or mixed result."
+        ),
+        "next_step": (
+            "Keep the result as the canonical issue-97 record and split the next bounded follow-up "
+            "from the remaining failure mode."
+        ),
+    }
+
+
+def build_payload(
+    repo_root: Path,
+    *,
+    psd_artifact_path: Path,
+    acutance_artifact_path: Path,
+) -> dict[str, Any]:
+    psd_payload = load_json(resolve_output(psd_artifact_path, repo_root))
+    acutance_payload = load_json(resolve_output(acutance_artifact_path, repo_root))
+    issue93_summary = load_json(
+        resolve_output(Path("artifacts/intrinsic_phase_retained_downstream_matched_ori_only_benchmark.json"), repo_root)
+    )
+    issue95_summary = load_json(
+        resolve_output(Path("artifacts/intrinsic_after_issue93_next_slice_benchmark.json"), repo_root)
+    )
+
+    candidate_profile_path = (
+        "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_"
+        "reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only_profile.json"
+    )
+
+    profiles = {
+        CURRENT_BEST_LABEL: issue93_summary["profiles"][CURRENT_BEST_LABEL],
+        ISSUE93_LABEL: issue93_summary["profiles"][ISSUE93_LABEL],
+        CANDIDATE_LABEL: summarize_profile(
+            label=CANDIDATE_LABEL,
+            psd_payload=psd_payload,
+            acutance_payload=acutance_payload,
+            profile_path=candidate_profile_path,
+        ),
+    }
+
+    current_best = profiles[CURRENT_BEST_LABEL]
+    issue93 = profiles[ISSUE93_LABEL]
+    candidate = profiles[CANDIDATE_LABEL]
+
+    comparisons = {
+        "candidate_vs_issue93": {
+            "delta": delta_map(candidate, issue93),
+            "curve_mae_non_worse_than_issue93": candidate["curve_mae_mean"] <= issue93["curve_mae_mean"],
+            "focus_preset_acutance_non_worse_than_issue93": (
+                candidate["focus_preset_acutance_mae_mean"]
+                <= issue93["focus_preset_acutance_mae_mean"]
+            ),
+            "overall_quality_loss_non_worse_than_issue93": (
+                candidate["overall_quality_loss_mae_mean"] <= issue93["overall_quality_loss_mae_mean"]
+            ),
+            "mtf20_improved_vs_issue93": (
+                candidate["mtf_threshold_mae"]["mtf20"] < issue93["mtf_threshold_mae"]["mtf20"]
+            ),
+            "mtf_abs_signed_rel_improved_vs_issue93": (
+                candidate["mtf_abs_signed_rel_mean"] < issue93["mtf_abs_signed_rel_mean"]
+            ),
+        },
+        "candidate_vs_current_best_pr30": {
+            "delta": delta_map(candidate, current_best),
+        },
+    }
+    acceptance = {
+        "curve_mae_non_worse_than_issue93": comparisons["candidate_vs_issue93"][
+            "curve_mae_non_worse_than_issue93"
+        ],
+        "focus_preset_acutance_non_worse_than_issue93": comparisons["candidate_vs_issue93"][
+            "focus_preset_acutance_non_worse_than_issue93"
+        ],
+        "overall_quality_loss_non_worse_than_issue93": comparisons["candidate_vs_issue93"][
+            "overall_quality_loss_non_worse_than_issue93"
+        ],
+        "mtf20_improved_vs_issue93": comparisons["candidate_vs_issue93"][
+            "mtf20_improved_vs_issue93"
+        ],
+        "mtf_abs_signed_rel_improved_vs_issue93": comparisons["candidate_vs_issue93"][
+            "mtf_abs_signed_rel_improved_vs_issue93"
+        ],
+    }
+    acceptance["all_issue97_gates_pass"] = all(acceptance.values())
+
+    payload = {
+        "issue": 97,
+        "summary_kind": SUMMARY_KIND,
+        "dataset_root": psd_payload["dataset_root"],
+        "profiles": profiles,
+        "comparisons": comparisons,
+        "acceptance": acceptance,
+        "implementation_change": {
+            "selected_slice_id": issue95_summary["selected_slice_id"],
+            "scope_name": "reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only",
+            "basis_profile_path": issue93["profile_path"],
+            "candidate_profile_path": candidate["profile_path"],
+            "change": (
+                "Keep the issue-93 downstream-only matched-ori Quality Loss branch and intrinsic "
+                "main-acutance branch, but disconnect reported-MTF threshold extraction from the "
+                "intrinsic reconnect path."
+            ),
+            "scope_difference": {
+                "readout_reconnect_quality_loss_isolation_downstream_matched_ori_only": (
+                    "Issue-93 topology: reported-MTF thresholds and the main acutance branch both "
+                    "use the intrinsic reconnect, while the downstream Quality Loss branch stays isolated."
+                ),
+                "reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only": (
+                    "Reported-MTF thresholds stay on the observed calibrated/compensated branch, "
+                    "while the main acutance branch and downstream-only matched-ori Quality Loss "
+                    "branch remain on the issue-93 topology."
+                ),
+            },
+        },
+        "conclusion": build_conclusion(
+            acceptance=acceptance,
+            candidate=candidate,
+            current_best=current_best,
+        ),
+        "storage": {
+            "golden_reference_roots": list(GOLDEN_REFERENCE_ROOTS),
+            "new_fitted_artifact_paths": [
+                "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only_profile.json",
+                "artifacts/issue97_intrinsic_phase_retained_reported_mtf_disconnect_psd_benchmark.json",
+                "artifacts/issue97_intrinsic_phase_retained_reported_mtf_disconnect_acutance_benchmark.json",
+                "artifacts/intrinsic_phase_retained_reported_mtf_disconnect_benchmark.json",
+            ],
+            "rules": [
+                "Keep issue-97 fitted outputs under `algo/` and `artifacts/` only.",
+                "Do not write fitted profiles, transfer tables, or generated outputs under the golden/reference roots.",
+                "Do not touch release-facing configs in this issue.",
+            ],
+        },
+    }
+    assert_storage_separation(payload)
+    return payload
+
+
+def render_markdown(payload: dict[str, Any]) -> str:
+    profiles = payload["profiles"]
+    current_best = profiles[CURRENT_BEST_LABEL]
+    issue93 = profiles[ISSUE93_LABEL]
+    candidate = profiles[CANDIDATE_LABEL]
+    comparison_issue93 = payload["comparisons"]["candidate_vs_issue93"]
+    comparison_current_best = payload["comparisons"]["candidate_vs_current_best_pr30"]
+
+    lines = [
+        "# Intrinsic Phase-Retained Reported-MTF Disconnect Follow-up",
+        "",
+        "Issue `#97` implements the bounded slice selected in issue `#95` / PR `#96`: keep the issue-93 downstream-only matched-ori Quality Loss branch, but disconnect reported-MTF thresholds from the intrinsic reconnect path.",
+        "",
+        "## Scope",
+        "",
+        "- New intrinsic scope: `reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only`",
+        f"- Basis profile: `{issue93['profile_path']}`",
+        f"- Candidate profile: `{candidate['profile_path']}`",
+        "- Difference from issue `#93`: the main acutance branch and downstream Quality Loss branch stay on the issue-93 topology, but reported-MTF threshold extraction returns to the observed calibrated/compensated branch.",
+        "",
+        "## Result",
+        "",
+        "Current PR `#30` branch:",
+        "",
+        f"- `curve_mae_mean = {current_best['curve_mae_mean']:.5f}`",
+        f"- `focus_preset_acutance_mae_mean = {current_best['focus_preset_acutance_mae_mean']:.5f}`",
+        f"- `overall_quality_loss_mae_mean = {current_best['overall_quality_loss_mae_mean']:.5f}`",
+        f"- `mtf20 = {current_best['mtf_threshold_mae']['mtf20']:.5f}`",
+        f"- `mtf_abs_signed_rel_mean = {current_best['mtf_abs_signed_rel_mean']:.5f}`",
+        "",
+        "Issue `#93` baseline:",
+        "",
+        f"- `curve_mae_mean = {issue93['curve_mae_mean']:.5f}`",
+        f"- `focus_preset_acutance_mae_mean = {issue93['focus_preset_acutance_mae_mean']:.5f}`",
+        f"- `overall_quality_loss_mae_mean = {issue93['overall_quality_loss_mae_mean']:.5f}`",
+        f"- `mtf20 = {issue93['mtf_threshold_mae']['mtf20']:.5f}`",
+        f"- `mtf_abs_signed_rel_mean = {issue93['mtf_abs_signed_rel_mean']:.5f}`",
+        "",
+        "Issue `#97` reported-MTF disconnect candidate:",
+        "",
+        f"- `curve_mae_mean = {candidate['curve_mae_mean']:.5f}`",
+        f"- `focus_preset_acutance_mae_mean = {candidate['focus_preset_acutance_mae_mean']:.5f}`",
+        f"- `overall_quality_loss_mae_mean = {candidate['overall_quality_loss_mae_mean']:.5f}`",
+        f"- `mtf20 = {candidate['mtf_threshold_mae']['mtf20']:.5f}`",
+        f"- `mtf_abs_signed_rel_mean = {candidate['mtf_abs_signed_rel_mean']:.5f}`",
+        "",
+        "## Comparison",
+        "",
+        f"- Versus issue `#93`, `curve_mae_mean` changes by `{comparison_issue93['delta']['curve_mae_mean']:+.5f}` and `focus_preset_acutance_mae_mean` changes by `{comparison_issue93['delta']['focus_preset_acutance_mae_mean']:+.5f}`.",
+        f"- Versus issue `#93`, `overall_quality_loss_mae_mean` changes by `{comparison_issue93['delta']['overall_quality_loss_mae_mean']:+.5f}`.",
+        f"- Versus issue `#93`, `mtf20` changes by `{comparison_issue93['delta']['mtf_threshold_mae']['mtf20']:+.5f}` and `mtf_abs_signed_rel_mean` changes by `{comparison_issue93['delta']['mtf_abs_signed_rel_mean']:+.5f}`.",
+        f"- Versus PR `#30`, `overall_quality_loss_mae_mean` changes by `{comparison_current_best['delta']['overall_quality_loss_mae_mean']:+.5f}` and `mtf_abs_signed_rel_mean` changes by `{comparison_current_best['delta']['mtf_abs_signed_rel_mean']:+.5f}`.",
+        "",
+        "## Acceptance",
+        "",
+        f"- `curve_mae_mean` no worse than issue `#93`: `{payload['acceptance']['curve_mae_non_worse_than_issue93']}`",
+        f"- `focus_preset_acutance_mae_mean` no worse than issue `#93`: `{payload['acceptance']['focus_preset_acutance_non_worse_than_issue93']}`",
+        f"- `overall_quality_loss_mae_mean` no worse than issue `#93`: `{payload['acceptance']['overall_quality_loss_non_worse_than_issue93']}`",
+        f"- `mtf20` improves versus issue `#93`: `{payload['acceptance']['mtf20_improved_vs_issue93']}`",
+        f"- `mtf_abs_signed_rel_mean` improves versus issue `#93`: `{payload['acceptance']['mtf_abs_signed_rel_improved_vs_issue93']}`",
+        f"- All issue-97 gates pass: `{payload['acceptance']['all_issue97_gates_pass']}`",
+        "",
+        "## Conclusion",
+        "",
+        f"- Status: `{payload['conclusion']['status']}`",
+        f"- Summary: {payload['conclusion']['summary']}",
+        f"- Next step: {payload['conclusion']['next_step']}",
+        "",
+        "## Storage Separation",
+        "",
+        f"- Golden/reference roots: `{GOLDEN_REFERENCE_ROOTS[0]}`, `{GOLDEN_REFERENCE_ROOTS[1]}`",
+        "- Fitted outputs for this issue stay under `algo/` and `artifacts/` only.",
+        "- No release-facing config is promoted in this issue.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    repo_root = args.repo_root.resolve()
+    payload = build_payload(
+        repo_root,
+        psd_artifact_path=args.psd_artifact,
+        acutance_artifact_path=args.acutance_artifact,
+    )
+    output_json = resolve_output(args.output_json, repo_root)
+    output_md = resolve_output(args.output_md, repo_root)
+    write_text(output_json, json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    write_text(output_md, render_markdown(payload))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only_profile.json
+++ b/algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only_profile.json
@@ -1,0 +1,182 @@
+{
+  "name": "deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only",
+  "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+  "gamma": 0.5,
+  "linearization_mode": "toe_power",
+  "linearization_toe": 0.12,
+  "bayer_pattern": "RGGB",
+  "bayer_mode": "demosaic_red",
+  "roi_source": "reference_refined",
+  "roi_width": 1655,
+  "roi_height": 1673,
+  "roi_refine_percentile": 45.0,
+  "roi_refine_sigma": 5.0,
+  "roi_refine_min_border_margin": 8,
+  "roi_refine_search_radius": 4,
+  "roi_refine_step": 2,
+  "roi_refine_area_tolerance": 0.98,
+  "intrinsic_full_reference_mode": "paired_ori_transfer",
+  "intrinsic_full_reference_scope": "reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only",
+  "intrinsic_full_reference_clip_lo": 0.5,
+  "intrinsic_full_reference_clip_hi": 1.5,
+  "intrinsic_full_reference_registration_mode": "phase_correlation",
+  "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+  "matched_ori_reference_anchor": true,
+  "matched_ori_correction_clip_lo": 0.5,
+  "matched_ori_correction_clip_hi": 2.0,
+  "matched_ori_anchor_mode": "all",
+  "matched_ori_strength_curve_frequencies": [
+    0.0,
+    0.12,
+    0.22,
+    0.35,
+    0.5
+  ],
+  "matched_ori_strength_curve_values": [
+    1.0,
+    1.0,
+    0.82,
+    0.95,
+    1.0
+  ],
+  "matched_ori_acutance_reference_anchor": true,
+  "matched_ori_acutance_correction_clip_lo": 0.9,
+  "matched_ori_acutance_correction_clip_hi": 1.1,
+  "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+  "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+    0.0,
+    0.25,
+    0.6,
+    0.8,
+    1.6,
+    2.5
+  ],
+  "matched_ori_acutance_curve_correction_clip_hi_values": [
+    1.02,
+    1.03,
+    0.895,
+    0.895,
+    1.05,
+    1.06
+  ],
+  "matched_ori_acutance_strength_curve_relative_scales": [
+    0.0,
+    0.2,
+    0.8,
+    1.6,
+    2.5
+  ],
+  "matched_ori_acutance_strength_curve_values": [
+    0.7,
+    0.69,
+    0.64,
+    0.62,
+    0.6
+  ],
+  "matched_ori_acutance_correction_delta_power": 1.0,
+  "matched_ori_acutance_curve_correction_delta_power": 0.95,
+  "matched_ori_acutance_preset_correction_delta_power": null,
+  "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+    0.0,
+    4.5,
+    5.8,
+    6.2
+  ],
+  "matched_ori_acutance_preset_correction_delta_power_values": [
+    1.05,
+    1.05,
+    1.85,
+    1.85
+  ],
+  "matched_ori_acutance_preset_strength_curve_relative_scales": [
+    0.0,
+    3.0,
+    4.5,
+    5.8,
+    6.2
+  ],
+  "matched_ori_acutance_preset_strength_curve_values": [
+    1.0,
+    1.0,
+    0.85,
+    0.45,
+    0.45
+  ],
+  "frequency_scale": 1.0,
+  "normalization_band_lo": 0.01,
+  "normalization_band_hi": 0.03,
+  "normalization_mode": "max",
+  "acutance_band_lo": 0.017,
+  "acutance_band_hi": 0.035,
+  "acutance_band_mode": "mean",
+  "noise_psd_model": "empirical",
+  "noise_psd_scale": 1.0,
+  "quality_loss_om_ceiling": 0.8851,
+  "quality_loss_coefficients": [
+    37.240228358776136,
+    26.54550669779819,
+    0.4538662637619741
+  ],
+  "quality_loss_preset_overrides": {
+    "Computer Monitor Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        5677361.198044325,
+        -16715685.9524707,
+        20317567.326582585,
+        -13046703.33912079,
+        4667794.619228022,
+        -882296.9160375095,
+        68863.59709647154
+      ]
+    },
+    "5.5\" Phone Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        -110912321.41149135,
+        50461107.51563171,
+        -9079490.127807735,
+        815148.8697247265,
+        -37712.984407641874,
+        854.6941149036079,
+        -6.261149027919645
+      ]
+    },
+    "UHDTV Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        1783462.6221675149,
+        -3813432.5606394163,
+        3326218.4642961356,
+        -1514886.1959663907,
+        380334.163146246,
+        -49956.87092015135,
+        2692.9566508574017
+      ]
+    },
+    "Small Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        6690980.837239251,
+        -12955277.716404187,
+        10300283.291740375,
+        -4303759.200708971,
+        996904.2653558743,
+        -121409.71509269004,
+        6084.6471373306085
+      ]
+    },
+    "Large Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        2355074.475971866,
+        -5276146.244338096,
+        4846781.143787682,
+        -2336594.295523967,
+        623766.4933095274,
+        -87476.30712136331,
+        5049.882965558553
+      ]
+    }
+  }
+}

--- a/artifacts/intrinsic_phase_retained_reported_mtf_disconnect_benchmark.json
+++ b/artifacts/intrinsic_phase_retained_reported_mtf_disconnect_benchmark.json
@@ -1,0 +1,789 @@
+{
+  "acceptance": {
+    "all_issue97_gates_pass": false,
+    "curve_mae_non_worse_than_issue93": true,
+    "focus_preset_acutance_non_worse_than_issue93": true,
+    "mtf20_improved_vs_issue93": true,
+    "mtf_abs_signed_rel_improved_vs_issue93": false,
+    "overall_quality_loss_non_worse_than_issue93": true
+  },
+  "comparisons": {
+    "candidate_vs_current_best_pr30": {
+      "delta": {
+        "curve_mae_mean": -0.0039872260971888646,
+        "focus_preset_acutance_mae_mean": -0.013566304809976663,
+        "mtf_abs_signed_rel_mean": 0.2901638701776287,
+        "mtf_threshold_mae": {
+          "mtf20": 0.041464807767238945,
+          "mtf30": 0.03859250411762396,
+          "mtf50": 0.024961219449571755
+        },
+        "overall_quality_loss_mae_mean": 2.725930579444415
+      }
+    },
+    "candidate_vs_issue93": {
+      "curve_mae_non_worse_than_issue93": true,
+      "delta": {
+        "curve_mae_mean": 0.0,
+        "focus_preset_acutance_mae_mean": 0.0,
+        "mtf_abs_signed_rel_mean": 0.23694025352067719,
+        "mtf_threshold_mae": {
+          "mtf20": -0.011290771537588798,
+          "mtf30": 0.0576373510022125,
+          "mtf50": 0.027097747475036262
+        },
+        "overall_quality_loss_mae_mean": 0.0
+      },
+      "focus_preset_acutance_non_worse_than_issue93": true,
+      "mtf20_improved_vs_issue93": true,
+      "mtf_abs_signed_rel_improved_vs_issue93": false,
+      "overall_quality_loss_non_worse_than_issue93": true
+    }
+  },
+  "conclusion": {
+    "next_step": "Keep the result as the canonical issue-97 record and split the next bounded follow-up from the remaining failure mode.",
+    "status": "issue97_reported_mtf_disconnect_failed",
+    "summary": "Disconnecting reported-MTF thresholds from the intrinsic reconnect did not improve the readout metrics enough while preserving the issue-93 acutance and Quality Loss record, so this bounded slice closes as a negative or mixed result."
+  },
+  "dataset_root": "20260318_deadleaf_13b10",
+  "implementation_change": {
+    "basis_profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_readout_reconnect_quality_loss_isolation_downstream_matched_ori_only_profile.json",
+    "candidate_profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only_profile.json",
+    "change": "Keep the issue-93 downstream-only matched-ori Quality Loss branch and intrinsic main-acutance branch, but disconnect reported-MTF threshold extraction from the intrinsic reconnect path.",
+    "scope_difference": {
+      "readout_reconnect_quality_loss_isolation_downstream_matched_ori_only": "Issue-93 topology: reported-MTF thresholds and the main acutance branch both use the intrinsic reconnect, while the downstream Quality Loss branch stays isolated.",
+      "reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only": "Reported-MTF thresholds stay on the observed calibrated/compensated branch, while the main acutance branch and downstream-only matched-ori Quality Loss branch remain on the issue-93 topology."
+    },
+    "scope_name": "reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only",
+    "selected_slice_id": "issue93_topology_keep_downstream_quality_loss_branch_but_disconnect_reported_mtf_from_intrinsic_reconnect"
+  },
+  "issue": 97,
+  "profiles": {
+    "current_best_pr30_branch": {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": 0.013802247905288301,
+        "Computer Monitor Acutance": 0.052665183748573804,
+        "Large Print Acutance": 0.05132586418527154,
+        "Small Print Acutance": 0.046702107662187464,
+        "UHDTV Display Acutance": 0.04793875259218785
+      },
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "readout_interpolation": "linear",
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": true
+      },
+      "curve_mae_mean": 0.03678903166100513,
+      "focus_preset_acutance_mae_mean": 0.042486831218701795,
+      "label": "current_best_pr30_branch",
+      "mtf_abs_signed_rel_mean": 0.08671416893394165,
+      "mtf_band_mae": {
+        "high": 0.01764835359892083,
+        "low": 0.03704553941403868,
+        "mid": 0.03898616152003224,
+        "top": 0.07374065223652229
+      },
+      "mtf_threshold_mae": {
+        "mtf20": 0.03301077142967389,
+        "mtf30": 0.03693639342667963,
+        "mtf50": 0.009332615436071163
+      },
+      "overall_quality_loss_mae_mean": 1.2214989544377113,
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_profile.json",
+      "quality_loss_preset_mae": {
+        "5.5\" Phone Display Quality Loss": 0.14297991495607307,
+        "Computer Monitor Quality Loss": 2.902905846061304,
+        "Large Print Quality Loss": 0.9548172583377941,
+        "Small Print Quality Loss": 0.6076935256225349,
+        "UHDTV Display Quality Loss": 1.4990982272108502
+      }
+    },
+    "issue93_downstream_matched_ori_only_candidate": {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": 0.035256377739795786,
+        "Computer Monitor Acutance": 0.024146307932311834,
+        "Large Print Acutance": 0.028624302638652583,
+        "Small Print Acutance": 0.031726251556383624,
+        "UHDTV Display Acutance": 0.024849392176481848
+      },
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": null,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "readout_reconnect_quality_loss_isolation_downstream_matched_ori_only",
+        "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "none",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "readout_interpolation": "linear",
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.0,
+        "texture_support_scale": false
+      },
+      "curve_mae_mean": 0.03280180556381627,
+      "focus_preset_acutance_mae_mean": 0.028920526408725132,
+      "label": "issue93_downstream_matched_ori_only_candidate",
+      "mtf_abs_signed_rel_mean": 0.13993778559089318,
+      "mtf_band_mae": {
+        "high": 0.046538330006884135,
+        "low": 0.009354903091206065,
+        "mid": 0.04532695609684774,
+        "top": 0.045570940534890705
+      },
+      "mtf_threshold_mae": {
+        "mtf20": 0.08576635073450163,
+        "mtf30": 0.017891546542091085,
+        "mtf50": 0.007196087410606654
+      },
+      "overall_quality_loss_mae_mean": 3.9474295338821266,
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_readout_reconnect_quality_loss_isolation_downstream_matched_ori_only_profile.json",
+      "quality_loss_preset_mae": {
+        "5.5\" Phone Display Quality Loss": 4.122316176755632,
+        "Computer Monitor Quality Loss": 6.1264243907692375,
+        "Large Print Quality Loss": 2.079928486542698,
+        "Small Print Quality Loss": 3.490178763693591,
+        "UHDTV Display Quality Loss": 3.918299851649472
+      }
+    },
+    "issue97_reported_mtf_disconnect_candidate": {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": 0.035256377739795786,
+        "Computer Monitor Acutance": 0.024146307932311834,
+        "Large Print Acutance": 0.028624302638652583,
+        "Small Print Acutance": 0.031726251556383624,
+        "UHDTV Display Acutance": 0.024849392176481848
+      },
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": null,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only",
+        "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "none",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "readout_interpolation": "linear",
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.0,
+        "texture_support_scale": false
+      },
+      "curve_mae_mean": 0.03280180556381627,
+      "focus_preset_acutance_mae_mean": 0.028920526408725132,
+      "label": "issue97_reported_mtf_disconnect_candidate",
+      "mtf_abs_signed_rel_mean": 0.37687803911157036,
+      "mtf_threshold_mae": {
+        "mtf20": 0.07447557919691283,
+        "mtf30": 0.07552889754430359,
+        "mtf50": 0.034293834885642915
+      },
+      "overall_quality_loss_mae_mean": 3.9474295338821266,
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only_profile.json",
+      "quality_loss_preset_mae": {
+        "5.5\" Phone Display Quality Loss": 4.122316176755632,
+        "Computer Monitor Quality Loss": 6.1264243907692375,
+        "Large Print Quality Loss": 2.079928486542698,
+        "Small Print Quality Loss": 3.490178763693591,
+        "UHDTV Display Quality Loss": 3.918299851649472
+      }
+    }
+  },
+  "storage": {
+    "golden_reference_roots": [
+      "20260318_deadleaf_13b10",
+      "release/deadleaf_13b10_release/data/20260318_deadleaf_13b10"
+    ],
+    "new_fitted_artifact_paths": [
+      "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only_profile.json",
+      "artifacts/issue97_intrinsic_phase_retained_reported_mtf_disconnect_psd_benchmark.json",
+      "artifacts/issue97_intrinsic_phase_retained_reported_mtf_disconnect_acutance_benchmark.json",
+      "artifacts/intrinsic_phase_retained_reported_mtf_disconnect_benchmark.json"
+    ],
+    "rules": [
+      "Keep issue-97 fitted outputs under `algo/` and `artifacts/` only.",
+      "Do not write fitted profiles, transfer tables, or generated outputs under the golden/reference roots.",
+      "Do not touch release-facing configs in this issue."
+    ]
+  },
+  "summary_kind": "intrinsic_phase_retained_reported_mtf_disconnect_followup"
+}

--- a/artifacts/issue97_intrinsic_phase_retained_reported_mtf_disconnect_acutance_benchmark.json
+++ b/artifacts/issue97_intrinsic_phase_retained_reported_mtf_disconnect_acutance_benchmark.json
@@ -1,0 +1,249 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": null,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only",
+        "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "none",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "readout_interpolation": "linear",
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.0,
+        "texture_support_scale": false
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.029378599163150443,
+        "0.25": 0.02479729017929424,
+        "0.4": 0.019363342842858032,
+        "0.65": 0.011953815251775047,
+        "0.8": 0.04482380483621107,
+        "ori": 0.07933816634336006
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 5.7514955234347775,
+        "0.25": 1.7142053163536248,
+        "0.4": 1.469541276127594,
+        "0.65": 0.5506448123272694,
+        "0.8": 1.2211750416990212,
+        "ori": 18.610816211263952
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.028920526408725132,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.035256377739795786,
+          "Computer Monitor Acutance": 0.024146307932311834,
+          "Large Print Acutance": 0.028624302638652583,
+          "Small Print Acutance": 0.031726251556383624,
+          "UHDTV Display Acutance": 0.024849392176481848
+        },
+        "curve_mae_mean": 0.03280180556381627,
+        "overall_quality_loss_mae_mean": 3.9474295338821266,
+        "quality_loss_focus_preset_mae_mean": 3.9474295338821266,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 4.122316176755632,
+          "Computer Monitor Quality Loss": 6.1264243907692375,
+          "Large Print Quality Loss": 2.079928486542698,
+          "Small Print Quality Loss": 3.490178763693591,
+          "UHDTV Display Quality Loss": 3.918299851649472
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only_profile.json"
+    }
+  ]
+}

--- a/artifacts/issue97_intrinsic_phase_retained_reported_mtf_disconnect_psd_benchmark.json
+++ b/artifacts/issue97_intrinsic_phase_retained_reported_mtf_disconnect_psd_benchmark.json
@@ -1,0 +1,191 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": null,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only",
+        "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "none",
+        "mtf_shape_correction_mode": "none",
+        "readout_interpolation": "linear",
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.0,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": false
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.029378599163150443,
+        "0.25": 0.02479729017929424,
+        "0.4": 0.019363342842858032,
+        "0.65": 0.011953815251775047,
+        "0.8": 0.04482380483621107,
+        "ori": 0.07933816634336006
+      },
+      "overall": {
+        "curve_mae_mean": 0.03280180556381627,
+        "mtf_abs_signed_rel_mean": 0.37687803911157036,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.09550923029182153,
+            "mre_mean": 0.4191386815262641,
+            "signed_rel_mean": -0.4191386815262641
+          },
+          "low": {
+            "mae_mean": 0.0779974763274383,
+            "mre_mean": 0.0972398641161041,
+            "signed_rel_mean": -0.09685152250222986
+          },
+          "mid": {
+            "mae_mean": 0.1137744268017257,
+            "mre_mean": 0.2841326982043283,
+            "signed_rel_mean": -0.2841326982043283
+          },
+          "top": {
+            "mae_mean": 0.2595088480097464,
+            "mre_mean": 0.7073892542134591,
+            "signed_rel_mean": -0.7073892542134591
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.07447557919691283,
+          "mtf30": 0.07552889754430359,
+          "mtf50": 0.034293834885642915
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.035256377739795786,
+          "Computer Monitor Acutance": 0.024146307932311834,
+          "Large Print Acutance": 0.028624302638652583,
+          "Small Print Acutance": 0.031726251556383624,
+          "UHDTV Display Acutance": 0.024849392176481848
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only_profile.json"
+    }
+  ]
+}

--- a/docs/intrinsic_phase_retained_reported_mtf_disconnect_followup.md
+++ b/docs/intrinsic_phase_retained_reported_mtf_disconnect_followup.md
@@ -1,0 +1,64 @@
+# Intrinsic Phase-Retained Reported-MTF Disconnect Follow-up
+
+Issue `#97` implements the bounded slice selected in issue `#95` / PR `#96`: keep the issue-93 downstream-only matched-ori Quality Loss branch, but disconnect reported-MTF thresholds from the intrinsic reconnect path.
+
+## Scope
+
+- New intrinsic scope: `reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only`
+- Basis profile: `algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_readout_reconnect_quality_loss_isolation_downstream_matched_ori_only_profile.json`
+- Candidate profile: `algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only_profile.json`
+- Difference from issue `#93`: the main acutance branch and downstream Quality Loss branch stay on the issue-93 topology, but reported-MTF threshold extraction returns to the observed calibrated/compensated branch.
+
+## Result
+
+Current PR `#30` branch:
+
+- `curve_mae_mean = 0.03679`
+- `focus_preset_acutance_mae_mean = 0.04249`
+- `overall_quality_loss_mae_mean = 1.22150`
+- `mtf20 = 0.03301`
+- `mtf_abs_signed_rel_mean = 0.08671`
+
+Issue `#93` baseline:
+
+- `curve_mae_mean = 0.03280`
+- `focus_preset_acutance_mae_mean = 0.02892`
+- `overall_quality_loss_mae_mean = 3.94743`
+- `mtf20 = 0.08577`
+- `mtf_abs_signed_rel_mean = 0.13994`
+
+Issue `#97` reported-MTF disconnect candidate:
+
+- `curve_mae_mean = 0.03280`
+- `focus_preset_acutance_mae_mean = 0.02892`
+- `overall_quality_loss_mae_mean = 3.94743`
+- `mtf20 = 0.07448`
+- `mtf_abs_signed_rel_mean = 0.37688`
+
+## Comparison
+
+- Versus issue `#93`, `curve_mae_mean` changes by `+0.00000` and `focus_preset_acutance_mae_mean` changes by `+0.00000`.
+- Versus issue `#93`, `overall_quality_loss_mae_mean` changes by `+0.00000`.
+- Versus issue `#93`, `mtf20` changes by `-0.01129` and `mtf_abs_signed_rel_mean` changes by `+0.23694`.
+- Versus PR `#30`, `overall_quality_loss_mae_mean` changes by `+2.72593` and `mtf_abs_signed_rel_mean` changes by `+0.29016`.
+
+## Acceptance
+
+- `curve_mae_mean` no worse than issue `#93`: `True`
+- `focus_preset_acutance_mae_mean` no worse than issue `#93`: `True`
+- `overall_quality_loss_mae_mean` no worse than issue `#93`: `True`
+- `mtf20` improves versus issue `#93`: `True`
+- `mtf_abs_signed_rel_mean` improves versus issue `#93`: `False`
+- All issue-97 gates pass: `False`
+
+## Conclusion
+
+- Status: `issue97_reported_mtf_disconnect_failed`
+- Summary: Disconnecting reported-MTF thresholds from the intrinsic reconnect did not improve the readout metrics enough while preserving the issue-93 acutance and Quality Loss record, so this bounded slice closes as a negative or mixed result.
+- Next step: Keep the result as the canonical issue-97 record and split the next bounded follow-up from the remaining failure mode.
+
+## Storage Separation
+
+- Golden/reference roots: `20260318_deadleaf_13b10`, `release/deadleaf_13b10_release/data/20260318_deadleaf_13b10`
+- Fitted outputs for this issue stay under `algo/` and `artifacts/` only.
+- No release-facing config is promoted in this issue.

--- a/tests/test_benchmark_parity_acutance_quality_loss.py
+++ b/tests/test_benchmark_parity_acutance_quality_loss.py
@@ -1185,6 +1185,187 @@ class BenchmarkParityAcutanceQualityLossTest(unittest.TestCase):
                 3.0,
             )
 
+    def test_reported_mtf_disconnect_scope_preserves_issue93_acutance_topology(self) -> None:
+        capture_key = "OV13b10_AG8_ET5500_deadleaf_12M_40"
+        preset_names = (
+            '5.5" Phone Display Acutance',
+            "Computer Monitor Acutance",
+            "UHDTV Display Acutance",
+            "Small Print Acutance",
+            "Large Print Acutance",
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dataset_root = Path(tmpdir)
+            variant_root = dataset_root / "OV13B10_AI_NR_OV13B10_ppqpkl_0.10"
+            results_dir = variant_root / "Results"
+            results_dir.mkdir(parents=True)
+            stem = f"{capture_key}_variantA"
+            (results_dir / f"{stem}_R_Random.csv").write_text("", encoding="utf-8")
+            (variant_root / f"{stem}.raw").write_bytes(b"")
+
+            reference = SimpleNamespace(
+                lrtb=RoiBounds(left=0, right=1, top=0, bottom=1),
+                frequencies_cpp=np.array([0.1, 0.2], dtype=np.float64),
+                mtf=np.array([1.0, 1.0], dtype=np.float64),
+                acutance_table=[
+                    AcutancePoint(print_height_cm=40.0, viewing_distance_cm=10.0, acutance=1.0)
+                ],
+                reported_acutance={name: 1.0 for name in preset_names},
+                reported_quality_loss={
+                    name.replace("Acutance", "Quality Loss"): 0.0 for name in preset_names
+                },
+            )
+            ori_reference = SimpleNamespace(
+                lrtb=RoiBounds(left=0, right=1, top=0, bottom=1),
+                frequencies_cpp=np.array([0.1, 0.2], dtype=np.float64),
+                mtf=np.array([1.0, 1.0], dtype=np.float64),
+                acutance_table=reference.acutance_table,
+            )
+            estimate = SimpleNamespace(
+                roi=RoiBounds(left=0, right=1, top=0, bottom=1),
+                frequencies_cpp=np.array([0.1, 0.2], dtype=np.float64),
+                mtf_for_acutance=np.array([1.0, 1.0], dtype=np.float64),
+                acutance_high_frequency_noise_share=0.0,
+            )
+            profile = Profile(
+                name="test",
+                calibration_file="calibration.json",
+                roi_source="reference",
+                intrinsic_full_reference_mode="paired_ori_transfer",
+                intrinsic_full_reference_scope=(
+                    "reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only"
+                ),
+                matched_ori_reference_anchor=True,
+                matched_ori_acutance_reference_anchor=True,
+            )
+
+            def parse_csv(path: Path):
+                return ori_reference if path.name == "ori.csv" else reference
+
+            def acutance_from_mtf(_freqs, mtf, **_kwargs):
+                value = float(np.asarray(mtf, dtype=np.float64)[0])
+                return {name: value for name in preset_names}
+
+            with (
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.load_ideal_psd_calibration",
+                    return_value=None,
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.build_ori_reference_map",
+                    return_value={capture_key: (dataset_root / "ori.csv", dataset_root / "ori.raw")},
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.parse_imatest_random_csv",
+                    side_effect=parse_csv,
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.load_raw_u16",
+                    side_effect=lambda path, width, height: np.zeros((height, width), dtype=np.uint16),
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.extract_analysis_plane",
+                    side_effect=lambda raw, **_: raw,
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.normalize_for_analysis",
+                    side_effect=lambda plane, **_: plane,
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.estimate_dead_leaves_mtf",
+                    return_value=estimate,
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.apply_mtf_compensation",
+                    side_effect=lambda mtf, freqs, **_: (
+                        np.asarray(mtf, dtype=np.float64),
+                        np.asarray(freqs, dtype=np.float64),
+                    ),
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.derive_intrinsic_transfer_curve",
+                    return_value=np.array([2.0, 2.0], dtype=np.float64),
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.derive_reference_correction_curve",
+                    return_value=np.array([1.0, 1.0], dtype=np.float64),
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.apply_reference_correction_curve",
+                    side_effect=lambda _freqs, values, *_args, **_kwargs: (
+                        np.asarray(values, dtype=np.float64) + 1.0
+                    ),
+                ) as apply_reference_correction_curve,
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.apply_mtf_shape_correction",
+                    side_effect=lambda mtf, freqs, **_: (
+                        np.asarray(mtf, dtype=np.float64),
+                        np.asarray(freqs, dtype=np.float64),
+                    ),
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.acutance_curve_from_mtf",
+                    side_effect=lambda _freqs, mtf, **_kwargs: [
+                        AcutancePoint(
+                            print_height_cm=40.0,
+                            viewing_distance_cm=10.0,
+                            acutance=float(np.asarray(mtf, dtype=np.float64)[0]),
+                        )
+                    ],
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.acutance_presets_from_mtf",
+                    side_effect=acutance_from_mtf,
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.derive_reference_acutance_correction_curve",
+                    return_value=(np.array([0.25], dtype=np.float64), np.array([1.0], dtype=np.float64)),
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.clip_reference_correction_curve",
+                    side_effect=lambda positions, correction, **_kwargs: np.asarray(correction, dtype=np.float64),
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.compare_acutance_curves",
+                    return_value={"count": 1, "mae": 0.0},
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.compare_acutance_presets",
+                    side_effect=lambda estimate_map, reference_map: {
+                        name: {
+                            "abs_error": abs(float(estimate_map[name]) - float(reference_map[name])),
+                            "estimate": float(estimate_map[name]),
+                            "reference": float(reference_map[name]),
+                        }
+                        for name in estimate_map
+                    },
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.quality_loss_presets_from_acutance",
+                    side_effect=lambda acutance, **_kwargs: {
+                        name.replace("Acutance", "Quality Loss"): value
+                        for name, value in acutance.items()
+                    },
+                ),
+            ):
+                payload = summarize_profile(
+                    dataset_root=dataset_root,
+                    profile_path=dataset_root / "profile.json",
+                    profile=profile,
+                    width=2,
+                    height=2,
+                )
+
+            self.assertEqual(apply_reference_correction_curve.call_count, 3)
+            self.assertEqual(
+                payload["overall"]["acutance_preset_mae"]['5.5" Phone Display Acutance'],
+                1.0,
+            )
+            self.assertEqual(
+                payload["overall"]["quality_loss_preset_mae"]['5.5" Phone Display Quality Loss'],
+                3.0,
+            )
+
     def test_intrinsic_scope_can_keep_downstream_matched_ori_without_main_branch_reopen(self) -> None:
         capture_key = "OV13b10_AG8_ET5500_deadleaf_12M_40"
         preset_names = [

--- a/tests/test_benchmark_parity_psd_mtf.py
+++ b/tests/test_benchmark_parity_psd_mtf.py
@@ -846,6 +846,128 @@ class BenchmarkParityPsdMtfTest(unittest.TestCase):
             np.testing.assert_allclose(compute_metrics.call_args.args[1], [2.0, 2.0, 2.0, 2.0])
             np.testing.assert_allclose(acutance_from_mtf.call_args.args[1], [2.0, 2.0, 2.0, 2.0])
 
+    def test_intrinsic_scope_can_disconnect_reported_mtf_from_intrinsic_reconnect(self) -> None:
+        capture_key = "OV13b10_AG8_ET5500_deadleaf_12M_40"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dataset_root = Path(tmpdir)
+            variant_root = dataset_root / "OV13B10_AI_NR_OV13B10_ppqpkl_0.10"
+            results_dir = variant_root / "Results"
+            results_dir.mkdir(parents=True)
+            stem = f"{capture_key}_variantA"
+            (results_dir / f"{stem}_R_Random.csv").write_text("", encoding="utf-8")
+            (variant_root / f"{stem}.raw").write_bytes(b"")
+
+            reference = SimpleNamespace(
+                lrtb=RoiBounds(left=0, right=1, top=0, bottom=1),
+                frequencies_cpp=np.array([0.02, 0.1, 0.25, 0.4], dtype=np.float64),
+                mtf=np.array([1.0, 1.0, 1.0, 1.0], dtype=np.float64),
+                acutance_table=[
+                    AcutancePoint(print_height_cm=40.0, viewing_distance_cm=10.0, acutance=1.0)
+                ],
+                reported_acutance={'5.5" Phone Display Acutance': 1.0},
+            )
+            ori_reference = SimpleNamespace(
+                lrtb=RoiBounds(left=0, right=1, top=0, bottom=1),
+                frequencies_cpp=np.array([0.03, 0.11, 0.26, 0.41], dtype=np.float64),
+                mtf=np.array([1.0, 1.0, 1.0, 1.0], dtype=np.float64),
+                acutance_table=reference.acutance_table,
+                reported_acutance=reference.reported_acutance,
+            )
+            estimate = SimpleNamespace(
+                roi=RoiBounds(left=0, right=1, top=0, bottom=1),
+                frequencies_cpp=np.array([0.02, 0.1, 0.25, 0.4], dtype=np.float64),
+                mtf=np.array([1.0, 1.0, 1.0, 1.0], dtype=np.float64),
+                mtf_for_acutance=np.array([1.0, 1.0, 1.0, 1.0], dtype=np.float64),
+            )
+            profile = Profile(
+                name="test",
+                calibration_file="calibration.json",
+                roi_source="reference",
+                intrinsic_full_reference_mode="paired_ori_transfer",
+                intrinsic_full_reference_scope=(
+                    "reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only"
+                ),
+                matched_ori_reference_anchor=True,
+                matched_ori_anchor_mode="all",
+            )
+
+            def parse_csv(path: Path):
+                return ori_reference if path.name == "ori.csv" else reference
+
+            with (
+                patch("algo.benchmark_parity_psd_mtf.load_ideal_psd_calibration", return_value=None),
+                patch(
+                    "algo.benchmark_parity_psd_mtf.build_ori_reference_map",
+                    return_value={capture_key: (dataset_root / "ori.csv", dataset_root / "ori.raw")},
+                ),
+                patch(
+                    "algo.benchmark_parity_psd_mtf.parse_imatest_random_csv",
+                    side_effect=parse_csv,
+                ),
+                patch(
+                    "algo.benchmark_parity_psd_mtf.load_raw_u16",
+                    side_effect=lambda path, width, height: np.zeros((height, width), dtype=np.uint16),
+                ),
+                patch("algo.benchmark_parity_psd_mtf.extract_analysis_plane", side_effect=lambda raw, **_: raw),
+                patch("algo.benchmark_parity_psd_mtf.normalize_for_analysis", side_effect=lambda plane, **_: plane),
+                patch("algo.benchmark_parity_psd_mtf.estimate_dead_leaves_mtf", return_value=estimate),
+                patch(
+                    "algo.benchmark_parity_psd_mtf.apply_mtf_compensation",
+                    side_effect=lambda mtf, freqs, **_: (
+                        np.asarray(mtf, dtype=np.float64),
+                        np.asarray(freqs, dtype=np.float64),
+                    ),
+                ),
+                patch(
+                    "algo.benchmark_parity_psd_mtf.derive_intrinsic_transfer_curve",
+                    return_value=np.array([2.0, 2.0, 2.0, 2.0], dtype=np.float64),
+                ),
+                patch(
+                    "algo.benchmark_parity_psd_mtf.derive_reference_correction_curve",
+                    return_value=np.array([1.0, 1.0, 1.0, 1.0], dtype=np.float64),
+                ),
+                patch(
+                    "algo.benchmark_parity_psd_mtf.apply_reference_correction_curve",
+                    side_effect=lambda _freqs, values, *_args, **_kwargs: (
+                        np.asarray(values, dtype=np.float64) + 1.0
+                    ),
+                ) as apply_correction_curve,
+                patch(
+                    "algo.benchmark_parity_psd_mtf.compute_mtf_metrics",
+                    return_value=SimpleNamespace(mtf50=0.1, mtf30=0.1, mtf20=0.1),
+                ) as compute_metrics,
+                patch("algo.benchmark_parity_psd_mtf.interpolate_threshold", return_value=0.1),
+                patch(
+                    "algo.benchmark_parity_psd_mtf.acutance_curve_from_mtf",
+                    return_value=reference.acutance_table,
+                ),
+                patch(
+                    "algo.benchmark_parity_psd_mtf.compare_acutance_curves",
+                    return_value={"count": 1, "mae": 0.0},
+                ),
+                patch(
+                    "algo.benchmark_parity_psd_mtf.acutance_presets_from_mtf",
+                    return_value=reference.reported_acutance,
+                ) as acutance_from_mtf,
+                patch(
+                    "algo.benchmark_parity_psd_mtf.compare_acutance_presets",
+                    return_value={'5.5" Phone Display Acutance': {"abs_error": 0.0}},
+                ),
+            ):
+                profile_payload(
+                    dataset_root=dataset_root,
+                    profile_path=dataset_root / "profile.json",
+                    profile=profile,
+                    width=2,
+                    height=2,
+                )
+
+            self.assertEqual(apply_correction_curve.call_count, 0)
+            np.testing.assert_allclose(compute_metrics.call_args.args[0], [0.02, 0.1, 0.25, 0.4])
+            np.testing.assert_allclose(compute_metrics.call_args.args[1], [1.0, 1.0, 1.0, 1.0])
+            np.testing.assert_allclose(acutance_from_mtf.call_args.args[0], [0.03, 0.11, 0.26, 0.41])
+            np.testing.assert_allclose(acutance_from_mtf.call_args.args[1], [2.0, 2.0, 2.0, 2.0])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_build_intrinsic_phase_retained_reported_mtf_disconnect_followup.py
+++ b/tests/test_build_intrinsic_phase_retained_reported_mtf_disconnect_followup.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from algo.build_intrinsic_phase_retained_reported_mtf_disconnect_followup import (
+    CANDIDATE_LABEL,
+    ISSUE93_LABEL,
+    SELECTED_SLICE_ID,
+    build_payload,
+    render_markdown,
+)
+
+
+class BuildIntrinsicPhaseRetainedReportedMtfDisconnectFollowupTest(unittest.TestCase):
+    def test_payload_records_issue97_scope_and_storage(self) -> None:
+        payload = build_payload(
+            self.repo_root(),
+            psd_artifact_path=Path(
+                "artifacts/issue97_intrinsic_phase_retained_reported_mtf_disconnect_psd_benchmark.json"
+            ),
+            acutance_artifact_path=Path(
+                "artifacts/issue97_intrinsic_phase_retained_reported_mtf_disconnect_acutance_benchmark.json"
+            ),
+        )
+
+        self.assertEqual(payload["issue"], 97)
+        self.assertEqual(
+            payload["implementation_change"]["scope_name"],
+            "reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only",
+        )
+        self.assertEqual(
+            payload["implementation_change"]["selected_slice_id"],
+            SELECTED_SLICE_ID,
+        )
+        self.assertIn("reported-MTF", payload["implementation_change"]["change"])
+        self.assertIn("mtf20_improved_vs_issue93", payload["acceptance"])
+        self.assertIn("mtf_abs_signed_rel_improved_vs_issue93", payload["acceptance"])
+        self.assertNotEqual(
+            payload["profiles"][CANDIDATE_LABEL]["profile_path"],
+            payload["profiles"][ISSUE93_LABEL]["profile_path"],
+        )
+        for path in payload["storage"]["new_fitted_artifact_paths"]:
+            self.assertFalse(path.startswith("20260318_deadleaf_13b10"))
+            self.assertFalse(
+                path.startswith("release/deadleaf_13b10_release/data/20260318_deadleaf_13b10")
+            )
+
+    def test_markdown_mentions_issue93_pr30_and_storage(self) -> None:
+        payload = build_payload(
+            self.repo_root(),
+            psd_artifact_path=Path(
+                "artifacts/issue97_intrinsic_phase_retained_reported_mtf_disconnect_psd_benchmark.json"
+            ),
+            acutance_artifact_path=Path(
+                "artifacts/issue97_intrinsic_phase_retained_reported_mtf_disconnect_acutance_benchmark.json"
+            ),
+        )
+        markdown = render_markdown(payload)
+
+        self.assertIn("# Intrinsic Phase-Retained Reported-MTF Disconnect Follow-up", markdown)
+        self.assertIn("Issue `#93` baseline", markdown)
+        self.assertIn("Current PR `#30` branch", markdown)
+        self.assertIn("All issue-97 gates pass", markdown)
+        self.assertIn("Storage Separation", markdown)
+
+    @staticmethod
+    def repo_root() -> Path:
+        return Path(__file__).resolve().parents[1]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement the issue-97 intrinsic scope that keeps the issue-93 downstream-only matched-ori Quality Loss branch but disconnects reported-MTF thresholds from the intrinsic reconnect path
- add focused runtime tests for the new readout/acutance split plus the issue-97 follow-up builder, checked-in raw benchmark artifacts, and markdown summary
- record the real result as a bounded mixed negative: curve/focus/Quality Loss stay at the issue-93 level and `mtf20` improves, but `mtf_abs_signed_rel_mean`, `mtf30`, and `mtf50` regress

## Validation
- `python3 -m pytest tests/test_benchmark_parity_psd_mtf.py tests/test_benchmark_parity_acutance_quality_loss.py tests/test_build_intrinsic_phase_retained_reported_mtf_disconnect_followup.py`
- `python3 -m algo.benchmark_parity_psd_mtf 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only_profile.json --output artifacts/issue97_intrinsic_phase_retained_reported_mtf_disconnect_psd_benchmark.json`
- `python3 -m algo.benchmark_parity_acutance_quality_loss 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only_profile.json --output artifacts/issue97_intrinsic_phase_retained_reported_mtf_disconnect_acutance_benchmark.json`
- `python3 -m algo.build_intrinsic_phase_retained_reported_mtf_disconnect_followup`

Refs #29
Refs #93
Refs #95
Refs #97
