### PR TITLE
Issue #102: preserve readout markers in summary artifact

### DIFF
--- a/algo/build_intrinsic_phase_retained_readout_only_sensor_comp_followup.py
+++ b/algo/build_intrinsic_phase_retained_readout_only_sensor_comp_followup.py
@@ -90,10 +90,14 @@ def summarize_profile(
     acutance_profile = select_profile(acutance_payload, profile_path)
     psd_overall = psd_profile["overall"]
     acutance_overall = acutance_profile["overall"]
+    analysis_pipeline = dict(acutance_profile["analysis_pipeline"])
+    for key in ("readout_mtf_compensation_mode", "readout_sensor_fill_factor"):
+        if key in psd_profile["analysis_pipeline"]:
+            analysis_pipeline[key] = psd_profile["analysis_pipeline"][key]
     return {
         "label": label,
         "profile_path": profile_path,
-        "analysis_pipeline": acutance_profile["analysis_pipeline"],
+        "analysis_pipeline": analysis_pipeline,
         "curve_mae_mean": float(acutance_overall["curve_mae_mean"]),
         "focus_preset_acutance_mae_mean": float(acutance_overall["acutance_focus_preset_mae_mean"]),
         "overall_quality_loss_mae_mean": float(acutance_overall["overall_quality_loss_mae_mean"]),

--- a/artifacts/intrinsic_phase_retained_readout_only_sensor_comp_benchmark.json
+++ b/artifacts/intrinsic_phase_retained_readout_only_sensor_comp_benchmark.json
@@ -522,6 +522,8 @@
           }
         },
         "readout_interpolation": "linear",
+        "readout_mtf_compensation_mode": "sensor_aperture_sinc",
+        "readout_sensor_fill_factor": 1.5,
         "readout_smoothing_window": 1,
         "roi_source": "reference_refined",
         "sensor_fill_factor": 1.0,

--- a/tests/test_build_intrinsic_phase_retained_readout_only_sensor_comp_followup.py
+++ b/tests/test_build_intrinsic_phase_retained_readout_only_sensor_comp_followup.py
@@ -37,6 +37,14 @@ class BuildIntrinsicPhaseRetainedReadoutOnlySensorCompFollowupTest(unittest.Test
         self.assertIn("sensor_aperture_sinc", payload["implementation_change"]["change"])
         self.assertIn("mtf30_improved_vs_issue97", payload["acceptance"])
         self.assertIn("mtf50_improved_vs_issue97", payload["acceptance"])
+        self.assertEqual(
+            payload["profiles"][CANDIDATE_LABEL]["analysis_pipeline"]["readout_mtf_compensation_mode"],
+            "sensor_aperture_sinc",
+        )
+        self.assertEqual(
+            payload["profiles"][CANDIDATE_LABEL]["analysis_pipeline"]["readout_sensor_fill_factor"],
+            1.5,
+        )
         self.assertNotEqual(
             payload["profiles"][CANDIDATE_LABEL]["profile_path"],
             payload["profiles"][ISSUE97_LABEL]["profile_path"],


### PR DESCRIPTION
## Summary
- preserve the issue-102 readout-only compensation markers in the published summary candidate by merging the PSD-side readout fields into the summary artifact `analysis_pipeline`
- add a regression test that fails if the summary candidate drops `readout_mtf_compensation_mode` or `readout_sensor_fill_factor`
- regenerate the checked-in issue-102 summary artifact after the provenance fix

## Validation
- `python3 -m pytest tests/test_build_intrinsic_phase_retained_readout_only_sensor_comp_followup.py`
- `python3 -m algo.build_intrinsic_phase_retained_readout_only_sensor_comp_followup`

## Result
- the machine-readable issue-102 summary now exposes `readout_mtf_compensation_mode = "sensor_aperture_sinc"` and `readout_sensor_fill_factor = 1.5` for the candidate profile
- no benchmark result changed; this fixes artifact provenance only

Refs #29
Refs #93
Refs #95
Refs #97
Refs #99
Refs #102
Follow-up to #103
