### PR TITLE
Issue #99: narrow the post-issue97 readout failure mode

### DIFF
--- a/algo/build_intrinsic_after_issue97_next_slice.py
+++ b/algo/build_intrinsic_after_issue97_next_slice.py
@@ -1,0 +1,610 @@
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+
+SUMMARY_KIND = "intrinsic_after_issue97_next_slice"
+CURRENT_BEST_LABEL = "current_best_pr30_branch"
+ISSUE93_LABEL = "issue93_downstream_matched_ori_only_candidate"
+ISSUE97_LABEL = "issue97_reported_mtf_disconnect_candidate"
+SELECTED_SLICE_ID = "issue97_topology_add_readout_only_sensor_aperture_compensation"
+GOLDEN_REFERENCE_ROOTS = (
+    "20260318_deadleaf_13b10",
+    "release/deadleaf_13b10_release/data/20260318_deadleaf_13b10",
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build the issue-99 intrinsic post-issue97 next-slice record."
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Repository root. Defaults to the parent of this script.",
+    )
+    parser.add_argument(
+        "--issue95-artifact",
+        type=Path,
+        default=Path("artifacts/intrinsic_after_issue93_next_slice_benchmark.json"),
+        help="Repo-relative issue-95 discovery artifact path.",
+    )
+    parser.add_argument(
+        "--issue93-artifact",
+        type=Path,
+        default=Path("artifacts/intrinsic_phase_retained_downstream_matched_ori_only_benchmark.json"),
+        help="Repo-relative issue-93 summary artifact path.",
+    )
+    parser.add_argument(
+        "--issue97-artifact",
+        type=Path,
+        default=Path("artifacts/intrinsic_phase_retained_reported_mtf_disconnect_benchmark.json"),
+        help="Repo-relative issue-97 summary artifact path.",
+    )
+    parser.add_argument(
+        "--current-best-psd-artifact",
+        type=Path,
+        default=Path("artifacts/issue77_measured_oecf_psd_benchmark.json"),
+        help="Repo-relative current-best PSD benchmark artifact path.",
+    )
+    parser.add_argument(
+        "--issue93-psd-artifact",
+        type=Path,
+        default=Path("artifacts/issue93_intrinsic_phase_retained_downstream_matched_ori_only_psd_benchmark.json"),
+        help="Repo-relative issue-93 PSD benchmark artifact path.",
+    )
+    parser.add_argument(
+        "--issue97-psd-artifact",
+        type=Path,
+        default=Path("artifacts/issue97_intrinsic_phase_retained_reported_mtf_disconnect_psd_benchmark.json"),
+        help="Repo-relative issue-97 PSD benchmark artifact path.",
+    )
+    parser.add_argument(
+        "--output-json",
+        type=Path,
+        default=Path("artifacts/intrinsic_after_issue97_next_slice_benchmark.json"),
+        help="Repo-relative output path for the machine-readable artifact.",
+    )
+    parser.add_argument(
+        "--output-md",
+        type=Path,
+        default=Path("docs/intrinsic_after_issue97_next_slice.md"),
+        help="Repo-relative output path for the Markdown note.",
+    )
+    return parser
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def resolve_path(repo_root: Path, path: Path) -> Path:
+    return path if path.is_absolute() else repo_root / path
+
+
+def format_metric(value: float) -> str:
+    return f"{value:.5f}"
+
+
+def is_close(a: float, b: float) -> bool:
+    return math.isclose(a, b, rel_tol=0.0, abs_tol=1e-12)
+
+
+def delta_map(candidate: dict[str, Any], baseline: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "curve_mae_mean": float(candidate["curve_mae_mean"] - baseline["curve_mae_mean"]),
+        "focus_preset_acutance_mae_mean": float(
+            candidate["focus_preset_acutance_mae_mean"]
+            - baseline["focus_preset_acutance_mae_mean"]
+        ),
+        "overall_quality_loss_mae_mean": float(
+            candidate["overall_quality_loss_mae_mean"] - baseline["overall_quality_loss_mae_mean"]
+        ),
+        "mtf_abs_signed_rel_mean": float(
+            candidate["mtf_abs_signed_rel_mean"] - baseline["mtf_abs_signed_rel_mean"]
+        ),
+        "mtf_threshold_mae": {
+            key: float(candidate["mtf_threshold_mae"][key] - baseline["mtf_threshold_mae"][key])
+            for key in ("mtf20", "mtf30", "mtf50")
+        },
+    }
+
+
+def pipeline_delta(candidate: dict[str, Any], baseline: dict[str, Any]) -> dict[str, Any]:
+    candidate_pipeline = candidate["analysis_pipeline"]
+    baseline_pipeline = baseline["analysis_pipeline"]
+    keys = [
+        "calibration_file",
+        "high_frequency_guard_start_cpp",
+        "intrinsic_full_reference_mode",
+        "intrinsic_full_reference_scope",
+        "intrinsic_full_reference_transfer_mode",
+        "matched_ori_anchor_mode",
+        "mtf_compensation_mode",
+        "sensor_fill_factor",
+        "texture_support_scale",
+    ]
+    return {
+        key: {
+            ISSUE97_LABEL: candidate_pipeline.get(key),
+            CURRENT_BEST_LABEL: baseline_pipeline.get(key),
+        }
+        for key in keys
+        if candidate_pipeline.get(key) != baseline_pipeline.get(key)
+    }
+
+
+def select_single_profile(payload: dict[str, Any]) -> dict[str, Any]:
+    profiles = payload["profiles"]
+    if len(profiles) != 1:
+        raise ValueError(f"Expected exactly one profile, found {len(profiles)}")
+    return profiles[0]
+
+
+def select_profile(payload: dict[str, Any], expected_profile_path: str) -> dict[str, Any]:
+    for profile in payload["profiles"]:
+        if profile["profile_path"] == expected_profile_path:
+            return profile
+    available = ", ".join(profile["profile_path"] for profile in payload["profiles"])
+    raise ValueError(
+        f"Profile {expected_profile_path!r} not found in artifact. Available: {available}"
+    )
+
+
+def band_signatures(profile: dict[str, Any]) -> dict[str, float]:
+    return {
+        band: float(summary["signed_rel_mean"])
+        for band, summary in profile["overall"]["mtf_bands"].items()
+    }
+
+
+def assert_storage_separation(payload: dict[str, Any]) -> None:
+    for path in payload["storage_policy"]["new_fitted_artifact_paths"]:
+        for root in GOLDEN_REFERENCE_ROOTS:
+            if path.startswith(root):
+                raise ValueError(f"Path {path} leaks into golden/reference root {root}")
+
+
+def build_payload(
+    repo_root: Path,
+    *,
+    issue95_artifact_path: Path,
+    issue93_artifact_path: Path,
+    issue97_artifact_path: Path,
+    current_best_psd_artifact_path: Path,
+    issue93_psd_artifact_path: Path,
+    issue97_psd_artifact_path: Path,
+) -> dict[str, Any]:
+    issue95_artifact = load_json(resolve_path(repo_root, issue95_artifact_path))
+    issue93_artifact = load_json(resolve_path(repo_root, issue93_artifact_path))
+    issue97_artifact = load_json(resolve_path(repo_root, issue97_artifact_path))
+    current_best_psd_artifact = load_json(resolve_path(repo_root, current_best_psd_artifact_path))
+    issue93_psd_artifact = load_json(resolve_path(repo_root, issue93_psd_artifact_path))
+    issue97_psd_artifact = load_json(resolve_path(repo_root, issue97_psd_artifact_path))
+
+    comparison_records = {
+        CURRENT_BEST_LABEL: issue97_artifact["profiles"][CURRENT_BEST_LABEL],
+        ISSUE93_LABEL: issue97_artifact["profiles"][ISSUE93_LABEL],
+        ISSUE97_LABEL: issue97_artifact["profiles"][ISSUE97_LABEL],
+    }
+    current_best = comparison_records[CURRENT_BEST_LABEL]
+    issue93 = comparison_records[ISSUE93_LABEL]
+    issue97 = comparison_records[ISSUE97_LABEL]
+
+    current_best_psd = select_profile(current_best_psd_artifact, current_best["profile_path"])
+    issue93_psd = select_single_profile(issue93_psd_artifact)
+    issue97_psd = select_single_profile(issue97_psd_artifact)
+
+    issue97_vs_issue93 = delta_map(issue97, issue93)
+    issue97_vs_current_best = delta_map(issue97, current_best)
+
+    current_best_band_signatures = band_signatures(current_best_psd)
+    issue93_band_signatures = band_signatures(issue93_psd)
+    issue97_band_signatures = band_signatures(issue97_psd)
+
+    residual_gap_evidence = {
+        "issue97_preserves_issue93_core_record": {
+            "curve_mae_mean": is_close(issue97["curve_mae_mean"], issue93["curve_mae_mean"]),
+            "focus_preset_acutance_mae_mean": is_close(
+                issue97["focus_preset_acutance_mae_mean"],
+                issue93["focus_preset_acutance_mae_mean"],
+            ),
+            "overall_quality_loss_mae_mean": is_close(
+                issue97["overall_quality_loss_mae_mean"],
+                issue93["overall_quality_loss_mae_mean"],
+            ),
+            "delta": {
+                "curve_mae_mean": issue97_vs_issue93["curve_mae_mean"],
+                "focus_preset_acutance_mae_mean": issue97_vs_issue93[
+                    "focus_preset_acutance_mae_mean"
+                ],
+                "overall_quality_loss_mae_mean": issue97_vs_issue93[
+                    "overall_quality_loss_mae_mean"
+                ],
+            },
+        },
+        "issue97_threshold_tradeoff_vs_issue93": {
+            "mtf20_improved": issue97["mtf_threshold_mae"]["mtf20"] < issue93["mtf_threshold_mae"]["mtf20"],
+            "mtf30_regressed": issue97["mtf_threshold_mae"]["mtf30"] > issue93["mtf_threshold_mae"]["mtf30"],
+            "mtf50_regressed": issue97["mtf_threshold_mae"]["mtf50"] > issue93["mtf_threshold_mae"]["mtf50"],
+            "mtf_abs_signed_rel_regressed": issue97["mtf_abs_signed_rel_mean"]
+            > issue93["mtf_abs_signed_rel_mean"],
+            "delta": issue97_vs_issue93,
+        },
+        "issue97_band_signed_rel_direction": {
+            band: {
+                CURRENT_BEST_LABEL: current_best_band_signatures[band],
+                ISSUE93_LABEL: issue93_band_signatures[band],
+                ISSUE97_LABEL: issue97_band_signatures[band],
+                "issue97_flips_negative_vs_issue93": issue93_band_signatures[band] > 0.0
+                and issue97_band_signatures[band] < 0.0,
+            }
+            for band in ("low", "mid", "high", "top")
+        },
+        "issue97_still_trails_pr30": {
+            "mtf20": issue97["mtf_threshold_mae"]["mtf20"]
+            > current_best["mtf_threshold_mae"]["mtf20"],
+            "mtf30": issue97["mtf_threshold_mae"]["mtf30"]
+            > current_best["mtf_threshold_mae"]["mtf30"],
+            "mtf50": issue97["mtf_threshold_mae"]["mtf50"]
+            > current_best["mtf_threshold_mae"]["mtf50"],
+            "mtf_abs_signed_rel_mean": issue97["mtf_abs_signed_rel_mean"]
+            > current_best["mtf_abs_signed_rel_mean"],
+            "delta": issue97_vs_current_best,
+        },
+    }
+
+    candidate_slices = [
+        {
+            "slice_id": SELECTED_SLICE_ID,
+            "label": "keep the issue-97 topology but add readout-only sensor-aperture compensation",
+            "decision": "advance",
+            "technical_narrowing_point": (
+                "issue97_showed_that_the_reported_mtf_disconnect_boundary_removed_the_wrong_"
+                "directional_bias_only_partially_and_left_a_readout_amplitude_underestimate_"
+                "that_now_points_at_the_compensation_boundary"
+            ),
+            "selected_summary": (
+                "Keep issue #97's observed reported-MTF threshold branch and issue #93's "
+                "downstream-only matched-ori Quality Loss branch unchanged, but restore "
+                "sensor-aperture MTF compensation only on the reported-MTF/readout path "
+                "before `compute_mtf_metrics(...)`. Use the PR #30 readout compensation "
+                "settings (`sensor_aperture_sinc`, `sensor_fill_factor=1.5`) only on that "
+                "branch, while leaving `compensated_mtf_for_acutance` and "
+                "`quality_loss_compensated_mtf_for_acutance` on the existing issue-97 topology."
+            ),
+            "repo_evidence": [
+                "Issue #97 preserves issue #93's `curve_mae_mean`, `focus_preset_acutance_mae_mean`, and `overall_quality_loss_mae_mean` exactly, so the downstream-only matched-ori Quality Loss branch remains correctly isolated and does not need to be reopened.",
+                "Issue #97 improves `mtf20` versus issue #93, but it regresses `mtf_abs_signed_rel_mean`, `mtf30`, and `mtf50`, which means the disconnect boundary moved the reported-MTF readout path in the right direction only for the lowest threshold and still left a residual readout-only failure mode.",
+                "In the raw PSD output, issue #97 flips every signed-relative band negative (`low`, `mid`, `high`, `top`), while issue #93 was positive in `mid`, `high`, and `top`. That is a directional underestimation pattern on the observed readout curve rather than a Quality Loss branch interaction.",
+                "The current PR #30 branch differs from issue #97 on several readout-adjacent knobs, but `mtf_compensation_mode='sensor_aperture_sinc'` plus `sensor_fill_factor=1.5` is the narrowest one that directly changes readout-curve amplitude before threshold extraction. `high_frequency_guard_start_cpp`, anchored calibration, and `texture_support_scale` are broader upstream or axis-scaling changes.",
+                "Issue #97 still keeps `readout_smoothing_window=1` and `readout_interpolation='linear'`, matching PR #30 already, so the remaining failure mode is not in the final threshold smoother/interpolator pair.",
+            ],
+            "comparison_basis": {
+                "pr96_selected_slice_id": issue95_artifact["selected_slice_id"],
+                "pr94_issue93_vs_current_best_pr30": {
+                    "delta": issue95_artifact["candidate_slices"][0]["comparison_basis"][
+                        "issue93_vs_current_best_pr30"
+                    ]["delta"],
+                },
+                "pr98_issue97_vs_issue93": {
+                    "delta": issue97_vs_issue93,
+                    "band_signed_rel_direction": residual_gap_evidence[
+                        "issue97_band_signed_rel_direction"
+                    ],
+                },
+                "pr98_issue97_vs_current_best_pr30": {
+                    "delta": issue97_vs_current_best,
+                },
+            },
+            "runtime_boundary_evidence": [
+                {
+                    "file_path": "algo/benchmark_parity_psd_mtf.py",
+                    "line_range": "425-435, 686-730",
+                    "observations": [
+                        "The PSD driver builds `compensated_mtf` and `compensated_mtf_for_acutance` from the same profile-wide `mtf_compensation_mode` before any intrinsic or matched-ori branching happens.",
+                        "`compute_mtf_metrics(...)` and `band_error_summary(...)` later consume only `readout_scaled_frequencies` plus `compensated_mtf`, so a dedicated readout-only compensation variable would directly isolate the remaining failure mode without touching the acutance branches.",
+                        "Issue #97 already leaves `compensated_mtf` on the observed branch by not overwriting it with `intrinsic_mtf`; the next minimum slice is therefore to change the readout compensation boundary on that observed branch, not to reconnect intrinsic MTF again.",
+                    ],
+                },
+                {
+                    "file_path": "algo/benchmark_parity_acutance_quality_loss.py",
+                    "line_range": "741-747, 866-972",
+                    "observations": [
+                        "The acutance/quality-loss driver already keeps `quality_loss_compensated_mtf_for_acutance` separate from the main acutance branch and anchors it later on the downstream-only matched-ori path.",
+                        "Because issue #97 preserves the issue-93 topology here, a readout-only compensation graft in the PSD driver can leave `compensated_mtf_for_acutance` and `quality_loss_compensated_mtf_for_acutance` untouched.",
+                        "This makes readout-only sensor-aperture compensation the smallest implementation that can target the remaining reported-MTF failure mode while preserving issue #97's curve/focus/Quality Loss record.",
+                    ],
+                },
+            ],
+            "minimum_implementation_boundary": [
+                "Keep issue #97's `reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only` topology, intrinsic transfer, registration mode, and downstream-only matched-ori Quality Loss branch unchanged.",
+                "Add one bounded scope or profile family that computes a readout-only `sensor_aperture_sinc` compensation path with `sensor_fill_factor=1.5` for the observed reported-MTF branch consumed by `compute_mtf_metrics(...)` and `band_error_summary(...)`.",
+                "Leave `compensated_mtf_for_acutance` and `quality_loss_compensated_mtf_for_acutance` on the existing issue-97 branches; do not yet enable anchored calibration, `texture_support_scale`, or `high_frequency_guard_start_cpp`.",
+            ],
+            "explicitly_do_not_change": [
+                "Do not reopen the issue-97 reported-MTF disconnect boundary or route thresholds back through the intrinsic reconnect path.",
+                "Do not touch the downstream-only matched-ori Quality Loss branch, the main acutance branch, or release-facing PR30 coefficients/configs.",
+                "Do not bundle anchored calibration, texture-support scaling, and high-frequency guard into the same implementation issue.",
+                "Do not write new fitted outputs under `20260318_deadleaf_13b10`, `release/deadleaf_13b10_release/data/20260318_deadleaf_13b10`, or `release/deadleaf_13b10_release/config/`.",
+            ],
+            "acceptance_criteria_for_next_issue": [
+                "The new bounded implementation keeps `curve_mae_mean`, `focus_preset_acutance_mae_mean`, and `overall_quality_loss_mae_mean` no worse than issue #97.",
+                "The same implementation improves `mtf_abs_signed_rel_mean`, `mtf30`, and `mtf50` versus issue #97 while keeping `mtf20` no worse than issue #97.",
+                "The implementation keeps the downstream-only matched-ori Quality Loss branch isolated from the reported-MTF/readout path.",
+                "All new fitted outputs remain under `algo/` or `artifacts/`, not under golden/reference roots or release-facing config roots.",
+            ],
+            "validation_plan_for_next_issue": [
+                "Run `python3 -m algo.benchmark_parity_psd_mtf ...` on an issue-97-based profile that adds readout-only sensor-aperture compensation, then compare `mtf_abs_signed_rel_mean`, `mtf20`, `mtf30`, and `mtf50` against issue #97, issue #93, and PR #30.",
+                "Run `python3 -m algo.benchmark_parity_acutance_quality_loss ...` on the same scope to confirm `curve_mae_mean`, `focus_preset_acutance_mae_mean`, and `overall_quality_loss_mae_mean` stay at or below issue #97.",
+                "Add focused tests that prove only the reported-MTF/readout path receives the new compensation mode while `compensated_mtf_for_acutance` and `quality_loss_compensated_mtf_for_acutance` remain on the existing issue-97 branches.",
+            ],
+        },
+        {
+            "slice_id": "bundle_anchored_calibration_texture_scale_and_high_frequency_guard",
+            "label": "bundle PR30's anchored calibration, texture-support scaling, and high-frequency guard into issue-97 now",
+            "decision": "exclude",
+            "exclusion_reasons": [
+                "Those knobs live in a broader observable-stack family and would change both upstream PSD estimation and the frequency axis together.",
+                "Issue #99 is a narrowing pass, so it should not jump from one failed readout boundary straight into a three-knob bundle before the single compensation boundary is isolated.",
+            ],
+        },
+        {
+            "slice_id": "reconnect_reported_mtf_to_intrinsic_branch_again",
+            "label": "route reported-MTF thresholds back through the intrinsic reconnect path",
+            "decision": "exclude",
+            "exclusion_reasons": [
+                "Issue #95 / PR #96 already selected the disconnect boundary as the minimum post-issue93 slice, and PR #98 completed that experiment cleanly.",
+                "Reconnecting thresholds to the intrinsic branch would reopen a path that issue #97 has already bounded, rather than narrowing the remaining failure mode.",
+            ],
+        },
+        {
+            "slice_id": "restart_broader_matched_ori_or_intrinsic_family_search",
+            "label": "restart broader matched-ori, observable-stack, or intrinsic family search",
+            "decision": "exclude",
+            "exclusion_reasons": [
+                "The remaining failure mode is already localized to the reported-MTF/readout path after issue #97; the repo evidence no longer supports reopening whole-family search.",
+                "Issue #99 must leave engineering with one direct bounded implementation issue, not another unbounded family sweep.",
+            ],
+        },
+    ]
+
+    payload = {
+        "issue": 99,
+        "summary_kind": SUMMARY_KIND,
+        "selected_slice_id": SELECTED_SLICE_ID,
+        "selected_summary": candidate_slices[0]["selected_summary"],
+        "source_artifacts": {
+            "issue95_summary_artifact": str(issue95_artifact_path),
+            "issue95_selected_slice_id": issue95_artifact["selected_slice_id"],
+            "issue93_summary_artifact": str(issue93_artifact_path),
+            "issue93_conclusion_status": issue93_artifact["conclusion"]["status"],
+            "issue97_summary_artifact": str(issue97_artifact_path),
+            "issue97_conclusion_status": issue97_artifact["conclusion"]["status"],
+        },
+        "comparison_records": comparison_records,
+        "residual_gap_evidence": residual_gap_evidence,
+        "pipeline_delta_summary": pipeline_delta(issue97, current_best),
+        "candidate_slices": candidate_slices,
+        "storage_policy": {
+            "golden_reference_roots": list(GOLDEN_REFERENCE_ROOTS),
+            "fitted_artifact_roots": ["algo/*.json", "artifacts/*.json"],
+            "release_config_roots": ["release/deadleaf_13b10_release/config/*.json"],
+            "new_fitted_artifact_paths": [
+                "artifacts/intrinsic_after_issue97_next_slice_benchmark.json",
+            ],
+            "rules": [
+                "Keep this issue's discovery outputs under `docs/` and `artifacts/` only.",
+                "Do not write new fitted intrinsic profiles, transfer tables, or benchmark outputs under the golden/reference roots.",
+                "Do not touch release-facing configs until a later bounded implementation clears the current README-facing guardrails.",
+            ],
+        },
+    }
+    assert_storage_separation(payload)
+    return payload
+
+
+def render_markdown(payload: dict[str, Any]) -> str:
+    selected = next(
+        row for row in payload["candidate_slices"] if row["slice_id"] == payload["selected_slice_id"]
+    )
+    records = payload["comparison_records"]
+    residual = payload["residual_gap_evidence"]
+
+    lines = [
+        "# Intrinsic After Issue 97 Next Slice",
+        "",
+        "This note records the issue `#99` developer-discovery pass after issue `#97` / PR `#98` proved that disconnecting reported-MTF thresholds from the intrinsic reconnect preserves the issue-93 curve/focus/Quality Loss record but still leaves a residual reported-MTF/readout failure mode.",
+        "",
+        "## Selected Slice",
+        "",
+        f"- Selected slice: `{payload['selected_slice_id']}`",
+        f"- Summary: {payload['selected_summary']}",
+        f"- Prior narrowing lineage: issue `#95` / PR `#96` selected `{payload['source_artifacts']['issue95_selected_slice_id']}`, and issue `#97` / PR `#98` completed that implementation cleanly enough to expose the next remaining boundary.",
+        "- Remaining gap location: after issue #97, the downstream-only matched-ori Quality Loss win is already preserved and the reported-MTF branch is already disconnected from intrinsic reconnect. The next minimum slice is now the readout-only compensation boundary on the observed branch.",
+        "",
+        "## Comparison Table",
+        "",
+        "| Record | Curve MAE | Focus Acu MAE | Overall QL | MTF20 | MTF30 | MTF50 | Abs Signed Rel | Reading |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+    ]
+
+    descriptions = {
+        CURRENT_BEST_LABEL: "Current best PR30 branch.",
+        ISSUE93_LABEL: "Issue-93 bounded positive baseline from PR #94.",
+        ISSUE97_LABEL: "Issue-97 reported-MTF disconnect result from PR #98.",
+    }
+    for key in (CURRENT_BEST_LABEL, ISSUE93_LABEL, ISSUE97_LABEL):
+        record = records[key]
+        mtf = record["mtf_threshold_mae"]
+        lines.append(
+            f"| {key} | "
+            f"{format_metric(record['curve_mae_mean'])} | "
+            f"{format_metric(record['focus_preset_acutance_mae_mean'])} | "
+            f"{format_metric(record['overall_quality_loss_mae_mean'])} | "
+            f"{format_metric(mtf['mtf20'])} | "
+            f"{format_metric(mtf['mtf30'])} | "
+            f"{format_metric(mtf['mtf50'])} | "
+            f"{format_metric(record['mtf_abs_signed_rel_mean'])} | "
+            f"{descriptions[key]} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Residual Gap Evidence",
+            "",
+            f"- Issue #97 preserves issue #93 `curve_mae_mean`: `{residual['issue97_preserves_issue93_core_record']['curve_mae_mean']}`",
+            f"- Issue #97 preserves issue #93 `focus_preset_acutance_mae_mean`: `{residual['issue97_preserves_issue93_core_record']['focus_preset_acutance_mae_mean']}`",
+            f"- Issue #97 preserves issue #93 `overall_quality_loss_mae_mean`: `{residual['issue97_preserves_issue93_core_record']['overall_quality_loss_mae_mean']}`",
+            f"- Issue #97 improves issue #93 `mtf20`: `{residual['issue97_threshold_tradeoff_vs_issue93']['mtf20_improved']}`",
+            f"- Issue #97 regresses issue #93 `mtf30`: `{residual['issue97_threshold_tradeoff_vs_issue93']['mtf30_regressed']}`",
+            f"- Issue #97 regresses issue #93 `mtf50`: `{residual['issue97_threshold_tradeoff_vs_issue93']['mtf50_regressed']}`",
+            f"- Issue #97 regresses issue #93 `mtf_abs_signed_rel_mean`: `{residual['issue97_threshold_tradeoff_vs_issue93']['mtf_abs_signed_rel_regressed']}`",
+            "",
+            "## Band Direction Evidence",
+            "",
+        ]
+    )
+    for band, values in residual["issue97_band_signed_rel_direction"].items():
+        lines.append(
+            f"- `{band}` signed-rel mean: pr30={values[CURRENT_BEST_LABEL]:.5f}, "
+            f"issue93={values[ISSUE93_LABEL]:.5f}, issue97={values[ISSUE97_LABEL]:.5f}, "
+            f"`issue97_flips_negative_vs_issue93={values['issue97_flips_negative_vs_issue93']}`"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Pipeline Delta Between Issue 97 And PR30",
+            "",
+        ]
+    )
+    for key, values in payload["pipeline_delta_summary"].items():
+        lines.append(
+            f"- `{key}`: issue97={values[ISSUE97_LABEL]!r}, pr30={values[CURRENT_BEST_LABEL]!r}"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Why The Next Slice Is Readout-Only Sensor-Aperture Compensation",
+            "",
+        ]
+    )
+    for reason in selected["repo_evidence"]:
+        lines.append(f"- {reason}")
+
+    lines.extend(
+        [
+            "",
+            "## Runtime Boundary Evidence",
+            "",
+        ]
+    )
+    for item in selected["runtime_boundary_evidence"]:
+        lines.append(f"### `{item['file_path']}` ({item['line_range']})")
+        lines.append("")
+        for observation in item["observations"]:
+            lines.append(f"- {observation}")
+        lines.append("")
+
+    lines.extend(
+        [
+            "## Implementation Boundary",
+            "",
+        ]
+    )
+    for entry in selected["minimum_implementation_boundary"]:
+        lines.append(f"- {entry}")
+
+    lines.extend(
+        [
+            "",
+            "## Explicit Non-Changes",
+            "",
+        ]
+    )
+    for entry in selected["explicitly_do_not_change"]:
+        lines.append(f"- {entry}")
+
+    lines.extend(
+        [
+            "",
+            "## Excluded Routes",
+            "",
+        ]
+    )
+    for row in payload["candidate_slices"]:
+        if row["decision"] != "exclude":
+            continue
+        lines.append(f"### `{row['slice_id']}`")
+        lines.append("")
+        lines.append(f"- Route: {row['label']}")
+        for reason in row["exclusion_reasons"]:
+            lines.append(f"- {reason}")
+        lines.append("")
+
+    lines.extend(
+        [
+            "## Acceptance For The Next Implementation Issue",
+            "",
+        ]
+    )
+    for entry in selected["acceptance_criteria_for_next_issue"]:
+        lines.append(f"- {entry}")
+
+    lines.extend(
+        [
+            "",
+            "## Validation Plan For The Next Implementation Issue",
+            "",
+        ]
+    )
+    for entry in selected["validation_plan_for_next_issue"]:
+        lines.append(f"- {entry}")
+
+    lines.extend(
+        [
+            "",
+            "## Storage Separation",
+            "",
+            f"- Golden/reference roots: `{GOLDEN_REFERENCE_ROOTS[0]}`, `{GOLDEN_REFERENCE_ROOTS[1]}`",
+            "- Fitted artifact roots: `algo/*.json`, `artifacts/*.json`",
+            "- Release config roots: `release/deadleaf_13b10_release/config/*.json`",
+        ]
+    )
+    for rule in payload["storage_policy"]["rules"]:
+        lines.append(f"- {rule}")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    payload = build_payload(
+        args.repo_root,
+        issue95_artifact_path=args.issue95_artifact,
+        issue93_artifact_path=args.issue93_artifact,
+        issue97_artifact_path=args.issue97_artifact,
+        current_best_psd_artifact_path=args.current_best_psd_artifact,
+        issue93_psd_artifact_path=args.issue93_psd_artifact,
+        issue97_psd_artifact_path=args.issue97_psd_artifact,
+    )
+    output_json = resolve_path(args.repo_root, args.output_json)
+    output_md = resolve_path(args.repo_root, args.output_md)
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    output_md.parent.mkdir(parents=True, exist_ok=True)
+    output_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    output_md.write_text(render_markdown(payload), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/artifacts/intrinsic_after_issue97_next_slice_benchmark.json
+++ b/artifacts/intrinsic_after_issue97_next_slice_benchmark.json
@@ -1,0 +1,1008 @@
+{
+  "candidate_slices": [
+    {
+      "acceptance_criteria_for_next_issue": [
+        "The new bounded implementation keeps `curve_mae_mean`, `focus_preset_acutance_mae_mean`, and `overall_quality_loss_mae_mean` no worse than issue #97.",
+        "The same implementation improves `mtf_abs_signed_rel_mean`, `mtf30`, and `mtf50` versus issue #97 while keeping `mtf20` no worse than issue #97.",
+        "The implementation keeps the downstream-only matched-ori Quality Loss branch isolated from the reported-MTF/readout path.",
+        "All new fitted outputs remain under `algo/` or `artifacts/`, not under golden/reference roots or release-facing config roots."
+      ],
+      "comparison_basis": {
+        "pr94_issue93_vs_current_best_pr30": {
+          "delta": {
+            "curve_mae_mean": -0.0039872260971888646,
+            "focus_preset_acutance_mae_mean": -0.013566304809976663,
+            "mtf_abs_signed_rel_mean": 0.05322361665695152,
+            "mtf_threshold_mae": {
+              "mtf20": 0.05275557930482774,
+              "mtf30": -0.019044846884588542,
+              "mtf50": -0.0021365280254645085
+            },
+            "overall_quality_loss_mae_mean": 2.725930579444415
+          }
+        },
+        "pr96_selected_slice_id": "issue93_topology_keep_downstream_quality_loss_branch_but_disconnect_reported_mtf_from_intrinsic_reconnect",
+        "pr98_issue97_vs_current_best_pr30": {
+          "delta": {
+            "curve_mae_mean": -0.0039872260971888646,
+            "focus_preset_acutance_mae_mean": -0.013566304809976663,
+            "mtf_abs_signed_rel_mean": 0.2901638701776287,
+            "mtf_threshold_mae": {
+              "mtf20": 0.041464807767238945,
+              "mtf30": 0.03859250411762396,
+              "mtf50": 0.024961219449571755
+            },
+            "overall_quality_loss_mae_mean": 2.725930579444415
+          }
+        },
+        "pr98_issue97_vs_issue93": {
+          "band_signed_rel_direction": {
+            "high": {
+              "current_best_pr30_branch": 0.04982888092128941,
+              "issue93_downstream_matched_ori_only_candidate": 0.350265151882866,
+              "issue97_flips_negative_vs_issue93": true,
+              "issue97_reported_mtf_disconnect_candidate": -0.4191386815262641
+            },
+            "low": {
+              "current_best_pr30_branch": 0.0237949421475065,
+              "issue93_downstream_matched_ori_only_candidate": -0.0036495976267245525,
+              "issue97_flips_negative_vs_issue93": false,
+              "issue97_reported_mtf_disconnect_candidate": -0.09685152250222986
+            },
+            "mid": {
+              "current_best_pr30_branch": 0.10965436746685472,
+              "issue93_downstream_matched_ori_only_candidate": 0.10026578142446776,
+              "issue97_flips_negative_vs_issue93": true,
+              "issue97_reported_mtf_disconnect_candidate": -0.2841326982043283
+            },
+            "top": {
+              "current_best_pr30_branch": -0.16357848520011598,
+              "issue93_downstream_matched_ori_only_candidate": 0.1055706114295144,
+              "issue97_flips_negative_vs_issue93": true,
+              "issue97_reported_mtf_disconnect_candidate": -0.7073892542134591
+            }
+          },
+          "delta": {
+            "curve_mae_mean": 0.0,
+            "focus_preset_acutance_mae_mean": 0.0,
+            "mtf_abs_signed_rel_mean": 0.23694025352067719,
+            "mtf_threshold_mae": {
+              "mtf20": -0.011290771537588798,
+              "mtf30": 0.0576373510022125,
+              "mtf50": 0.027097747475036262
+            },
+            "overall_quality_loss_mae_mean": 0.0
+          }
+        }
+      },
+      "decision": "advance",
+      "explicitly_do_not_change": [
+        "Do not reopen the issue-97 reported-MTF disconnect boundary or route thresholds back through the intrinsic reconnect path.",
+        "Do not touch the downstream-only matched-ori Quality Loss branch, the main acutance branch, or release-facing PR30 coefficients/configs.",
+        "Do not bundle anchored calibration, texture-support scaling, and high-frequency guard into the same implementation issue.",
+        "Do not write new fitted outputs under `20260318_deadleaf_13b10`, `release/deadleaf_13b10_release/data/20260318_deadleaf_13b10`, or `release/deadleaf_13b10_release/config/`."
+      ],
+      "label": "keep the issue-97 topology but add readout-only sensor-aperture compensation",
+      "minimum_implementation_boundary": [
+        "Keep issue #97's `reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only` topology, intrinsic transfer, registration mode, and downstream-only matched-ori Quality Loss branch unchanged.",
+        "Add one bounded scope or profile family that computes a readout-only `sensor_aperture_sinc` compensation path with `sensor_fill_factor=1.5` for the observed reported-MTF branch consumed by `compute_mtf_metrics(...)` and `band_error_summary(...)`.",
+        "Leave `compensated_mtf_for_acutance` and `quality_loss_compensated_mtf_for_acutance` on the existing issue-97 branches; do not yet enable anchored calibration, `texture_support_scale`, or `high_frequency_guard_start_cpp`."
+      ],
+      "repo_evidence": [
+        "Issue #97 preserves issue #93's `curve_mae_mean`, `focus_preset_acutance_mae_mean`, and `overall_quality_loss_mae_mean` exactly, so the downstream-only matched-ori Quality Loss branch remains correctly isolated and does not need to be reopened.",
+        "Issue #97 improves `mtf20` versus issue #93, but it regresses `mtf_abs_signed_rel_mean`, `mtf30`, and `mtf50`, which means the disconnect boundary moved the reported-MTF readout path in the right direction only for the lowest threshold and still left a residual readout-only failure mode.",
+        "In the raw PSD output, issue #97 flips every signed-relative band negative (`low`, `mid`, `high`, `top`), while issue #93 was positive in `mid`, `high`, and `top`. That is a directional underestimation pattern on the observed readout curve rather than a Quality Loss branch interaction.",
+        "The current PR #30 branch differs from issue #97 on several readout-adjacent knobs, but `mtf_compensation_mode='sensor_aperture_sinc'` plus `sensor_fill_factor=1.5` is the narrowest one that directly changes readout-curve amplitude before threshold extraction. `high_frequency_guard_start_cpp`, anchored calibration, and `texture_support_scale` are broader upstream or axis-scaling changes.",
+        "Issue #97 still keeps `readout_smoothing_window=1` and `readout_interpolation='linear'`, matching PR #30 already, so the remaining failure mode is not in the final threshold smoother/interpolator pair."
+      ],
+      "runtime_boundary_evidence": [
+        {
+          "file_path": "algo/benchmark_parity_psd_mtf.py",
+          "line_range": "425-435, 686-730",
+          "observations": [
+            "The PSD driver builds `compensated_mtf` and `compensated_mtf_for_acutance` from the same profile-wide `mtf_compensation_mode` before any intrinsic or matched-ori branching happens.",
+            "`compute_mtf_metrics(...)` and `band_error_summary(...)` later consume only `readout_scaled_frequencies` plus `compensated_mtf`, so a dedicated readout-only compensation variable would directly isolate the remaining failure mode without touching the acutance branches.",
+            "Issue #97 already leaves `compensated_mtf` on the observed branch by not overwriting it with `intrinsic_mtf`; the next minimum slice is therefore to change the readout compensation boundary on that observed branch, not to reconnect intrinsic MTF again."
+          ]
+        },
+        {
+          "file_path": "algo/benchmark_parity_acutance_quality_loss.py",
+          "line_range": "741-747, 866-972",
+          "observations": [
+            "The acutance/quality-loss driver already keeps `quality_loss_compensated_mtf_for_acutance` separate from the main acutance branch and anchors it later on the downstream-only matched-ori path.",
+            "Because issue #97 preserves the issue-93 topology here, a readout-only compensation graft in the PSD driver can leave `compensated_mtf_for_acutance` and `quality_loss_compensated_mtf_for_acutance` untouched.",
+            "This makes readout-only sensor-aperture compensation the smallest implementation that can target the remaining reported-MTF failure mode while preserving issue #97's curve/focus/Quality Loss record."
+          ]
+        }
+      ],
+      "selected_summary": "Keep issue #97's observed reported-MTF threshold branch and issue #93's downstream-only matched-ori Quality Loss branch unchanged, but restore sensor-aperture MTF compensation only on the reported-MTF/readout path before `compute_mtf_metrics(...)`. Use the PR #30 readout compensation settings (`sensor_aperture_sinc`, `sensor_fill_factor=1.5`) only on that branch, while leaving `compensated_mtf_for_acutance` and `quality_loss_compensated_mtf_for_acutance` on the existing issue-97 topology.",
+      "slice_id": "issue97_topology_add_readout_only_sensor_aperture_compensation",
+      "technical_narrowing_point": "issue97_showed_that_the_reported_mtf_disconnect_boundary_removed_the_wrong_directional_bias_only_partially_and_left_a_readout_amplitude_underestimate_that_now_points_at_the_compensation_boundary",
+      "validation_plan_for_next_issue": [
+        "Run `python3 -m algo.benchmark_parity_psd_mtf ...` on an issue-97-based profile that adds readout-only sensor-aperture compensation, then compare `mtf_abs_signed_rel_mean`, `mtf20`, `mtf30`, and `mtf50` against issue #97, issue #93, and PR #30.",
+        "Run `python3 -m algo.benchmark_parity_acutance_quality_loss ...` on the same scope to confirm `curve_mae_mean`, `focus_preset_acutance_mae_mean`, and `overall_quality_loss_mae_mean` stay at or below issue #97.",
+        "Add focused tests that prove only the reported-MTF/readout path receives the new compensation mode while `compensated_mtf_for_acutance` and `quality_loss_compensated_mtf_for_acutance` remain on the existing issue-97 branches."
+      ]
+    },
+    {
+      "decision": "exclude",
+      "exclusion_reasons": [
+        "Those knobs live in a broader observable-stack family and would change both upstream PSD estimation and the frequency axis together.",
+        "Issue #99 is a narrowing pass, so it should not jump from one failed readout boundary straight into a three-knob bundle before the single compensation boundary is isolated."
+      ],
+      "label": "bundle PR30's anchored calibration, texture-support scaling, and high-frequency guard into issue-97 now",
+      "slice_id": "bundle_anchored_calibration_texture_scale_and_high_frequency_guard"
+    },
+    {
+      "decision": "exclude",
+      "exclusion_reasons": [
+        "Issue #95 / PR #96 already selected the disconnect boundary as the minimum post-issue93 slice, and PR #98 completed that experiment cleanly.",
+        "Reconnecting thresholds to the intrinsic branch would reopen a path that issue #97 has already bounded, rather than narrowing the remaining failure mode."
+      ],
+      "label": "route reported-MTF thresholds back through the intrinsic reconnect path",
+      "slice_id": "reconnect_reported_mtf_to_intrinsic_branch_again"
+    },
+    {
+      "decision": "exclude",
+      "exclusion_reasons": [
+        "The remaining failure mode is already localized to the reported-MTF/readout path after issue #97; the repo evidence no longer supports reopening whole-family search.",
+        "Issue #99 must leave engineering with one direct bounded implementation issue, not another unbounded family sweep."
+      ],
+      "label": "restart broader matched-ori, observable-stack, or intrinsic family search",
+      "slice_id": "restart_broader_matched_ori_or_intrinsic_family_search"
+    }
+  ],
+  "comparison_records": {
+    "current_best_pr30_branch": {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": 0.013802247905288301,
+        "Computer Monitor Acutance": 0.052665183748573804,
+        "Large Print Acutance": 0.05132586418527154,
+        "Small Print Acutance": 0.046702107662187464,
+        "UHDTV Display Acutance": 0.04793875259218785
+      },
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "readout_interpolation": "linear",
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": true
+      },
+      "curve_mae_mean": 0.03678903166100513,
+      "focus_preset_acutance_mae_mean": 0.042486831218701795,
+      "label": "current_best_pr30_branch",
+      "mtf_abs_signed_rel_mean": 0.08671416893394165,
+      "mtf_band_mae": {
+        "high": 0.01764835359892083,
+        "low": 0.03704553941403868,
+        "mid": 0.03898616152003224,
+        "top": 0.07374065223652229
+      },
+      "mtf_threshold_mae": {
+        "mtf20": 0.03301077142967389,
+        "mtf30": 0.03693639342667963,
+        "mtf50": 0.009332615436071163
+      },
+      "overall_quality_loss_mae_mean": 1.2214989544377113,
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_profile.json",
+      "quality_loss_preset_mae": {
+        "5.5\" Phone Display Quality Loss": 0.14297991495607307,
+        "Computer Monitor Quality Loss": 2.902905846061304,
+        "Large Print Quality Loss": 0.9548172583377941,
+        "Small Print Quality Loss": 0.6076935256225349,
+        "UHDTV Display Quality Loss": 1.4990982272108502
+      }
+    },
+    "issue93_downstream_matched_ori_only_candidate": {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": 0.035256377739795786,
+        "Computer Monitor Acutance": 0.024146307932311834,
+        "Large Print Acutance": 0.028624302638652583,
+        "Small Print Acutance": 0.031726251556383624,
+        "UHDTV Display Acutance": 0.024849392176481848
+      },
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": null,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "readout_reconnect_quality_loss_isolation_downstream_matched_ori_only",
+        "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "none",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "readout_interpolation": "linear",
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.0,
+        "texture_support_scale": false
+      },
+      "curve_mae_mean": 0.03280180556381627,
+      "focus_preset_acutance_mae_mean": 0.028920526408725132,
+      "label": "issue93_downstream_matched_ori_only_candidate",
+      "mtf_abs_signed_rel_mean": 0.13993778559089318,
+      "mtf_band_mae": {
+        "high": 0.046538330006884135,
+        "low": 0.009354903091206065,
+        "mid": 0.04532695609684774,
+        "top": 0.045570940534890705
+      },
+      "mtf_threshold_mae": {
+        "mtf20": 0.08576635073450163,
+        "mtf30": 0.017891546542091085,
+        "mtf50": 0.007196087410606654
+      },
+      "overall_quality_loss_mae_mean": 3.9474295338821266,
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_readout_reconnect_quality_loss_isolation_downstream_matched_ori_only_profile.json",
+      "quality_loss_preset_mae": {
+        "5.5\" Phone Display Quality Loss": 4.122316176755632,
+        "Computer Monitor Quality Loss": 6.1264243907692375,
+        "Large Print Quality Loss": 2.079928486542698,
+        "Small Print Quality Loss": 3.490178763693591,
+        "UHDTV Display Quality Loss": 3.918299851649472
+      }
+    },
+    "issue97_reported_mtf_disconnect_candidate": {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": 0.035256377739795786,
+        "Computer Monitor Acutance": 0.024146307932311834,
+        "Large Print Acutance": 0.028624302638652583,
+        "Small Print Acutance": 0.031726251556383624,
+        "UHDTV Display Acutance": 0.024849392176481848
+      },
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": null,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only",
+        "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "none",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "readout_interpolation": "linear",
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.0,
+        "texture_support_scale": false
+      },
+      "curve_mae_mean": 0.03280180556381627,
+      "focus_preset_acutance_mae_mean": 0.028920526408725132,
+      "label": "issue97_reported_mtf_disconnect_candidate",
+      "mtf_abs_signed_rel_mean": 0.37687803911157036,
+      "mtf_threshold_mae": {
+        "mtf20": 0.07447557919691283,
+        "mtf30": 0.07552889754430359,
+        "mtf50": 0.034293834885642915
+      },
+      "overall_quality_loss_mae_mean": 3.9474295338821266,
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only_profile.json",
+      "quality_loss_preset_mae": {
+        "5.5\" Phone Display Quality Loss": 4.122316176755632,
+        "Computer Monitor Quality Loss": 6.1264243907692375,
+        "Large Print Quality Loss": 2.079928486542698,
+        "Small Print Quality Loss": 3.490178763693591,
+        "UHDTV Display Quality Loss": 3.918299851649472
+      }
+    }
+  },
+  "issue": 99,
+  "pipeline_delta_summary": {
+    "calibration_file": {
+      "current_best_pr30_branch": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+      "issue97_reported_mtf_disconnect_candidate": "algo/deadleaf_13b10_psd_calibration.json"
+    },
+    "high_frequency_guard_start_cpp": {
+      "current_best_pr30_branch": 0.36,
+      "issue97_reported_mtf_disconnect_candidate": null
+    },
+    "intrinsic_full_reference_mode": {
+      "current_best_pr30_branch": "none",
+      "issue97_reported_mtf_disconnect_candidate": "paired_ori_transfer"
+    },
+    "intrinsic_full_reference_scope": {
+      "current_best_pr30_branch": "replace_all",
+      "issue97_reported_mtf_disconnect_candidate": "reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only"
+    },
+    "intrinsic_full_reference_transfer_mode": {
+      "current_best_pr30_branch": "magnitude_ratio",
+      "issue97_reported_mtf_disconnect_candidate": "radial_real_mean"
+    },
+    "matched_ori_anchor_mode": {
+      "current_best_pr30_branch": "acutance_only",
+      "issue97_reported_mtf_disconnect_candidate": "all"
+    },
+    "mtf_compensation_mode": {
+      "current_best_pr30_branch": "sensor_aperture_sinc",
+      "issue97_reported_mtf_disconnect_candidate": "none"
+    },
+    "sensor_fill_factor": {
+      "current_best_pr30_branch": 1.5,
+      "issue97_reported_mtf_disconnect_candidate": 1.0
+    },
+    "texture_support_scale": {
+      "current_best_pr30_branch": true,
+      "issue97_reported_mtf_disconnect_candidate": false
+    }
+  },
+  "residual_gap_evidence": {
+    "issue97_band_signed_rel_direction": {
+      "high": {
+        "current_best_pr30_branch": 0.04982888092128941,
+        "issue93_downstream_matched_ori_only_candidate": 0.350265151882866,
+        "issue97_flips_negative_vs_issue93": true,
+        "issue97_reported_mtf_disconnect_candidate": -0.4191386815262641
+      },
+      "low": {
+        "current_best_pr30_branch": 0.0237949421475065,
+        "issue93_downstream_matched_ori_only_candidate": -0.0036495976267245525,
+        "issue97_flips_negative_vs_issue93": false,
+        "issue97_reported_mtf_disconnect_candidate": -0.09685152250222986
+      },
+      "mid": {
+        "current_best_pr30_branch": 0.10965436746685472,
+        "issue93_downstream_matched_ori_only_candidate": 0.10026578142446776,
+        "issue97_flips_negative_vs_issue93": true,
+        "issue97_reported_mtf_disconnect_candidate": -0.2841326982043283
+      },
+      "top": {
+        "current_best_pr30_branch": -0.16357848520011598,
+        "issue93_downstream_matched_ori_only_candidate": 0.1055706114295144,
+        "issue97_flips_negative_vs_issue93": true,
+        "issue97_reported_mtf_disconnect_candidate": -0.7073892542134591
+      }
+    },
+    "issue97_preserves_issue93_core_record": {
+      "curve_mae_mean": true,
+      "delta": {
+        "curve_mae_mean": 0.0,
+        "focus_preset_acutance_mae_mean": 0.0,
+        "overall_quality_loss_mae_mean": 0.0
+      },
+      "focus_preset_acutance_mae_mean": true,
+      "overall_quality_loss_mae_mean": true
+    },
+    "issue97_still_trails_pr30": {
+      "delta": {
+        "curve_mae_mean": -0.0039872260971888646,
+        "focus_preset_acutance_mae_mean": -0.013566304809976663,
+        "mtf_abs_signed_rel_mean": 0.2901638701776287,
+        "mtf_threshold_mae": {
+          "mtf20": 0.041464807767238945,
+          "mtf30": 0.03859250411762396,
+          "mtf50": 0.024961219449571755
+        },
+        "overall_quality_loss_mae_mean": 2.725930579444415
+      },
+      "mtf20": true,
+      "mtf30": true,
+      "mtf50": true,
+      "mtf_abs_signed_rel_mean": true
+    },
+    "issue97_threshold_tradeoff_vs_issue93": {
+      "delta": {
+        "curve_mae_mean": 0.0,
+        "focus_preset_acutance_mae_mean": 0.0,
+        "mtf_abs_signed_rel_mean": 0.23694025352067719,
+        "mtf_threshold_mae": {
+          "mtf20": -0.011290771537588798,
+          "mtf30": 0.0576373510022125,
+          "mtf50": 0.027097747475036262
+        },
+        "overall_quality_loss_mae_mean": 0.0
+      },
+      "mtf20_improved": true,
+      "mtf30_regressed": true,
+      "mtf50_regressed": true,
+      "mtf_abs_signed_rel_regressed": true
+    }
+  },
+  "selected_slice_id": "issue97_topology_add_readout_only_sensor_aperture_compensation",
+  "selected_summary": "Keep issue #97's observed reported-MTF threshold branch and issue #93's downstream-only matched-ori Quality Loss branch unchanged, but restore sensor-aperture MTF compensation only on the reported-MTF/readout path before `compute_mtf_metrics(...)`. Use the PR #30 readout compensation settings (`sensor_aperture_sinc`, `sensor_fill_factor=1.5`) only on that branch, while leaving `compensated_mtf_for_acutance` and `quality_loss_compensated_mtf_for_acutance` on the existing issue-97 topology.",
+  "source_artifacts": {
+    "issue93_conclusion_status": "issue93_acceptance_passed_but_not_current_best",
+    "issue93_summary_artifact": "artifacts/intrinsic_phase_retained_downstream_matched_ori_only_benchmark.json",
+    "issue95_selected_slice_id": "issue93_topology_keep_downstream_quality_loss_branch_but_disconnect_reported_mtf_from_intrinsic_reconnect",
+    "issue95_summary_artifact": "artifacts/intrinsic_after_issue93_next_slice_benchmark.json",
+    "issue97_conclusion_status": "issue97_reported_mtf_disconnect_failed",
+    "issue97_summary_artifact": "artifacts/intrinsic_phase_retained_reported_mtf_disconnect_benchmark.json"
+  },
+  "storage_policy": {
+    "fitted_artifact_roots": [
+      "algo/*.json",
+      "artifacts/*.json"
+    ],
+    "golden_reference_roots": [
+      "20260318_deadleaf_13b10",
+      "release/deadleaf_13b10_release/data/20260318_deadleaf_13b10"
+    ],
+    "new_fitted_artifact_paths": [
+      "artifacts/intrinsic_after_issue97_next_slice_benchmark.json"
+    ],
+    "release_config_roots": [
+      "release/deadleaf_13b10_release/config/*.json"
+    ],
+    "rules": [
+      "Keep this issue's discovery outputs under `docs/` and `artifacts/` only.",
+      "Do not write new fitted intrinsic profiles, transfer tables, or benchmark outputs under the golden/reference roots.",
+      "Do not touch release-facing configs until a later bounded implementation clears the current README-facing guardrails."
+    ]
+  },
+  "summary_kind": "intrinsic_after_issue97_next_slice"
+}

