### PR TITLE
Issue #99: fix discovery artifact provenance

### DIFF
--- a/algo/build_intrinsic_after_issue97_next_slice.py
+++ b/algo/build_intrinsic_after_issue97_next_slice.py
@@ -156,6 +156,19 @@ def select_profile(payload: dict[str, Any], expected_profile_path: str) -> dict[
     )
 
 
+def assert_record_matches(
+    *,
+    source: dict[str, Any],
+    embedded: dict[str, Any],
+    label: str,
+    artifact_label: str,
+) -> None:
+    if source != embedded:
+        raise ValueError(
+            f"{artifact_label} embedded {label} record diverges from the declared source artifact"
+        )
+
+
 def band_signatures(profile: dict[str, Any]) -> dict[str, float]:
     return {
         band: float(summary["signed_rel_mean"])
@@ -187,10 +200,29 @@ def build_payload(
     issue93_psd_artifact = load_json(resolve_path(repo_root, issue93_psd_artifact_path))
     issue97_psd_artifact = load_json(resolve_path(repo_root, issue97_psd_artifact_path))
 
+    issue93_source_current_best = issue93_artifact["profiles"][CURRENT_BEST_LABEL]
+    issue93_source_issue93 = issue93_artifact["profiles"][ISSUE93_LABEL]
+    issue97_embedded_current_best = issue97_artifact["profiles"][CURRENT_BEST_LABEL]
+    issue97_embedded_issue93 = issue97_artifact["profiles"][ISSUE93_LABEL]
+    issue97_record = issue97_artifact["profiles"][ISSUE97_LABEL]
+
+    assert_record_matches(
+        source=issue93_source_current_best,
+        embedded=issue97_embedded_current_best,
+        label=CURRENT_BEST_LABEL,
+        artifact_label="issue97_artifact",
+    )
+    assert_record_matches(
+        source=issue93_source_issue93,
+        embedded=issue97_embedded_issue93,
+        label=ISSUE93_LABEL,
+        artifact_label="issue97_artifact",
+    )
+
     comparison_records = {
-        CURRENT_BEST_LABEL: issue97_artifact["profiles"][CURRENT_BEST_LABEL],
-        ISSUE93_LABEL: issue97_artifact["profiles"][ISSUE93_LABEL],
-        ISSUE97_LABEL: issue97_artifact["profiles"][ISSUE97_LABEL],
+        CURRENT_BEST_LABEL: issue93_source_current_best,
+        ISSUE93_LABEL: issue93_source_issue93,
+        ISSUE97_LABEL: issue97_record,
     }
     current_best = comparison_records[CURRENT_BEST_LABEL]
     issue93 = comparison_records[ISSUE93_LABEL]

--- a/tests/test_build_intrinsic_after_issue97_next_slice.py
+++ b/tests/test_build_intrinsic_after_issue97_next_slice.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -62,6 +64,12 @@ class BuildIntrinsicAfterIssue97NextSliceTest(unittest.TestCase):
             payload["pipeline_delta_summary"]["mtf_compensation_mode"][CURRENT_BEST_LABEL],
             "sensor_aperture_sinc",
         )
+        self.assertEqual(
+            payload["comparison_records"]["issue93_downstream_matched_ori_only_candidate"][
+                "mtf_abs_signed_rel_mean"
+            ],
+            0.13993778559089318,
+        )
         for path in payload["storage_policy"]["new_fitted_artifact_paths"]:
             self.assertFalse(path.startswith("20260318_deadleaf_13b10"))
             self.assertFalse(
@@ -94,6 +102,43 @@ class BuildIntrinsicAfterIssue97NextSliceTest(unittest.TestCase):
         self.assertIn("issue97_flips_negative_vs_issue93", markdown)
         self.assertIn("high_frequency_guard_start_cpp", markdown)
         self.assertIn("Storage Separation", markdown)
+
+    def test_build_payload_fails_when_issue97_embedded_issue93_copy_diverges(self) -> None:
+        repo_root = self.repo_root()
+        source_artifact = repo_root / "artifacts/intrinsic_phase_retained_downstream_matched_ori_only_benchmark.json"
+        diverged = json.loads(source_artifact.read_text(encoding="utf-8"))
+        diverged["profiles"]["issue93_downstream_matched_ori_only_candidate"][
+            "mtf_abs_signed_rel_mean"
+        ] = 9.999
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            diverged_path = Path(tmpdir) / "issue93_diverged.json"
+            diverged_path.write_text(
+                json.dumps(diverged, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+            )
+
+            with self.assertRaisesRegex(
+                ValueError, "embedded issue93_downstream_matched_ori_only_candidate record diverges"
+            ):
+                build_payload(
+                    repo_root,
+                    issue95_artifact_path=Path(
+                        "artifacts/intrinsic_after_issue93_next_slice_benchmark.json"
+                    ),
+                    issue93_artifact_path=diverged_path,
+                    issue97_artifact_path=Path(
+                        "artifacts/intrinsic_phase_retained_reported_mtf_disconnect_benchmark.json"
+                    ),
+                    current_best_psd_artifact_path=Path(
+                        "artifacts/issue77_measured_oecf_psd_benchmark.json"
+                    ),
+                    issue93_psd_artifact_path=Path(
+                        "artifacts/issue93_intrinsic_phase_retained_downstream_matched_ori_only_psd_benchmark.json"
+                    ),
+                    issue97_psd_artifact_path=Path(
+                        "artifacts/issue97_intrinsic_phase_retained_reported_mtf_disconnect_psd_benchmark.json"
+                    ),
+                )
 
     @staticmethod
     def repo_root() -> Path:


### PR DESCRIPTION
## Summary

- wire the issue-99 discovery builder to the declared issue-93 source artifact
- fail fast if issue-97's embedded historical copy diverges from that declared source
- add a regression test that proves divergence is caught

## Why

PR #100 merged the issue-99 narrowing record, but review identified a provenance hole:

- `comparison_records` were rebuilt from `issue97_artifact["profiles"]`
- the declared issue-93 source artifact was loaded but not actually used as the source of truth
- a diverged issue-93 artifact copy would not have changed or invalidated the payload

This follow-up keeps the selected issue-99 slice unchanged, but makes the discovery artifact source-correct and regression-tested.

## Validation

- `python3 -m pytest tests/test_build_intrinsic_after_issue97_next_slice.py`
- `python3 -m algo.build_intrinsic_after_issue97_next_slice`

Refs #29
Refs #93
Refs #95
Refs #97
Refs #99
Follow-up to #100
