### PR TITLE
Issue #105: narrow the post-issue102 PR30 gap

### DIFF
--- a/algo/build_intrinsic_after_issue102_next_slice.py
+++ b/algo/build_intrinsic_after_issue102_next_slice.py
@@ -1,0 +1,460 @@
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+
+SUMMARY_KIND = "intrinsic_after_issue102_next_slice"
+CURRENT_BEST_LABEL = "current_best_pr30_branch"
+ISSUE93_LABEL = "issue93_downstream_matched_ori_only_candidate"
+ISSUE97_LABEL = "issue97_reported_mtf_disconnect_candidate"
+ISSUE102_LABEL = "issue102_readout_only_sensor_comp_candidate"
+SELECTED_SLICE_ID = "issue102_topology_graft_pr30_observable_stack_onto_observed_branches"
+GOLDEN_REFERENCE_ROOTS = (
+    "20260318_deadleaf_13b10",
+    "release/deadleaf_13b10_release/data/20260318_deadleaf_13b10",
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build the issue-105 intrinsic post-issue102 next-slice record."
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Repository root. Defaults to the parent of this script.",
+    )
+    parser.add_argument(
+        "--issue99-artifact",
+        type=Path,
+        default=Path("artifacts/intrinsic_after_issue97_next_slice_benchmark.json"),
+        help="Repo-relative issue-99 discovery artifact path.",
+    )
+    parser.add_argument(
+        "--issue102-artifact",
+        type=Path,
+        default=Path("artifacts/intrinsic_phase_retained_readout_only_sensor_comp_benchmark.json"),
+        help="Repo-relative issue-102 summary artifact path.",
+    )
+    parser.add_argument(
+        "--output-json",
+        type=Path,
+        default=Path("artifacts/intrinsic_after_issue102_next_slice_benchmark.json"),
+        help="Repo-relative output path for the machine-readable artifact.",
+    )
+    parser.add_argument(
+        "--output-md",
+        type=Path,
+        default=Path("docs/intrinsic_after_issue102_next_slice.md"),
+        help="Repo-relative output path for the Markdown note.",
+    )
+    return parser
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def resolve_path(repo_root: Path, path: Path) -> Path:
+    return path if path.is_absolute() else repo_root / path
+
+
+def format_metric(value: float) -> str:
+    return f"{value:.5f}"
+
+
+def is_close(a: float, b: float) -> bool:
+    return math.isclose(a, b, rel_tol=0.0, abs_tol=1e-12)
+
+
+def delta_map(candidate: dict[str, Any], baseline: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "curve_mae_mean": float(candidate["curve_mae_mean"] - baseline["curve_mae_mean"]),
+        "focus_preset_acutance_mae_mean": float(
+            candidate["focus_preset_acutance_mae_mean"]
+            - baseline["focus_preset_acutance_mae_mean"]
+        ),
+        "overall_quality_loss_mae_mean": float(
+            candidate["overall_quality_loss_mae_mean"] - baseline["overall_quality_loss_mae_mean"]
+        ),
+        "mtf_abs_signed_rel_mean": float(
+            candidate["mtf_abs_signed_rel_mean"] - baseline["mtf_abs_signed_rel_mean"]
+        ),
+        "mtf_threshold_mae": {
+            key: float(candidate["mtf_threshold_mae"][key] - baseline["mtf_threshold_mae"][key])
+            for key in ("mtf20", "mtf30", "mtf50")
+        },
+    }
+
+
+def pipeline_delta(candidate: dict[str, Any], baseline: dict[str, Any]) -> dict[str, Any]:
+    candidate_pipeline = candidate["analysis_pipeline"]
+    baseline_pipeline = baseline["analysis_pipeline"]
+    keys = [
+        "calibration_file",
+        "high_frequency_guard_start_cpp",
+        "intrinsic_full_reference_mode",
+        "intrinsic_full_reference_scope",
+        "intrinsic_full_reference_transfer_mode",
+        "matched_ori_anchor_mode",
+        "mtf_compensation_mode",
+        "readout_mtf_compensation_mode",
+        "sensor_fill_factor",
+        "readout_sensor_fill_factor",
+        "texture_support_scale",
+    ]
+    return {
+        key: {
+            ISSUE102_LABEL: candidate_pipeline.get(key),
+            CURRENT_BEST_LABEL: baseline_pipeline.get(key),
+        }
+        for key in keys
+        if candidate_pipeline.get(key) != baseline_pipeline.get(key)
+    }
+
+
+def assert_storage_separation(payload: dict[str, Any]) -> None:
+    for path in payload["storage_policy"]["new_fitted_artifact_paths"]:
+        for root in GOLDEN_REFERENCE_ROOTS:
+            if path.startswith(root):
+                raise ValueError(f"Path {path} leaks into golden/reference root {root}")
+
+
+def build_payload(
+    repo_root: Path,
+    *,
+    issue99_artifact_path: Path,
+    issue102_artifact_path: Path,
+) -> dict[str, Any]:
+    issue99_artifact = load_json(resolve_path(repo_root, issue99_artifact_path))
+    issue102_artifact = load_json(resolve_path(repo_root, issue102_artifact_path))
+
+    comparison_records = {
+        CURRENT_BEST_LABEL: issue102_artifact["profiles"][CURRENT_BEST_LABEL],
+        ISSUE93_LABEL: issue102_artifact["profiles"][ISSUE93_LABEL],
+        ISSUE97_LABEL: issue102_artifact["profiles"][ISSUE97_LABEL],
+        ISSUE102_LABEL: issue102_artifact["profiles"][ISSUE102_LABEL],
+    }
+    current_best = comparison_records[CURRENT_BEST_LABEL]
+    issue93 = comparison_records[ISSUE93_LABEL]
+    issue97 = comparison_records[ISSUE97_LABEL]
+    issue102 = comparison_records[ISSUE102_LABEL]
+
+    issue102_vs_issue97 = delta_map(issue102, issue97)
+    issue102_vs_issue93 = delta_map(issue102, issue93)
+    issue102_vs_current_best = delta_map(issue102, current_best)
+
+    residual_gap_evidence = {
+        "issue102_preserves_issue97_core_record": {
+            "curve_mae_mean": is_close(issue102["curve_mae_mean"], issue97["curve_mae_mean"]),
+            "focus_preset_acutance_mae_mean": is_close(
+                issue102["focus_preset_acutance_mae_mean"],
+                issue97["focus_preset_acutance_mae_mean"],
+            ),
+            "overall_quality_loss_mae_mean": is_close(
+                issue102["overall_quality_loss_mae_mean"],
+                issue97["overall_quality_loss_mae_mean"],
+            ),
+            "delta": {
+                "curve_mae_mean": issue102_vs_issue97["curve_mae_mean"],
+                "focus_preset_acutance_mae_mean": issue102_vs_issue97[
+                    "focus_preset_acutance_mae_mean"
+                ],
+                "overall_quality_loss_mae_mean": issue102_vs_issue97[
+                    "overall_quality_loss_mae_mean"
+                ],
+            },
+        },
+        "issue102_readout_improves_but_does_not_close_pr30_gap": {
+            "mtf_abs_signed_rel_improved_vs_issue97": (
+                issue102["mtf_abs_signed_rel_mean"] < issue97["mtf_abs_signed_rel_mean"]
+            ),
+            "mtf20_beats_current_best_pr30": (
+                issue102["mtf_threshold_mae"]["mtf20"] < current_best["mtf_threshold_mae"]["mtf20"]
+            ),
+            "mtf30_still_worse_than_current_best_pr30": (
+                issue102["mtf_threshold_mae"]["mtf30"] > current_best["mtf_threshold_mae"]["mtf30"]
+            ),
+            "mtf50_still_worse_than_current_best_pr30": (
+                issue102["mtf_threshold_mae"]["mtf50"] > current_best["mtf_threshold_mae"]["mtf50"]
+            ),
+            "mtf_abs_signed_rel_still_worse_than_current_best_pr30": (
+                issue102["mtf_abs_signed_rel_mean"] > current_best["mtf_abs_signed_rel_mean"]
+            ),
+            "delta_vs_issue97": {
+                "mtf20": issue102_vs_issue97["mtf_threshold_mae"]["mtf20"],
+                "mtf30": issue102_vs_issue97["mtf_threshold_mae"]["mtf30"],
+                "mtf50": issue102_vs_issue97["mtf_threshold_mae"]["mtf50"],
+                "mtf_abs_signed_rel_mean": issue102_vs_issue97["mtf_abs_signed_rel_mean"],
+            },
+            "delta_vs_current_best_pr30": {
+                "mtf20": issue102_vs_current_best["mtf_threshold_mae"]["mtf20"],
+                "mtf30": issue102_vs_current_best["mtf_threshold_mae"]["mtf30"],
+                "mtf50": issue102_vs_current_best["mtf_threshold_mae"]["mtf50"],
+                "mtf_abs_signed_rel_mean": issue102_vs_current_best["mtf_abs_signed_rel_mean"],
+            },
+        },
+        "issue93_issue97_issue102_quality_loss_record_is_invariant": {
+            "issue93_equals_issue97": is_close(
+                issue93["overall_quality_loss_mae_mean"],
+                issue97["overall_quality_loss_mae_mean"],
+            ),
+            "issue97_equals_issue102": is_close(
+                issue97["overall_quality_loss_mae_mean"],
+                issue102["overall_quality_loss_mae_mean"],
+            ),
+            "issue93_equals_issue102": is_close(
+                issue93["overall_quality_loss_mae_mean"],
+                issue102["overall_quality_loss_mae_mean"],
+            ),
+            "delta_issue102_vs_current_best_pr30": issue102_vs_current_best[
+                "overall_quality_loss_mae_mean"
+            ],
+        },
+        "issue102_keeps_intrinsic_main_branch_better_than_pr30": {
+            "curve_mae_mean_better_than_current_best_pr30": (
+                issue102["curve_mae_mean"] < current_best["curve_mae_mean"]
+            ),
+            "focus_preset_acutance_mae_mean_better_than_current_best_pr30": (
+                issue102["focus_preset_acutance_mae_mean"]
+                < current_best["focus_preset_acutance_mae_mean"]
+            ),
+            "delta_vs_current_best_pr30": {
+                "curve_mae_mean": issue102_vs_current_best["curve_mae_mean"],
+                "focus_preset_acutance_mae_mean": issue102_vs_current_best[
+                    "focus_preset_acutance_mae_mean"
+                ],
+            },
+        },
+    }
+
+    candidate_slices = [
+        {
+            "slice_id": SELECTED_SLICE_ID,
+            "label": "keep the issue-102 intrinsic main branch but graft the PR30 observable-stack bundle onto the observed reported-MTF and downstream Quality Loss branches",
+            "decision": "advance",
+            "selected_summary": (
+                "Keep issue #102's intrinsic main-acutance branch and readout-only sensor-aperture "
+                "compensation record intact, but move the observed-branch consumers that still lag "
+                "PR #30 onto one bounded PR30-style observable-stack bundle: anchored calibration, "
+                "`texture_support_scale`, and `high_frequency_guard_start_cpp=0.36` for the "
+                "reported-MTF/readout path and the downstream Quality Loss branch only."
+            ),
+            "repo_evidence": [
+                "Issue #102 preserves issue #97 exactly on `curve_mae_mean`, `focus_preset_acutance_mae_mean`, and `overall_quality_loss_mae_mean`, so the issue-97 intrinsic main branch is no longer the unstable part of the stack.",
+                "Issue #102 improves every tracked readout metric versus issue #97, which proves the single-knob readout compensation boundary was real, but the branch still trails PR #30 on `mtf_abs_signed_rel_mean`, `mtf30`, and `mtf50`.",
+                "Issue #102's `mtf20` already beats PR #30 while `mtf30` and `mtf50` still lag, so the remaining readout gap is no longer a uniform amplitude miss. It now looks like an upstream observable-shape / high-frequency-tail boundary.",
+                "The downstream Quality Loss record is invariant across issue #93, issue #97, and issue #102 at `overall_quality_loss_mae_mean = 3.94743`, while PR #30 is much lower at `1.22150`. That proves the residual large gap does not live in the issue-102 readout-only compensation change and still sits on the observed/downstream branch family.",
+                "Compared with PR #30, issue #102 still differs on the observed-branch observable-stack knobs `calibration_file`, `texture_support_scale`, and `high_frequency_guard_start_cpp`, while the intrinsic-topology differences are the same knobs that currently preserve issue-102's stronger curve and focus-preset Acutance record."
+            ],
+            "comparison_basis": {
+                "pr30_issue102_delta": issue102_vs_current_best,
+                "pr98_issue97_vs_current_best_pr30": issue102_artifact["comparisons"][
+                    "candidate_vs_current_best_pr30"
+                ],
+                "pr100_selected_slice_id": issue99_artifact["selected_slice_id"],
+                "pr100_selected_summary": issue99_artifact["selected_summary"],
+                "pr103_issue102_vs_issue97": issue102_artifact["comparisons"][
+                    "candidate_vs_issue97"
+                ],
+                "pr104_result": (
+                    "PR #104 repaired issue-102 summary-artifact provenance only and did not change "
+                    "the benchmark result, so the post-issue102 narrowing should use the same "
+                    "metrics published by PR #103."
+                ),
+            },
+            "minimum_implementation_boundary": [
+                "Keep issue #102's intrinsic main-acutance branch, `intrinsic_full_reference_scope`, and readout-only sensor-aperture compensation (`sensor_aperture_sinc`) unchanged.",
+                "Introduce one observed-branch bundle for the reported-MTF/readout path and the downstream Quality Loss branch that uses PR #30's anchored calibration file, `texture_support_scale=True`, and `high_frequency_guard_start_cpp=0.36`.",
+                "Do not move the main acutance branch back to PR #30's non-intrinsic topology, and do not promote release-facing PR30 configs directly."
+            ],
+            "explicitly_do_not_change": [
+                "Do not drop the issue-102 intrinsic main branch back to PR #30's non-intrinsic observable stack.",
+                "Do not reopen broader observable-stack, matched-ori, or intrinsic family search outside the bounded observed-branch bundle.",
+                "Do not retune only the readout-only sensor-aperture compensation again as a single-knob follow-up.",
+                "Do not write new fitted outputs under `20260318_deadleaf_13b10`, `release/deadleaf_13b10_release/data/20260318_deadleaf_13b10`, or `release/deadleaf_13b10_release/config/`."
+            ],
+            "validation_plan_for_next_issue": [
+                "Run `python3 -m algo.benchmark_parity_psd_mtf ...` on an issue-102-based profile that keeps readout-only sensor-aperture compensation but adds the PR30 observable-stack bundle on the observed readout branch, then compare `mtf_abs_signed_rel_mean`, `mtf20`, `mtf30`, and `mtf50` against issue #102 and PR #30.",
+                "Run `python3 -m algo.benchmark_parity_acutance_quality_loss ...` on the same bounded scope to confirm `curve_mae_mean` and `focus_preset_acutance_mae_mean` stay no worse than issue #102 while `overall_quality_loss_mae_mean` improves materially.",
+                "Add focused tests that prove anchored calibration, `texture_support_scale`, and `high_frequency_guard_start_cpp` affect only the observed reported-MTF / downstream Quality Loss consumers and not the issue-102 intrinsic main-acutance branch."
+            ],
+        },
+        {
+            "slice_id": "retune_readout_only_sensor_aperture_compensation_again",
+            "label": "keep tuning only the readout-only sensor-aperture compensation parameters",
+            "decision": "exclude",
+            "exclusion_reasons": [
+                "Issue #102 already improved every tracked readout metric versus issue #97 and even beat PR #30 on `mtf20`, so the remaining readout gap is no longer the same single-knob amplitude problem.",
+                "Overall Quality Loss never moved across issue #93, issue #97, and issue #102, so another readout-only compensation retune would not address the largest residual PR30 gap."
+            ],
+        },
+        {
+            "slice_id": "drop_intrinsic_main_branch_and_rejoin_whole_pr30_stack",
+            "label": "discard the issue-102 intrinsic main branch and move the whole stack back toward PR #30",
+            "decision": "exclude",
+            "exclusion_reasons": [
+                "Issue #102 still beats PR #30 on `curve_mae_mean` and `focus_preset_acutance_mae_mean`, so collapsing the whole topology back toward PR #30 would throw away the strongest part of the current bounded record.",
+                "Issue #105 is supposed to leave one direct bounded implementation slice, not reopen the full observable-stack replacement path."
+            ],
+        },
+        {
+            "slice_id": "restart_broader_observable_stack_or_intrinsic_family_search",
+            "label": "restart broader observable-stack, matched-ori, or intrinsic family search",
+            "decision": "exclude",
+            "exclusion_reasons": [
+                "The remaining issue-102 residuals are already localized: the intrinsic main branch is stable, the readout-only compensation boundary is proven, and the unchanged downstream Quality Loss record points at the observed-branch bundle.",
+                "Issue #105 is a developer-discovery narrowing pass and must hand engineering one direct next implementation issue rather than another unbounded search."
+            ],
+        },
+    ]
+
+    payload = {
+        "issue": 105,
+        "summary_kind": SUMMARY_KIND,
+        "selected_slice_id": SELECTED_SLICE_ID,
+        "selected_summary": candidate_slices[0]["selected_summary"],
+        "comparison_records": comparison_records,
+        "residual_gap_evidence": residual_gap_evidence,
+        "pipeline_delta_summary": pipeline_delta(issue102, current_best),
+        "candidate_slices": candidate_slices,
+        "source_artifacts": {
+            "issue99_artifact": str(issue99_artifact_path),
+            "issue102_artifact": str(issue102_artifact_path),
+            "comparison_basis_refs": ["pr-30", "pr-98", "pr-100", "pr-103", "pr-104"],
+        },
+        "storage_policy": {
+            "golden_reference_roots": list(GOLDEN_REFERENCE_ROOTS),
+            "new_fitted_artifact_paths": [
+                "artifacts/intrinsic_after_issue102_next_slice_benchmark.json",
+            ],
+            "rules": [
+                "Keep issue-105 discovery outputs under `docs/` and `artifacts/` only.",
+                "Do not write fitted profiles, transfer tables, or generated outputs under the golden/reference roots.",
+                "Do not touch release-facing configs in this issue.",
+            ],
+        },
+    }
+    assert_storage_separation(payload)
+    return payload
+
+
+def render_markdown(payload: dict[str, Any]) -> str:
+    records = payload["comparison_records"]
+    current_best = records[CURRENT_BEST_LABEL]
+    issue97 = records[ISSUE97_LABEL]
+    issue102 = records[ISSUE102_LABEL]
+    selected = next(
+        row for row in payload["candidate_slices"] if row["slice_id"] == payload["selected_slice_id"]
+    )
+
+    lines = [
+        "# Intrinsic After Issue 102 Next Slice",
+        "",
+        "This note records the issue `#105` developer-discovery pass after issue `#102` / PR `#103` / PR `#104` proved that readout-only sensor-aperture compensation is a real bounded improvement but still leaves a residual gap versus PR `#30`.",
+        "",
+        "## Selected Slice",
+        "",
+        f"- Selected slice: `{payload['selected_slice_id']}`",
+        f"- Summary: {payload['selected_summary']}",
+        "- Prior narrowing lineage: issue `#99` / PR `#100` / PR `#101` selected the readout-only compensation slice, and issue `#102` / PR `#103` / PR `#104` completed it cleanly enough to expose the next remaining boundary.",
+        "- Remaining gap location: after issue `#102`, the intrinsic main branch and the readout-only compensation boundary are both bounded. The large residual gap now sits on the observed-branch observable stack that still feeds reported-MTF and downstream Quality Loss differently from PR `#30`.",
+        "",
+        "## Comparison Table",
+        "",
+        "| Record | Curve MAE | Focus Acu MAE | Overall QL | MTF20 | MTF30 | MTF50 | Abs Signed Rel | Reading |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+        f"| {CURRENT_BEST_LABEL} | {format_metric(current_best['curve_mae_mean'])} | {format_metric(current_best['focus_preset_acutance_mae_mean'])} | {format_metric(current_best['overall_quality_loss_mae_mean'])} | {format_metric(current_best['mtf_threshold_mae']['mtf20'])} | {format_metric(current_best['mtf_threshold_mae']['mtf30'])} | {format_metric(current_best['mtf_threshold_mae']['mtf50'])} | {format_metric(current_best['mtf_abs_signed_rel_mean'])} | Current best PR30 branch. |",
+        f"| {ISSUE97_LABEL} | {format_metric(issue97['curve_mae_mean'])} | {format_metric(issue97['focus_preset_acutance_mae_mean'])} | {format_metric(issue97['overall_quality_loss_mae_mean'])} | {format_metric(issue97['mtf_threshold_mae']['mtf20'])} | {format_metric(issue97['mtf_threshold_mae']['mtf30'])} | {format_metric(issue97['mtf_threshold_mae']['mtf50'])} | {format_metric(issue97['mtf_abs_signed_rel_mean'])} | Issue-97 mixed-negative disconnect result from PR #98. |",
+        f"| {ISSUE102_LABEL} | {format_metric(issue102['curve_mae_mean'])} | {format_metric(issue102['focus_preset_acutance_mae_mean'])} | {format_metric(issue102['overall_quality_loss_mae_mean'])} | {format_metric(issue102['mtf_threshold_mae']['mtf20'])} | {format_metric(issue102['mtf_threshold_mae']['mtf30'])} | {format_metric(issue102['mtf_threshold_mae']['mtf50'])} | {format_metric(issue102['mtf_abs_signed_rel_mean'])} | Issue-102 bounded positive result from PR #103/#104. |",
+        "",
+        "## Residual Gap Evidence",
+        "",
+        f"- Issue #102 preserves issue #97 `curve_mae_mean`: `{payload['residual_gap_evidence']['issue102_preserves_issue97_core_record']['curve_mae_mean']}`",
+        f"- Issue #102 preserves issue #97 `focus_preset_acutance_mae_mean`: `{payload['residual_gap_evidence']['issue102_preserves_issue97_core_record']['focus_preset_acutance_mae_mean']}`",
+        f"- Issue #102 preserves issue #97 `overall_quality_loss_mae_mean`: `{payload['residual_gap_evidence']['issue102_preserves_issue97_core_record']['overall_quality_loss_mae_mean']}`",
+        f"- Issue #102 improves `mtf_abs_signed_rel_mean` versus issue #97: `{payload['residual_gap_evidence']['issue102_readout_improves_but_does_not_close_pr30_gap']['mtf_abs_signed_rel_improved_vs_issue97']}`",
+        f"- Issue #102 still trails PR #30 on `mtf30`: `{payload['residual_gap_evidence']['issue102_readout_improves_but_does_not_close_pr30_gap']['mtf30_still_worse_than_current_best_pr30']}`",
+        f"- Issue #102 still trails PR #30 on `mtf50`: `{payload['residual_gap_evidence']['issue102_readout_improves_but_does_not_close_pr30_gap']['mtf50_still_worse_than_current_best_pr30']}`",
+        f"- Issue #102 still trails PR #30 on `mtf_abs_signed_rel_mean`: `{payload['residual_gap_evidence']['issue102_readout_improves_but_does_not_close_pr30_gap']['mtf_abs_signed_rel_still_worse_than_current_best_pr30']}`",
+        f"- Issue #102 already beats PR #30 on `mtf20`: `{payload['residual_gap_evidence']['issue102_readout_improves_but_does_not_close_pr30_gap']['mtf20_beats_current_best_pr30']}`",
+        f"- Issue #93 / #97 / #102 keep the same downstream Quality Loss record: `{payload['residual_gap_evidence']['issue93_issue97_issue102_quality_loss_record_is_invariant']['issue93_equals_issue102']}`",
+        "",
+        "## Pipeline Delta Summary",
+        "",
+    ]
+    for key, delta in payload["pipeline_delta_summary"].items():
+        lines.append(
+            f"- `{key}`: issue102={delta[ISSUE102_LABEL]!r}, pr30={delta[CURRENT_BEST_LABEL]!r}"
+        )
+    lines.extend(
+        [
+            "",
+            "## Why The Next Slice Is The Observed-Branch PR30 Observable Stack",
+            "",
+            "- Issue #102 proved the readout-only sensor-aperture compensation boundary and already improved all tracked readout metrics versus issue #97, so another single-knob readout retune is no longer the highest-signal follow-up.",
+            "- `overall_quality_loss_mae_mean` never changed across issue `#93`, issue `#97`, and issue `#102`, which means the residual large PR30 gap still sits on the downstream observed-branch family rather than the issue-102 intrinsic main branch.",
+            "- The remaining pipeline deltas that can hit both reported-MTF and downstream Quality Loss without discarding the issue-102 intrinsic main branch are PR30's anchored calibration, `texture_support_scale`, and `high_frequency_guard_start_cpp` on the observed branch.",
+            "- PR #104 changed only summary-artifact provenance, so the post-issue102 narrowing should treat PR #103 and PR #104 as the same benchmark record.",
+            "",
+            "## Selected Implementation Boundary",
+            "",
+        ]
+    )
+    for row in selected["minimum_implementation_boundary"]:
+        lines.append(f"- {row}")
+    lines.extend(["", "## Explicit Non-Changes", ""])
+    for row in selected["explicitly_do_not_change"]:
+        lines.append(f"- {row}")
+    lines.extend(["", "## Excluded Routes", ""])
+    for row in payload["candidate_slices"]:
+        if row["decision"] == "exclude":
+            lines.append(f"### `{row['slice_id']}`")
+            lines.append("")
+            lines.append(f"- Route: {row['label']}")
+            for reason in row["exclusion_reasons"]:
+                lines.append(f"- {reason}")
+            lines.append("")
+    lines.extend(["## Validation Plan For The Next Implementation Issue", ""])
+    for row in selected["validation_plan_for_next_issue"]:
+        lines.append(f"- {row}")
+    lines.extend(
+        [
+            "",
+            "## Storage Separation",
+            "",
+            f"- Golden/reference roots: `{GOLDEN_REFERENCE_ROOTS[0]}`, `{GOLDEN_REFERENCE_ROOTS[1]}`",
+            "- Discovery outputs for this issue stay under `docs/` and `artifacts/` only.",
+            "- Do not write new fitted profiles, transfer tables, or benchmark outputs under the golden/reference roots or release-facing config roots.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    repo_root = args.repo_root.resolve()
+    payload = build_payload(
+        repo_root,
+        issue99_artifact_path=args.issue99_artifact,
+        issue102_artifact_path=args.issue102_artifact,
+    )
+    output_json = resolve_path(repo_root, args.output_json)
+    output_md = resolve_path(repo_root, args.output_md)
+    write_text(output_json, json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    write_text(output_md, render_markdown(payload))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/artifacts/intrinsic_after_issue102_next_slice_benchmark.json
+++ b/artifacts/intrinsic_after_issue102_next_slice_benchmark.json
@@ -1,0 +1,1173 @@
+{
+  "candidate_slices": [
+    {
+      "comparison_basis": {
+        "pr100_selected_slice_id": "issue97_topology_add_readout_only_sensor_aperture_compensation",
+        "pr100_selected_summary": "Keep issue #97's observed reported-MTF threshold branch and issue #93's downstream-only matched-ori Quality Loss branch unchanged, but restore sensor-aperture MTF compensation only on the reported-MTF/readout path before `compute_mtf_metrics(...)`. Use the PR #30 readout compensation settings (`sensor_aperture_sinc`, `sensor_fill_factor=1.5`) only on that branch, while leaving `compensated_mtf_for_acutance` and `quality_loss_compensated_mtf_for_acutance` on the existing issue-97 topology.",
+        "pr103_issue102_vs_issue97": {
+          "curve_mae_non_worse_than_issue97": true,
+          "delta": {
+            "curve_mae_mean": 0.0,
+            "focus_preset_acutance_mae_mean": 0.0,
+            "mtf_abs_signed_rel_mean": -0.14655064724620254,
+            "mtf_threshold_mae": {
+              "mtf20": -0.04475842784446967,
+              "mtf30": -0.03260282947001782,
+              "mtf50": -0.003352565492476055
+            },
+            "overall_quality_loss_mae_mean": 0.0
+          },
+          "focus_preset_acutance_non_worse_than_issue97": true,
+          "mtf20_non_worse_than_issue97": true,
+          "mtf30_improved_vs_issue97": true,
+          "mtf50_improved_vs_issue97": true,
+          "mtf_abs_signed_rel_improved_vs_issue97": true,
+          "overall_quality_loss_non_worse_than_issue97": true
+        },
+        "pr104_result": "PR #104 repaired issue-102 summary-artifact provenance only and did not change the benchmark result, so the post-issue102 narrowing should use the same metrics published by PR #103.",
+        "pr30_issue102_delta": {
+          "curve_mae_mean": -0.0039872260971888646,
+          "focus_preset_acutance_mae_mean": -0.013566304809976663,
+          "mtf_abs_signed_rel_mean": 0.14361322293142617,
+          "mtf_threshold_mae": {
+            "mtf20": -0.003293620077230726,
+            "mtf30": 0.005989674647606136,
+            "mtf50": 0.0216086539570957
+          },
+          "overall_quality_loss_mae_mean": 2.725930579444415
+        },
+        "pr98_issue97_vs_current_best_pr30": {
+          "delta": {
+            "curve_mae_mean": -0.0039872260971888646,
+            "focus_preset_acutance_mae_mean": -0.013566304809976663,
+            "mtf_abs_signed_rel_mean": 0.14361322293142617,
+            "mtf_threshold_mae": {
+              "mtf20": -0.003293620077230726,
+              "mtf30": 0.005989674647606136,
+              "mtf50": 0.0216086539570957
+            },
+            "overall_quality_loss_mae_mean": 2.725930579444415
+          }
+        }
+      },
+      "decision": "advance",
+      "explicitly_do_not_change": [
+        "Do not drop the issue-102 intrinsic main branch back to PR #30's non-intrinsic observable stack.",
+        "Do not reopen broader observable-stack, matched-ori, or intrinsic family search outside the bounded observed-branch bundle.",
+        "Do not retune only the readout-only sensor-aperture compensation again as a single-knob follow-up.",
+        "Do not write new fitted outputs under `20260318_deadleaf_13b10`, `release/deadleaf_13b10_release/data/20260318_deadleaf_13b10`, or `release/deadleaf_13b10_release/config/`."
+      ],
+      "label": "keep the issue-102 intrinsic main branch but graft the PR30 observable-stack bundle onto the observed reported-MTF and downstream Quality Loss branches",
+      "minimum_implementation_boundary": [
+        "Keep issue #102's intrinsic main-acutance branch, `intrinsic_full_reference_scope`, and readout-only sensor-aperture compensation (`sensor_aperture_sinc`) unchanged.",
+        "Introduce one observed-branch bundle for the reported-MTF/readout path and the downstream Quality Loss branch that uses PR #30's anchored calibration file, `texture_support_scale=True`, and `high_frequency_guard_start_cpp=0.36`.",
+        "Do not move the main acutance branch back to PR #30's non-intrinsic topology, and do not promote release-facing PR30 configs directly."
+      ],
+      "repo_evidence": [
+        "Issue #102 preserves issue #97 exactly on `curve_mae_mean`, `focus_preset_acutance_mae_mean`, and `overall_quality_loss_mae_mean`, so the issue-97 intrinsic main branch is no longer the unstable part of the stack.",
+        "Issue #102 improves every tracked readout metric versus issue #97, which proves the single-knob readout compensation boundary was real, but the branch still trails PR #30 on `mtf_abs_signed_rel_mean`, `mtf30`, and `mtf50`.",
+        "Issue #102's `mtf20` already beats PR #30 while `mtf30` and `mtf50` still lag, so the remaining readout gap is no longer a uniform amplitude miss. It now looks like an upstream observable-shape / high-frequency-tail boundary.",
+        "The downstream Quality Loss record is invariant across issue #93, issue #97, and issue #102 at `overall_quality_loss_mae_mean = 3.94743`, while PR #30 is much lower at `1.22150`. That proves the residual large gap does not live in the issue-102 readout-only compensation change and still sits on the observed/downstream branch family.",
+        "Compared with PR #30, issue #102 still differs on the observed-branch observable-stack knobs `calibration_file`, `texture_support_scale`, and `high_frequency_guard_start_cpp`, while the intrinsic-topology differences are the same knobs that currently preserve issue-102's stronger curve and focus-preset Acutance record."
+      ],
+      "selected_summary": "Keep issue #102's intrinsic main-acutance branch and readout-only sensor-aperture compensation record intact, but move the observed-branch consumers that still lag PR #30 onto one bounded PR30-style observable-stack bundle: anchored calibration, `texture_support_scale`, and `high_frequency_guard_start_cpp=0.36` for the reported-MTF/readout path and the downstream Quality Loss branch only.",
+      "slice_id": "issue102_topology_graft_pr30_observable_stack_onto_observed_branches",
+      "validation_plan_for_next_issue": [
+        "Run `python3 -m algo.benchmark_parity_psd_mtf ...` on an issue-102-based profile that keeps readout-only sensor-aperture compensation but adds the PR30 observable-stack bundle on the observed readout branch, then compare `mtf_abs_signed_rel_mean`, `mtf20`, `mtf30`, and `mtf50` against issue #102 and PR #30.",
+        "Run `python3 -m algo.benchmark_parity_acutance_quality_loss ...` on the same bounded scope to confirm `curve_mae_mean` and `focus_preset_acutance_mae_mean` stay no worse than issue #102 while `overall_quality_loss_mae_mean` improves materially.",
+        "Add focused tests that prove anchored calibration, `texture_support_scale`, and `high_frequency_guard_start_cpp` affect only the observed reported-MTF / downstream Quality Loss consumers and not the issue-102 intrinsic main-acutance branch."
+      ]
+    },
+    {
+      "decision": "exclude",
+      "exclusion_reasons": [
+        "Issue #102 already improved every tracked readout metric versus issue #97 and even beat PR #30 on `mtf20`, so the remaining readout gap is no longer the same single-knob amplitude problem.",
+        "Overall Quality Loss never moved across issue #93, issue #97, and issue #102, so another readout-only compensation retune would not address the largest residual PR30 gap."
+      ],
+      "label": "keep tuning only the readout-only sensor-aperture compensation parameters",
+      "slice_id": "retune_readout_only_sensor_aperture_compensation_again"
+    },
+    {
+      "decision": "exclude",
+      "exclusion_reasons": [
+        "Issue #102 still beats PR #30 on `curve_mae_mean` and `focus_preset_acutance_mae_mean`, so collapsing the whole topology back toward PR #30 would throw away the strongest part of the current bounded record.",
+        "Issue #105 is supposed to leave one direct bounded implementation slice, not reopen the full observable-stack replacement path."
+      ],
+      "label": "discard the issue-102 intrinsic main branch and move the whole stack back toward PR #30",
+      "slice_id": "drop_intrinsic_main_branch_and_rejoin_whole_pr30_stack"
+    },
+    {
+      "decision": "exclude",
+      "exclusion_reasons": [
+        "The remaining issue-102 residuals are already localized: the intrinsic main branch is stable, the readout-only compensation boundary is proven, and the unchanged downstream Quality Loss record points at the observed-branch bundle.",
+        "Issue #105 is a developer-discovery narrowing pass and must hand engineering one direct next implementation issue rather than another unbounded search."
+      ],
+      "label": "restart broader observable-stack, matched-ori, or intrinsic family search",
+      "slice_id": "restart_broader_observable_stack_or_intrinsic_family_search"
+    }
+  ],
+  "comparison_records": {
+    "current_best_pr30_branch": {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": 0.013802247905288301,
+        "Computer Monitor Acutance": 0.052665183748573804,
+        "Large Print Acutance": 0.05132586418527154,
+        "Small Print Acutance": 0.046702107662187464,
+        "UHDTV Display Acutance": 0.04793875259218785
+      },
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "readout_interpolation": "linear",
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": true
+      },
+      "curve_mae_mean": 0.03678903166100513,
+      "focus_preset_acutance_mae_mean": 0.042486831218701795,
+      "label": "current_best_pr30_branch",
+      "mtf_abs_signed_rel_mean": 0.08671416893394165,
+      "mtf_band_mae": {
+        "high": 0.01764835359892083,
+        "low": 0.03704553941403868,
+        "mid": 0.03898616152003224,
+        "top": 0.07374065223652229
+      },
+      "mtf_threshold_mae": {
+        "mtf20": 0.03301077142967389,
+        "mtf30": 0.03693639342667963,
+        "mtf50": 0.009332615436071163
+      },
+      "overall_quality_loss_mae_mean": 1.2214989544377113,
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_profile.json",
+      "quality_loss_preset_mae": {
+        "5.5\" Phone Display Quality Loss": 0.14297991495607307,
+        "Computer Monitor Quality Loss": 2.902905846061304,
+        "Large Print Quality Loss": 0.9548172583377941,
+        "Small Print Quality Loss": 0.6076935256225349,
+        "UHDTV Display Quality Loss": 1.4990982272108502
+      }
+    },
+    "issue102_readout_only_sensor_comp_candidate": {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": 0.035256377739795786,
+        "Computer Monitor Acutance": 0.024146307932311834,
+        "Large Print Acutance": 0.028624302638652583,
+        "Small Print Acutance": 0.031726251556383624,
+        "UHDTV Display Acutance": 0.024849392176481848
+      },
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": null,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "reported_mtf_disconnect_readout_only_sensor_comp_quality_loss_isolation_downstream_matched_ori_only",
+        "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "none",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "readout_interpolation": "linear",
+        "readout_mtf_compensation_mode": "sensor_aperture_sinc",
+        "readout_sensor_fill_factor": 1.5,
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.0,
+        "texture_support_scale": false
+      },
+      "curve_mae_mean": 0.03280180556381627,
+      "focus_preset_acutance_mae_mean": 0.028920526408725132,
+      "label": "issue102_readout_only_sensor_comp_candidate",
+      "mtf_abs_signed_rel_mean": 0.23032739186536783,
+      "mtf_threshold_mae": {
+        "mtf20": 0.029717151352443162,
+        "mtf30": 0.04292606807428576,
+        "mtf50": 0.03094126939316686
+      },
+      "overall_quality_loss_mae_mean": 3.9474295338821266,
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_readout_only_sensor_comp_quality_loss_isolation_downstream_matched_ori_only_profile.json",
+      "quality_loss_preset_mae": {
+        "5.5\" Phone Display Quality Loss": 4.122316176755632,
+        "Computer Monitor Quality Loss": 6.1264243907692375,
+        "Large Print Quality Loss": 2.079928486542698,
+        "Small Print Quality Loss": 3.490178763693591,
+        "UHDTV Display Quality Loss": 3.918299851649472
+      }
+    },
+    "issue93_downstream_matched_ori_only_candidate": {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": 0.035256377739795786,
+        "Computer Monitor Acutance": 0.024146307932311834,
+        "Large Print Acutance": 0.028624302638652583,
+        "Small Print Acutance": 0.031726251556383624,
+        "UHDTV Display Acutance": 0.024849392176481848
+      },
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": null,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "readout_reconnect_quality_loss_isolation_downstream_matched_ori_only",
+        "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "none",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "readout_interpolation": "linear",
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.0,
+        "texture_support_scale": false
+      },
+      "curve_mae_mean": 0.03280180556381627,
+      "focus_preset_acutance_mae_mean": 0.028920526408725132,
+      "label": "issue93_downstream_matched_ori_only_candidate",
+      "mtf_abs_signed_rel_mean": 0.13993778559089318,
+      "mtf_band_mae": {
+        "high": 0.046538330006884135,
+        "low": 0.009354903091206065,
+        "mid": 0.04532695609684774,
+        "top": 0.045570940534890705
+      },
+      "mtf_threshold_mae": {
+        "mtf20": 0.08576635073450163,
+        "mtf30": 0.017891546542091085,
+        "mtf50": 0.007196087410606654
+      },
+      "overall_quality_loss_mae_mean": 3.9474295338821266,
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_readout_reconnect_quality_loss_isolation_downstream_matched_ori_only_profile.json",
+      "quality_loss_preset_mae": {
+        "5.5\" Phone Display Quality Loss": 4.122316176755632,
+        "Computer Monitor Quality Loss": 6.1264243907692375,
+        "Large Print Quality Loss": 2.079928486542698,
+        "Small Print Quality Loss": 3.490178763693591,
+        "UHDTV Display Quality Loss": 3.918299851649472
+      }
+    },
+    "issue97_reported_mtf_disconnect_candidate": {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": 0.035256377739795786,
+        "Computer Monitor Acutance": 0.024146307932311834,
+        "Large Print Acutance": 0.028624302638652583,
+        "Small Print Acutance": 0.031726251556383624,
+        "UHDTV Display Acutance": 0.024849392176481848
+      },
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": null,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only",
+        "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "none",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "readout_interpolation": "linear",
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.0,
+        "texture_support_scale": false
+      },
+      "curve_mae_mean": 0.03280180556381627,
+      "focus_preset_acutance_mae_mean": 0.028920526408725132,
+      "label": "issue97_reported_mtf_disconnect_candidate",
+      "mtf_abs_signed_rel_mean": 0.37687803911157036,
+      "mtf_threshold_mae": {
+        "mtf20": 0.07447557919691283,
+        "mtf30": 0.07552889754430359,
+        "mtf50": 0.034293834885642915
+      },
+      "overall_quality_loss_mae_mean": 3.9474295338821266,
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_quality_loss_isolation_downstream_matched_ori_only_profile.json",
+      "quality_loss_preset_mae": {
+        "5.5\" Phone Display Quality Loss": 4.122316176755632,
+        "Computer Monitor Quality Loss": 6.1264243907692375,
+        "Large Print Quality Loss": 2.079928486542698,
+        "Small Print Quality Loss": 3.490178763693591,
+        "UHDTV Display Quality Loss": 3.918299851649472
+      }
+    }
+  },
+  "issue": 105,
+  "pipeline_delta_summary": {
+    "calibration_file": {
+      "current_best_pr30_branch": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+      "issue102_readout_only_sensor_comp_candidate": "algo/deadleaf_13b10_psd_calibration.json"
+    },
+    "high_frequency_guard_start_cpp": {
+      "current_best_pr30_branch": 0.36,
+      "issue102_readout_only_sensor_comp_candidate": null
+    },
+    "intrinsic_full_reference_mode": {
+      "current_best_pr30_branch": "none",
+      "issue102_readout_only_sensor_comp_candidate": "paired_ori_transfer"
+    },
+    "intrinsic_full_reference_scope": {
+      "current_best_pr30_branch": "replace_all",
+      "issue102_readout_only_sensor_comp_candidate": "reported_mtf_disconnect_readout_only_sensor_comp_quality_loss_isolation_downstream_matched_ori_only"
+    },
+    "intrinsic_full_reference_transfer_mode": {
+      "current_best_pr30_branch": "magnitude_ratio",
+      "issue102_readout_only_sensor_comp_candidate": "radial_real_mean"
+    },
+    "matched_ori_anchor_mode": {
+      "current_best_pr30_branch": "acutance_only",
+      "issue102_readout_only_sensor_comp_candidate": "all"
+    },
+    "mtf_compensation_mode": {
+      "current_best_pr30_branch": "sensor_aperture_sinc",
+      "issue102_readout_only_sensor_comp_candidate": "none"
+    },
+    "readout_mtf_compensation_mode": {
+      "current_best_pr30_branch": null,
+      "issue102_readout_only_sensor_comp_candidate": "sensor_aperture_sinc"
+    },
+    "readout_sensor_fill_factor": {
+      "current_best_pr30_branch": null,
+      "issue102_readout_only_sensor_comp_candidate": 1.5
+    },
+    "sensor_fill_factor": {
+      "current_best_pr30_branch": 1.5,
+      "issue102_readout_only_sensor_comp_candidate": 1.0
+    },
+    "texture_support_scale": {
+      "current_best_pr30_branch": true,
+      "issue102_readout_only_sensor_comp_candidate": false
+    }
+  },
+  "residual_gap_evidence": {
+    "issue102_keeps_intrinsic_main_branch_better_than_pr30": {
+      "curve_mae_mean_better_than_current_best_pr30": true,
+      "delta_vs_current_best_pr30": {
+        "curve_mae_mean": -0.0039872260971888646,
+        "focus_preset_acutance_mae_mean": -0.013566304809976663
+      },
+      "focus_preset_acutance_mae_mean_better_than_current_best_pr30": true
+    },
+    "issue102_preserves_issue97_core_record": {
+      "curve_mae_mean": true,
+      "delta": {
+        "curve_mae_mean": 0.0,
+        "focus_preset_acutance_mae_mean": 0.0,
+        "overall_quality_loss_mae_mean": 0.0
+      },
+      "focus_preset_acutance_mae_mean": true,
+      "overall_quality_loss_mae_mean": true
+    },
+    "issue102_readout_improves_but_does_not_close_pr30_gap": {
+      "delta_vs_current_best_pr30": {
+        "mtf20": -0.003293620077230726,
+        "mtf30": 0.005989674647606136,
+        "mtf50": 0.0216086539570957,
+        "mtf_abs_signed_rel_mean": 0.14361322293142617
+      },
+      "delta_vs_issue97": {
+        "mtf20": -0.04475842784446967,
+        "mtf30": -0.03260282947001782,
+        "mtf50": -0.003352565492476055,
+        "mtf_abs_signed_rel_mean": -0.14655064724620254
+      },
+      "mtf20_beats_current_best_pr30": true,
+      "mtf30_still_worse_than_current_best_pr30": true,
+      "mtf50_still_worse_than_current_best_pr30": true,
+      "mtf_abs_signed_rel_improved_vs_issue97": true,
+      "mtf_abs_signed_rel_still_worse_than_current_best_pr30": true
+    },
+    "issue93_issue97_issue102_quality_loss_record_is_invariant": {
+      "delta_issue102_vs_current_best_pr30": 2.725930579444415,
+      "issue93_equals_issue102": true,
+      "issue93_equals_issue97": true,
+      "issue97_equals_issue102": true
+    }
+  },
+  "selected_slice_id": "issue102_topology_graft_pr30_observable_stack_onto_observed_branches",
+  "selected_summary": "Keep issue #102's intrinsic main-acutance branch and readout-only sensor-aperture compensation record intact, but move the observed-branch consumers that still lag PR #30 onto one bounded PR30-style observable-stack bundle: anchored calibration, `texture_support_scale`, and `high_frequency_guard_start_cpp=0.36` for the reported-MTF/readout path and the downstream Quality Loss branch only.",
+  "source_artifacts": {
+    "comparison_basis_refs": [
+      "pr-30",
+      "pr-98",
+      "pr-100",
+      "pr-103",
+      "pr-104"
+    ],
+    "issue102_artifact": "artifacts/intrinsic_phase_retained_readout_only_sensor_comp_benchmark.json",
+    "issue99_artifact": "artifacts/intrinsic_after_issue97_next_slice_benchmark.json"
+  },
+  "storage_policy": {
+    "golden_reference_roots": [
+      "20260318_deadleaf_13b10",
+      "release/deadleaf_13b10_release/data/20260318_deadleaf_13b10"
+    ],
+    "new_fitted_artifact_paths": [
+      "artifacts/intrinsic_after_issue102_next_slice_benchmark.json"
+    ],
+    "rules": [
+      "Keep issue-105 discovery outputs under `docs/` and `artifacts/` only.",
+      "Do not write fitted profiles, transfer tables, or generated outputs under the golden/reference roots.",
+      "Do not touch release-facing configs in this issue."
+    ]
+  },
+  "summary_kind": "intrinsic_after_issue102_next_slice"
+}