--- a/docs/intrinsic_after_issue97_next_slice.md
+++ b/docs/intrinsic_after_issue97_next_slice.md
@@ -1,0 +1,124 @@
+# Intrinsic After Issue 97 Next Slice
+
+This note records the issue `#99` developer-discovery pass after issue `#97` / PR `#98` proved that disconnecting reported-MTF thresholds from the intrinsic reconnect preserves the issue-93 curve/focus/Quality Loss record but still leaves a residual reported-MTF/readout failure mode.
+
+## Selected Slice
+
+- Selected slice: `issue97_topology_add_readout_only_sensor_aperture_compensation`
+- Summary: Keep issue #97's observed reported-MTF threshold branch and issue #93's downstream-only matched-ori Quality Loss branch unchanged, but restore sensor-aperture MTF compensation only on the reported-MTF/readout path before `compute_mtf_metrics(...)`. Use the PR #30 readout compensation settings (`sensor_aperture_sinc`, `sensor_fill_factor=1.5`) only on that branch, while leaving `compensated_mtf_for_acutance` and `quality_loss_compensated_mtf_for_acutance` on the existing issue-97 topology.
+- Prior narrowing lineage: issue `#95` / PR `#96` selected `issue93_topology_keep_downstream_quality_loss_branch_but_disconnect_reported_mtf_from_intrinsic_reconnect`, and issue `#97` / PR `#98` completed that implementation cleanly enough to expose the next remaining boundary.
+- Remaining gap location: after issue #97, the downstream-only matched-ori Quality Loss win is already preserved and the reported-MTF branch is already disconnected from intrinsic reconnect. The next minimum slice is now the readout-only compensation boundary on the observed branch.
+
+## Comparison Table
+
+| Record | Curve MAE | Focus Acu MAE | Overall QL | MTF20 | MTF30 | MTF50 | Abs Signed Rel | Reading |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| current_best_pr30_branch | 0.03679 | 0.04249 | 1.22150 | 0.03301 | 0.03694 | 0.00933 | 0.08671 | Current best PR30 branch. |
+| issue93_downstream_matched_ori_only_candidate | 0.03280 | 0.02892 | 3.94743 | 0.08577 | 0.01789 | 0.00720 | 0.13994 | Issue-93 bounded positive baseline from PR #94. |
+| issue97_reported_mtf_disconnect_candidate | 0.03280 | 0.02892 | 3.94743 | 0.07448 | 0.07553 | 0.03429 | 0.37688 | Issue-97 reported-MTF disconnect result from PR #98. |
+
+## Residual Gap Evidence
+
+- Issue #97 preserves issue #93 `curve_mae_mean`: `True`
+- Issue #97 preserves issue #93 `focus_preset_acutance_mae_mean`: `True`
+- Issue #97 preserves issue #93 `overall_quality_loss_mae_mean`: `True`
+- Issue #97 improves issue #93 `mtf20`: `True`
+- Issue #97 regresses issue #93 `mtf30`: `True`
+- Issue #97 regresses issue #93 `mtf50`: `True`
+- Issue #97 regresses issue #93 `mtf_abs_signed_rel_mean`: `True`
+
+## Band Direction Evidence
+
+- `low` signed-rel mean: pr30=0.02379, issue93=-0.00365, issue97=-0.09685, `issue97_flips_negative_vs_issue93=False`
+- `mid` signed-rel mean: pr30=0.10965, issue93=0.10027, issue97=-0.28413, `issue97_flips_negative_vs_issue93=True`
+- `high` signed-rel mean: pr30=0.04983, issue93=0.35027, issue97=-0.41914, `issue97_flips_negative_vs_issue93=True`
+- `top` signed-rel mean: pr30=-0.16358, issue93=0.10557, issue97=-0.70739, `issue97_flips_negative_vs_issue93=True`
+
+## Pipeline Delta Between Issue 97 And PR30
+
+- `calibration_file`: issue97='algo/deadleaf_13b10_psd_calibration.json', pr30='algo/deadleaf_13b10_psd_calibration_anchored.json'
+- `high_frequency_guard_start_cpp`: issue97=None, pr30=0.36
+- `intrinsic_full_reference_mode`: issue97='paired_ori_transfer', pr30='none'
+- `intrinsic_full_reference_scope`: issue97='reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only', pr30='replace_all'
+- `intrinsic_full_reference_transfer_mode`: issue97='radial_real_mean', pr30='magnitude_ratio'
+- `matched_ori_anchor_mode`: issue97='all', pr30='acutance_only'
+- `mtf_compensation_mode`: issue97='none', pr30='sensor_aperture_sinc'
+- `sensor_fill_factor`: issue97=1.0, pr30=1.5
+- `texture_support_scale`: issue97=False, pr30=True
+
+## Why The Next Slice Is Readout-Only Sensor-Aperture Compensation
+
+- Issue #97 preserves issue #93's `curve_mae_mean`, `focus_preset_acutance_mae_mean`, and `overall_quality_loss_mae_mean` exactly, so the downstream-only matched-ori Quality Loss branch remains correctly isolated and does not need to be reopened.
+- Issue #97 improves `mtf20` versus issue #93, but it regresses `mtf_abs_signed_rel_mean`, `mtf30`, and `mtf50`, which means the disconnect boundary moved the reported-MTF readout path in the right direction only for the lowest threshold and still left a residual readout-only failure mode.
+- In the raw PSD output, issue #97 flips every signed-relative band negative (`low`, `mid`, `high`, `top`), while issue #93 was positive in `mid`, `high`, and `top`. That is a directional underestimation pattern on the observed readout curve rather than a Quality Loss branch interaction.
+- The current PR #30 branch differs from issue #97 on several readout-adjacent knobs, but `mtf_compensation_mode='sensor_aperture_sinc'` plus `sensor_fill_factor=1.5` is the narrowest one that directly changes readout-curve amplitude before threshold extraction. `high_frequency_guard_start_cpp`, anchored calibration, and `texture_support_scale` are broader upstream or axis-scaling changes.
+- Issue #97 still keeps `readout_smoothing_window=1` and `readout_interpolation='linear'`, matching PR #30 already, so the remaining failure mode is not in the final threshold smoother/interpolator pair.
+
+## Runtime Boundary Evidence
+
+### `algo/benchmark_parity_psd_mtf.py` (425-435, 686-730)
+
+- The PSD driver builds `compensated_mtf` and `compensated_mtf_for_acutance` from the same profile-wide `mtf_compensation_mode` before any intrinsic or matched-ori branching happens.
+- `compute_mtf_metrics(...)` and `band_error_summary(...)` later consume only `readout_scaled_frequencies` plus `compensated_mtf`, so a dedicated readout-only compensation variable would directly isolate the remaining failure mode without touching the acutance branches.
+- Issue #97 already leaves `compensated_mtf` on the observed branch by not overwriting it with `intrinsic_mtf`; the next minimum slice is therefore to change the readout compensation boundary on that observed branch, not to reconnect intrinsic MTF again.
+
+### `algo/benchmark_parity_acutance_quality_loss.py` (741-747, 866-972)
+
+- The acutance/quality-loss driver already keeps `quality_loss_compensated_mtf_for_acutance` separate from the main acutance branch and anchors it later on the downstream-only matched-ori path.
+- Because issue #97 preserves the issue-93 topology here, a readout-only compensation graft in the PSD driver can leave `compensated_mtf_for_acutance` and `quality_loss_compensated_mtf_for_acutance` untouched.
+- This makes readout-only sensor-aperture compensation the smallest implementation that can target the remaining reported-MTF failure mode while preserving issue #97's curve/focus/Quality Loss record.
+
+## Implementation Boundary
+
+- Keep issue #97's `reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only` topology, intrinsic transfer, registration mode, and downstream-only matched-ori Quality Loss branch unchanged.
+- Add one bounded scope or profile family that computes a readout-only `sensor_aperture_sinc` compensation path with `sensor_fill_factor=1.5` for the observed reported-MTF branch consumed by `compute_mtf_metrics(...)` and `band_error_summary(...)`.
+- Leave `compensated_mtf_for_acutance` and `quality_loss_compensated_mtf_for_acutance` on the existing issue-97 branches; do not yet enable anchored calibration, `texture_support_scale`, or `high_frequency_guard_start_cpp`.
+
+## Explicit Non-Changes
+
+- Do not reopen the issue-97 reported-MTF disconnect boundary or route thresholds back through the intrinsic reconnect path.
+- Do not touch the downstream-only matched-ori Quality Loss branch, the main acutance branch, or release-facing PR30 coefficients/configs.
+- Do not bundle anchored calibration, texture-support scaling, and high-frequency guard into the same implementation issue.
+- Do not write new fitted outputs under `20260318_deadleaf_13b10`, `release/deadleaf_13b10_release/data/20260318_deadleaf_13b10`, or `release/deadleaf_13b10_release/config/`.
+
+## Excluded Routes
+
+### `bundle_anchored_calibration_texture_scale_and_high_frequency_guard`
+
+- Route: bundle PR30's anchored calibration, texture-support scaling, and high-frequency guard into issue-97 now
+- Those knobs live in a broader observable-stack family and would change both upstream PSD estimation and the frequency axis together.
+- Issue #99 is a narrowing pass, so it should not jump from one failed readout boundary straight into a three-knob bundle before the single compensation boundary is isolated.
+
+### `reconnect_reported_mtf_to_intrinsic_branch_again`
+
+- Route: route reported-MTF thresholds back through the intrinsic reconnect path
+- Issue #95 / PR #96 already selected the disconnect boundary as the minimum post-issue93 slice, and PR #98 completed that experiment cleanly.
+- Reconnecting thresholds to the intrinsic branch would reopen a path that issue #97 has already bounded, rather than narrowing the remaining failure mode.
+
+### `restart_broader_matched_ori_or_intrinsic_family_search`
+
+- Route: restart broader matched-ori, observable-stack, or intrinsic family search
+- The remaining failure mode is already localized to the reported-MTF/readout path after issue #97; the repo evidence no longer supports reopening whole-family search.
+- Issue #99 must leave engineering with one direct bounded implementation issue, not another unbounded family sweep.
+
+## Acceptance For The Next Implementation Issue
+
+- The new bounded implementation keeps `curve_mae_mean`, `focus_preset_acutance_mae_mean`, and `overall_quality_loss_mae_mean` no worse than issue #97.
+- The same implementation improves `mtf_abs_signed_rel_mean`, `mtf30`, and `mtf50` versus issue #97 while keeping `mtf20` no worse than issue #97.
+- The implementation keeps the downstream-only matched-ori Quality Loss branch isolated from the reported-MTF/readout path.
+- All new fitted outputs remain under `algo/` or `artifacts/`, not under golden/reference roots or release-facing config roots.
+
+## Validation Plan For The Next Implementation Issue
+
+- Run `python3 -m algo.benchmark_parity_psd_mtf ...` on an issue-97-based profile that adds readout-only sensor-aperture compensation, then compare `mtf_abs_signed_rel_mean`, `mtf20`, `mtf30`, and `mtf50` against issue #97, issue #93, and PR #30.
+- Run `python3 -m algo.benchmark_parity_acutance_quality_loss ...` on the same scope to confirm `curve_mae_mean`, `focus_preset_acutance_mae_mean`, and `overall_quality_loss_mae_mean` stay at or below issue #97.
+- Add focused tests that prove only the reported-MTF/readout path receives the new compensation mode while `compensated_mtf_for_acutance` and `quality_loss_compensated_mtf_for_acutance` remain on the existing issue-97 branches.
+
+## Storage Separation
+
+- Golden/reference roots: `20260318_deadleaf_13b10`, `release/deadleaf_13b10_release/data/20260318_deadleaf_13b10`
+- Fitted artifact roots: `algo/*.json`, `artifacts/*.json`
+- Release config roots: `release/deadleaf_13b10_release/config/*.json`
+- Keep this issue's discovery outputs under `docs/` and `artifacts/` only.
+- Do not write new fitted intrinsic profiles, transfer tables, or benchmark outputs under the golden/reference roots.
+- Do not touch release-facing configs until a later bounded implementation clears the current README-facing guardrails.

--- a/tests/test_build_intrinsic_after_issue97_next_slice.py
+++ b/tests/test_build_intrinsic_after_issue97_next_slice.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from algo.build_intrinsic_after_issue97_next_slice import (
+    CURRENT_BEST_LABEL,
+    ISSUE97_LABEL,
+    SELECTED_SLICE_ID,
+    build_payload,
+    render_markdown,
+)
+
+
+class BuildIntrinsicAfterIssue97NextSliceTest(unittest.TestCase):
+    def test_payload_selects_readout_only_sensor_aperture_compensation(self) -> None:
+        payload = build_payload(
+            self.repo_root(),
+            issue95_artifact_path=Path("artifacts/intrinsic_after_issue93_next_slice_benchmark.json"),
+            issue93_artifact_path=Path(
+                "artifacts/intrinsic_phase_retained_downstream_matched_ori_only_benchmark.json"
+            ),
+            issue97_artifact_path=Path(
+                "artifacts/intrinsic_phase_retained_reported_mtf_disconnect_benchmark.json"
+            ),
+            current_best_psd_artifact_path=Path("artifacts/issue77_measured_oecf_psd_benchmark.json"),
+            issue93_psd_artifact_path=Path(
+                "artifacts/issue93_intrinsic_phase_retained_downstream_matched_ori_only_psd_benchmark.json"
+            ),
+            issue97_psd_artifact_path=Path(
+                "artifacts/issue97_intrinsic_phase_retained_reported_mtf_disconnect_psd_benchmark.json"
+            ),
+        )
+
+        self.assertEqual(payload["issue"], 99)
+        self.assertEqual(payload["summary_kind"], "intrinsic_after_issue97_next_slice")
+        self.assertEqual(payload["selected_slice_id"], SELECTED_SLICE_ID)
+        selected = next(
+            row for row in payload["candidate_slices"] if row["slice_id"] == SELECTED_SLICE_ID
+        )
+        self.assertIn("sensor_aperture_sinc", selected["selected_summary"])
+        self.assertIn("compensated_mtf_for_acutance", selected["minimum_implementation_boundary"][2])
+        self.assertTrue(
+            payload["residual_gap_evidence"]["issue97_preserves_issue93_core_record"][
+                "overall_quality_loss_mae_mean"
+            ]
+        )
+        self.assertTrue(
+            payload["residual_gap_evidence"]["issue97_threshold_tradeoff_vs_issue93"][
+                "mtf_abs_signed_rel_regressed"
+            ]
+        )
+        self.assertTrue(
+            payload["residual_gap_evidence"]["issue97_band_signed_rel_direction"]["high"][
+                "issue97_flips_negative_vs_issue93"
+            ]
+        )
+        self.assertEqual(
+            payload["pipeline_delta_summary"]["mtf_compensation_mode"][ISSUE97_LABEL], "none"
+        )
+        self.assertEqual(
+            payload["pipeline_delta_summary"]["mtf_compensation_mode"][CURRENT_BEST_LABEL],
+            "sensor_aperture_sinc",
+        )
+        for path in payload["storage_policy"]["new_fitted_artifact_paths"]:
+            self.assertFalse(path.startswith("20260318_deadleaf_13b10"))
+            self.assertFalse(
+                path.startswith("release/deadleaf_13b10_release/data/20260318_deadleaf_13b10")
+            )
+
+    def test_markdown_mentions_band_sign_flip_and_compensation_slice(self) -> None:
+        payload = build_payload(
+            self.repo_root(),
+            issue95_artifact_path=Path("artifacts/intrinsic_after_issue93_next_slice_benchmark.json"),
+            issue93_artifact_path=Path(
+                "artifacts/intrinsic_phase_retained_downstream_matched_ori_only_benchmark.json"
+            ),
+            issue97_artifact_path=Path(
+                "artifacts/intrinsic_phase_retained_reported_mtf_disconnect_benchmark.json"
+            ),
+            current_best_psd_artifact_path=Path("artifacts/issue77_measured_oecf_psd_benchmark.json"),
+            issue93_psd_artifact_path=Path(
+                "artifacts/issue93_intrinsic_phase_retained_downstream_matched_ori_only_psd_benchmark.json"
+            ),
+            issue97_psd_artifact_path=Path(
+                "artifacts/issue97_intrinsic_phase_retained_reported_mtf_disconnect_psd_benchmark.json"
+            ),
+        )
+        markdown = render_markdown(payload)
+
+        self.assertIn("# Intrinsic After Issue 97 Next Slice", markdown)
+        self.assertIn("## Band Direction Evidence", markdown)
+        self.assertIn("sensor-aperture compensation", markdown)
+        self.assertIn("issue97_flips_negative_vs_issue93", markdown)
+        self.assertIn("high_frequency_guard_start_cpp", markdown)
+        self.assertIn("Storage Separation", markdown)
+
+    @staticmethod
+    def repo_root() -> Path:
+        return Path(__file__).resolve().parents[1]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add the issue-99 discovery builder and focused test
- publish the checked-in issue-99 artifact and note
- narrow the post-issue97 residual reported-MTF/readout failure mode to one next implementation slice

## Findings

The checked-in issue-99 record shows that issue #97 already preserves issue #93's curve, focus-preset Acutance, and overall Quality Loss exactly, but it leaves a residual readout-only failure mode:

- `mtf20` improves versus issue #93
- `mtf30`, `mtf50`, and `mtf_abs_signed_rel_mean` regress versus issue #93
- raw PSD band summaries flip negative across the reported-MTF path, especially in the `high` and `top` bands

That evidence points to one next bounded slice:

- keep the issue-97 topology and downstream-only matched-ori Quality Loss branch unchanged
- add readout-only `sensor_aperture_sinc` compensation with the PR30 fill-factor setting on the reported-MTF path only
- do not yet bundle anchored calibration, texture-support scaling, or high-frequency guard changes

## Validation

- `python3 -m pytest tests/test_build_intrinsic_after_issue97_next_slice.py`
- `python3 -m algo.build_intrinsic_after_issue97_next_slice`

Refs #29
Refs #93
Refs #95
Refs #97
Refs #99