--- a/docs/intrinsic_after_issue102_next_slice.md
+++ b/docs/intrinsic_after_issue102_next_slice.md
@@ -1,0 +1,96 @@
+# Intrinsic After Issue 102 Next Slice
+
+This note records the issue `#105` developer-discovery pass after issue `#102` / PR `#103` / PR `#104` proved that readout-only sensor-aperture compensation is a real bounded improvement but still leaves a residual gap versus PR `#30`.
+
+## Selected Slice
+
+- Selected slice: `issue102_topology_graft_pr30_observable_stack_onto_observed_branches`
+- Summary: Keep issue #102's intrinsic main-acutance branch and readout-only sensor-aperture compensation record intact, but move the observed-branch consumers that still lag PR #30 onto one bounded PR30-style observable-stack bundle: anchored calibration, `texture_support_scale`, and `high_frequency_guard_start_cpp=0.36` for the reported-MTF/readout path and the downstream Quality Loss branch only.
+- Prior narrowing lineage: issue `#99` / PR `#100` / PR `#101` selected the readout-only compensation slice, and issue `#102` / PR `#103` / PR `#104` completed it cleanly enough to expose the next remaining boundary.
+- Remaining gap location: after issue `#102`, the intrinsic main branch and the readout-only compensation boundary are both bounded. The large residual gap now sits on the observed-branch observable stack that still feeds reported-MTF and downstream Quality Loss differently from PR `#30`.
+
+## Comparison Table
+
+| Record | Curve MAE | Focus Acu MAE | Overall QL | MTF20 | MTF30 | MTF50 | Abs Signed Rel | Reading |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| current_best_pr30_branch | 0.03679 | 0.04249 | 1.22150 | 0.03301 | 0.03694 | 0.00933 | 0.08671 | Current best PR30 branch. |
+| issue97_reported_mtf_disconnect_candidate | 0.03280 | 0.02892 | 3.94743 | 0.07448 | 0.07553 | 0.03429 | 0.37688 | Issue-97 mixed-negative disconnect result from PR #98. |
+| issue102_readout_only_sensor_comp_candidate | 0.03280 | 0.02892 | 3.94743 | 0.02972 | 0.04293 | 0.03094 | 0.23033 | Issue-102 bounded positive result from PR #103/#104. |
+
+## Residual Gap Evidence
+
+- Issue #102 preserves issue #97 `curve_mae_mean`: `True`
+- Issue #102 preserves issue #97 `focus_preset_acutance_mae_mean`: `True`
+- Issue #102 preserves issue #97 `overall_quality_loss_mae_mean`: `True`
+- Issue #102 improves `mtf_abs_signed_rel_mean` versus issue #97: `True`
+- Issue #102 still trails PR #30 on `mtf30`: `True`
+- Issue #102 still trails PR #30 on `mtf50`: `True`
+- Issue #102 still trails PR #30 on `mtf_abs_signed_rel_mean`: `True`
+- Issue #102 already beats PR #30 on `mtf20`: `True`
+- Issue #93 / #97 / #102 keep the same downstream Quality Loss record: `True`
+
+## Pipeline Delta Summary
+
+- `calibration_file`: issue102='algo/deadleaf_13b10_psd_calibration.json', pr30='algo/deadleaf_13b10_psd_calibration_anchored.json'
+- `high_frequency_guard_start_cpp`: issue102=None, pr30=0.36
+- `intrinsic_full_reference_mode`: issue102='paired_ori_transfer', pr30='none'
+- `intrinsic_full_reference_scope`: issue102='reported_mtf_disconnect_readout_only_sensor_comp_quality_loss_isolation_downstream_matched_ori_only', pr30='replace_all'
+- `intrinsic_full_reference_transfer_mode`: issue102='radial_real_mean', pr30='magnitude_ratio'
+- `matched_ori_anchor_mode`: issue102='all', pr30='acutance_only'
+- `mtf_compensation_mode`: issue102='none', pr30='sensor_aperture_sinc'
+- `readout_mtf_compensation_mode`: issue102='sensor_aperture_sinc', pr30=None
+- `sensor_fill_factor`: issue102=1.0, pr30=1.5
+- `readout_sensor_fill_factor`: issue102=1.5, pr30=None
+- `texture_support_scale`: issue102=False, pr30=True
+
+## Why The Next Slice Is The Observed-Branch PR30 Observable Stack
+
+- Issue #102 proved the readout-only sensor-aperture compensation boundary and already improved all tracked readout metrics versus issue #97, so another single-knob readout retune is no longer the highest-signal follow-up.
+- `overall_quality_loss_mae_mean` never changed across issue `#93`, issue `#97`, and issue `#102`, which means the residual large PR30 gap still sits on the downstream observed-branch family rather than the issue-102 intrinsic main branch.
+- The remaining pipeline deltas that can hit both reported-MTF and downstream Quality Loss without discarding the issue-102 intrinsic main branch are PR30's anchored calibration, `texture_support_scale`, and `high_frequency_guard_start_cpp` on the observed branch.
+- PR #104 changed only summary-artifact provenance, so the post-issue102 narrowing should treat PR #103 and PR #104 as the same benchmark record.
+
+## Selected Implementation Boundary
+
+- Keep issue #102's intrinsic main-acutance branch, `intrinsic_full_reference_scope`, and readout-only sensor-aperture compensation (`sensor_aperture_sinc`) unchanged.
+- Introduce one observed-branch bundle for the reported-MTF/readout path and the downstream Quality Loss branch that uses PR #30's anchored calibration file, `texture_support_scale=True`, and `high_frequency_guard_start_cpp=0.36`.
+- Do not move the main acutance branch back to PR #30's non-intrinsic topology, and do not promote release-facing PR30 configs directly.
+
+## Explicit Non-Changes
+
+- Do not drop the issue-102 intrinsic main branch back to PR #30's non-intrinsic observable stack.
+- Do not reopen broader observable-stack, matched-ori, or intrinsic family search outside the bounded observed-branch bundle.
+- Do not retune only the readout-only sensor-aperture compensation again as a single-knob follow-up.
+- Do not write new fitted outputs under `20260318_deadleaf_13b10`, `release/deadleaf_13b10_release/data/20260318_deadleaf_13b10`, or `release/deadleaf_13b10_release/config/`.
+
+## Excluded Routes
+
+### `retune_readout_only_sensor_aperture_compensation_again`
+
+- Route: keep tuning only the readout-only sensor-aperture compensation parameters
+- Issue #102 already improved every tracked readout metric versus issue #97 and even beat PR #30 on `mtf20`, so the remaining readout gap is no longer the same single-knob amplitude problem.
+- Overall Quality Loss never moved across issue #93, issue #97, and issue #102, so another readout-only compensation retune would not address the largest residual PR30 gap.
+
+### `drop_intrinsic_main_branch_and_rejoin_whole_pr30_stack`
+
+- Route: discard the issue-102 intrinsic main branch and move the whole stack back toward PR #30
+- Issue #102 still beats PR #30 on `curve_mae_mean` and `focus_preset_acutance_mae_mean`, so collapsing the whole topology back toward PR #30 would throw away the strongest part of the current bounded record.
+- Issue #105 is supposed to leave one direct bounded implementation slice, not reopen the full observable-stack replacement path.
+
+### `restart_broader_observable_stack_or_intrinsic_family_search`
+
+- Route: restart broader observable-stack, matched-ori, or intrinsic family search
+- The remaining issue-102 residuals are already localized: the intrinsic main branch is stable, the readout-only compensation boundary is proven, and the unchanged downstream Quality Loss record points at the observed-branch bundle.
+- Issue #105 is a developer-discovery narrowing pass and must hand engineering one direct next implementation issue rather than another unbounded search.
+
+## Validation Plan For The Next Implementation Issue
+
+- Run `python3 -m algo.benchmark_parity_psd_mtf ...` on an issue-102-based profile that keeps readout-only sensor-aperture compensation but adds the PR30 observable-stack bundle on the observed readout branch, then compare `mtf_abs_signed_rel_mean`, `mtf20`, `mtf30`, and `mtf50` against issue #102 and PR #30.
+- Run `python3 -m algo.benchmark_parity_acutance_quality_loss ...` on the same bounded scope to confirm `curve_mae_mean` and `focus_preset_acutance_mae_mean` stay no worse than issue #102 while `overall_quality_loss_mae_mean` improves materially.
+- Add focused tests that prove anchored calibration, `texture_support_scale`, and `high_frequency_guard_start_cpp` affect only the observed reported-MTF / downstream Quality Loss consumers and not the issue-102 intrinsic main-acutance branch.
+
+## Storage Separation
+
+- Golden/reference roots: `20260318_deadleaf_13b10`, `release/deadleaf_13b10_release/data/20260318_deadleaf_13b10`
+- Discovery outputs for this issue stay under `docs/` and `artifacts/` only.
+- Do not write new fitted profiles, transfer tables, or benchmark outputs under the golden/reference roots or release-facing config roots.

--- a/tests/test_build_intrinsic_after_issue102_next_slice.py
+++ b/tests/test_build_intrinsic_after_issue102_next_slice.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from algo.build_intrinsic_after_issue102_next_slice import (
+    CURRENT_BEST_LABEL,
+    ISSUE102_LABEL,
+    SELECTED_SLICE_ID,
+    build_payload,
+    render_markdown,
+)
+
+
+class BuildIntrinsicAfterIssue102NextSliceTest(unittest.TestCase):
+    def test_payload_selects_observed_branch_pr30_bundle(self) -> None:
+        payload = build_payload(
+            self.repo_root(),
+            issue99_artifact_path=Path("artifacts/intrinsic_after_issue97_next_slice_benchmark.json"),
+            issue102_artifact_path=Path(
+                "artifacts/intrinsic_phase_retained_readout_only_sensor_comp_benchmark.json"
+            ),
+        )
+
+        self.assertEqual(payload["issue"], 105)
+        self.assertEqual(payload["summary_kind"], "intrinsic_after_issue102_next_slice")
+        self.assertEqual(payload["selected_slice_id"], SELECTED_SLICE_ID)
+        selected = next(
+            row for row in payload["candidate_slices"] if row["slice_id"] == SELECTED_SLICE_ID
+        )
+        self.assertIn("anchored calibration", selected["selected_summary"])
+        self.assertIn("texture_support_scale", selected["selected_summary"])
+        self.assertIn("high_frequency_guard_start_cpp", selected["selected_summary"])
+        self.assertIn("readout-only sensor-aperture compensation", selected["minimum_implementation_boundary"][0])
+        self.assertTrue(
+            payload["residual_gap_evidence"]["issue93_issue97_issue102_quality_loss_record_is_invariant"][
+                "issue93_equals_issue102"
+            ]
+        )
+        self.assertTrue(
+            payload["residual_gap_evidence"]["issue102_readout_improves_but_does_not_close_pr30_gap"][
+                "mtf20_beats_current_best_pr30"
+            ]
+        )
+        self.assertTrue(
+            payload["residual_gap_evidence"]["issue102_readout_improves_but_does_not_close_pr30_gap"][
+                "mtf30_still_worse_than_current_best_pr30"
+            ]
+        )
+        self.assertEqual(
+            payload["pipeline_delta_summary"]["calibration_file"][ISSUE102_LABEL],
+            "algo/deadleaf_13b10_psd_calibration.json",
+        )
+        self.assertEqual(
+            payload["pipeline_delta_summary"]["calibration_file"][CURRENT_BEST_LABEL],
+            "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        )
+        self.assertEqual(
+            payload["pipeline_delta_summary"]["texture_support_scale"][ISSUE102_LABEL], False
+        )
+        self.assertEqual(
+            payload["pipeline_delta_summary"]["texture_support_scale"][CURRENT_BEST_LABEL], True
+        )
+        self.assertEqual(
+            payload["comparison_records"][ISSUE102_LABEL]["analysis_pipeline"][
+                "readout_mtf_compensation_mode"
+            ],
+            "sensor_aperture_sinc",
+        )
+        for path in payload["storage_policy"]["new_fitted_artifact_paths"]:
+            self.assertFalse(path.startswith("20260318_deadleaf_13b10"))
+            self.assertFalse(
+                path.startswith("release/deadleaf_13b10_release/data/20260318_deadleaf_13b10")
+            )
+
+    def test_markdown_mentions_pr30_bundle_and_storage(self) -> None:
+        payload = build_payload(
+            self.repo_root(),
+            issue99_artifact_path=Path("artifacts/intrinsic_after_issue97_next_slice_benchmark.json"),
+            issue102_artifact_path=Path(
+                "artifacts/intrinsic_phase_retained_readout_only_sensor_comp_benchmark.json"
+            ),
+        )
+        markdown = render_markdown(payload)
+
+        self.assertIn("# Intrinsic After Issue 102 Next Slice", markdown)
+        self.assertIn("## Pipeline Delta Summary", markdown)
+        self.assertIn("anchored calibration", markdown)
+        self.assertIn("texture_support_scale", markdown)
+        self.assertIn("high_frequency_guard_start_cpp", markdown)
+        self.assertIn("Storage Separation", markdown)
+
+    @staticmethod
+    def repo_root() -> Path:
+        return Path(__file__).resolve().parents[1]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs #29
Refs #97
Refs #99
Refs #102
Refs #105

## Summary
- add the issue-105 discovery builder for the bounded post-issue102 next slice
- record the selected next slice in checked-in artifact and docs outputs
- add focused regression coverage for the issue-105 builder

## Selected Slice
- keep issue #102's intrinsic main-acutance branch and readout-only sensor-aperture compensation unchanged
- graft PR #30's observed-branch observable-stack bundle onto the reported-MTF/readout path and downstream Quality Loss branch only
- constrain that bundle to anchored calibration, `texture_support_scale`, and `high_frequency_guard_start_cpp = 0.36`

## Validation
- `python3 -m pytest tests/test_build_intrinsic_after_issue102_next_slice.py`
- `python3 -m algo.build_intrinsic_after_issue102_next_slice`