### PR TITLE
Issue #111: narrow post-108 Quality Loss gap

### DIFF
--- a/algo/build_intrinsic_after_issue108_next_slice.py
+++ b/algo/build_intrinsic_after_issue108_next_slice.py
@@ -1,0 +1,482 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+SUMMARY_KIND = "intrinsic_after_issue108_next_slice"
+CURRENT_BEST_LABEL = "current_best_pr30_branch"
+ISSUE102_LABEL = "issue102_readout_only_sensor_comp_candidate"
+ISSUE108_LABEL = "issue108_pr30_observed_bundle_candidate"
+SELECTED_SLICE_ID = "issue108_computer_monitor_quality_loss_preset_boundary"
+GOLDEN_REFERENCE_ROOTS = (
+    "20260318_deadleaf_13b10",
+    "release/deadleaf_13b10_release/data/20260318_deadleaf_13b10",
+    "release/deadleaf_13b10_release/config",
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build the issue-111 post-issue108 Quality Loss next-slice record."
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Repository root. Defaults to the parent of this script.",
+    )
+    parser.add_argument(
+        "--issue108-summary",
+        type=Path,
+        default=Path("artifacts/intrinsic_phase_retained_pr30_observed_bundle_benchmark.json"),
+        help="Repo-relative issue-108 summary artifact path.",
+    )
+    parser.add_argument(
+        "--issue108-acutance-artifact",
+        type=Path,
+        default=Path(
+            "artifacts/issue108_intrinsic_phase_retained_pr30_observed_bundle_acutance_benchmark.json"
+        ),
+        help="Repo-relative issue-108 acutance/Quality Loss raw benchmark artifact path.",
+    )
+    parser.add_argument(
+        "--issue105-summary",
+        type=Path,
+        default=Path("artifacts/intrinsic_after_issue102_next_slice_benchmark.json"),
+        help="Repo-relative issue-105 selected-slice artifact path.",
+    )
+    parser.add_argument(
+        "--output-json",
+        type=Path,
+        default=Path("artifacts/intrinsic_after_issue108_next_slice_benchmark.json"),
+        help="Repo-relative output path for the machine-readable artifact.",
+    )
+    parser.add_argument(
+        "--output-md",
+        type=Path,
+        default=Path("docs/intrinsic_after_issue108_next_slice.md"),
+        help="Repo-relative output path for the Markdown note.",
+    )
+    return parser
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def resolve_path(repo_root: Path, path: Path) -> Path:
+    return path if path.is_absolute() else repo_root / path
+
+
+def format_metric(value: float) -> str:
+    return f"{value:.5f}"
+
+
+def delta_map(candidate: dict[str, Any], baseline: dict[str, Any]) -> dict[str, float]:
+    return {
+        "curve_mae_mean": float(candidate["curve_mae_mean"] - baseline["curve_mae_mean"]),
+        "focus_preset_acutance_mae_mean": float(
+            candidate["focus_preset_acutance_mae_mean"]
+            - baseline["focus_preset_acutance_mae_mean"]
+        ),
+        "overall_quality_loss_mae_mean": float(
+            candidate["overall_quality_loss_mae_mean"]
+            - baseline["overall_quality_loss_mae_mean"]
+        ),
+        "mtf_abs_signed_rel_mean": float(
+            candidate["mtf_abs_signed_rel_mean"] - baseline["mtf_abs_signed_rel_mean"]
+        ),
+        "mtf20": float(candidate["mtf_threshold_mae"]["mtf20"] - baseline["mtf_threshold_mae"]["mtf20"]),
+        "mtf30": float(candidate["mtf_threshold_mae"]["mtf30"] - baseline["mtf_threshold_mae"]["mtf30"]),
+        "mtf50": float(candidate["mtf_threshold_mae"]["mtf50"] - baseline["mtf_threshold_mae"]["mtf50"]),
+    }
+
+
+def quality_loss_preset_deltas(
+    candidate: dict[str, Any],
+    baseline: dict[str, Any],
+) -> list[dict[str, Any]]:
+    candidate_values = candidate["quality_loss_preset_mae"]
+    baseline_values = baseline["quality_loss_preset_mae"]
+    preset_count = len(candidate_values)
+    rows = []
+    for preset_name in sorted(candidate_values):
+        delta = float(candidate_values[preset_name] - baseline_values[preset_name])
+        rows.append(
+            {
+                "preset": preset_name,
+                "issue108": float(candidate_values[preset_name]),
+                "current_best_pr30": float(baseline_values[preset_name]),
+                "delta": delta,
+                "mean_contribution": float(delta / preset_count),
+                "direction": "worse_than_pr30" if delta > 0.0 else "better_than_or_equal_pr30",
+            }
+        )
+    return sorted(rows, key=lambda row: row["delta"], reverse=True)
+
+
+def acutance_preset_deltas(
+    candidate: dict[str, Any],
+    baseline: dict[str, Any],
+) -> list[dict[str, Any]]:
+    candidate_values = candidate["acutance_preset_mae"]
+    baseline_values = baseline["acutance_preset_mae"]
+    return [
+        {
+            "preset": preset_name,
+            "issue108": float(candidate_values[preset_name]),
+            "current_best_pr30": float(baseline_values[preset_name]),
+            "delta": float(candidate_values[preset_name] - baseline_values[preset_name]),
+        }
+        for preset_name in sorted(candidate_values)
+    ]
+
+
+def by_mixup_quality_loss_deltas(raw_acutance_artifact: dict[str, Any]) -> list[dict[str, Any]]:
+    current_best = raw_acutance_artifact["profiles"][0]["by_mixup_quality_loss_mae_mean"]
+    issue108 = raw_acutance_artifact["profiles"][2]["by_mixup_quality_loss_mae_mean"]
+    rows = [
+        {
+            "mixup": mixup,
+            "issue108": float(issue108[mixup]),
+            "current_best_pr30": float(current_best[mixup]),
+            "delta": float(issue108[mixup] - current_best[mixup]),
+        }
+        for mixup in sorted(issue108)
+    ]
+    return sorted(rows, key=lambda row: row["delta"], reverse=True)
+
+
+def quality_loss_coefficients_equal(candidate: dict[str, Any], baseline: dict[str, Any]) -> bool:
+    candidate_pipeline = candidate["analysis_pipeline"]
+    baseline_pipeline = baseline["analysis_pipeline"]
+    return (
+        candidate_pipeline["quality_loss_coefficients"]
+        == baseline_pipeline["quality_loss_coefficients"]
+        and candidate_pipeline["quality_loss_om_ceiling"]
+        == baseline_pipeline["quality_loss_om_ceiling"]
+        and candidate_pipeline["quality_loss_preset_overrides"]
+        == baseline_pipeline["quality_loss_preset_overrides"]
+    )
+
+
+def differing_pipeline_keys(candidate: dict[str, Any], baseline: dict[str, Any]) -> dict[str, Any]:
+    candidate_pipeline = candidate["analysis_pipeline"]
+    baseline_pipeline = baseline["analysis_pipeline"]
+    keys = (
+        "acutance_noise_scale_mode",
+        "intrinsic_full_reference_mode",
+        "intrinsic_full_reference_scope",
+        "intrinsic_full_reference_transfer_mode",
+        "matched_ori_anchor_mode",
+        "readout_mtf_compensation_mode",
+        "readout_sensor_fill_factor",
+    )
+    return {
+        key: {
+            ISSUE108_LABEL: candidate_pipeline.get(key),
+            CURRENT_BEST_LABEL: baseline_pipeline.get(key),
+        }
+        for key in keys
+        if candidate_pipeline.get(key) != baseline_pipeline.get(key)
+    }
+
+
+def assert_storage_separation(payload: dict[str, Any]) -> None:
+    for path in payload["storage_policy"]["new_fitted_artifact_paths"]:
+        for root in GOLDEN_REFERENCE_ROOTS:
+            if path.startswith(root):
+                raise ValueError(f"Path {path} leaks into golden/reference root {root}")
+
+
+def build_payload(
+    repo_root: Path,
+    *,
+    issue108_summary_path: Path,
+    issue108_acutance_artifact_path: Path,
+    issue105_summary_path: Path,
+) -> dict[str, Any]:
+    issue108_summary = load_json(resolve_path(repo_root, issue108_summary_path))
+    raw_acutance_artifact = load_json(resolve_path(repo_root, issue108_acutance_artifact_path))
+    issue105_summary = load_json(resolve_path(repo_root, issue105_summary_path))
+
+    profiles = issue108_summary["profiles"]
+    current_best = profiles[CURRENT_BEST_LABEL]
+    issue102 = profiles[ISSUE102_LABEL]
+    issue108 = profiles[ISSUE108_LABEL]
+
+    issue108_vs_pr30 = delta_map(issue108, current_best)
+    issue108_vs_issue102 = delta_map(issue108, issue102)
+    preset_deltas = quality_loss_preset_deltas(issue108, current_best)
+    positive_preset_contribution = float(
+        sum(row["mean_contribution"] for row in preset_deltas if row["mean_contribution"] > 0.0)
+    )
+    top_preset = preset_deltas[0]
+
+    candidate_slices = [
+        {
+            "slice_id": SELECTED_SLICE_ID,
+            "decision": "advance",
+            "label": "isolate the Computer Monitor Quality Loss preset-family downstream input boundary",
+            "adoption_reason": (
+                "Computer Monitor Quality Loss is the largest positive preset delta after issue #108 "
+                "and contributes most of the net residual mean gap by itself."
+            ),
+            "selected_summary": (
+                "Keep issue #108 reported-MTF parity, the issue #102 intrinsic main-acutance gains, "
+                "and the existing PR #30 Quality Loss coefficients/ceilings. The next bounded "
+                "implementation should isolate only the Computer Monitor downstream Quality Loss "
+                "preset-family input branch, comparing an issue-108 Quality Loss input against a "
+                "PR #30-compatible acutance-only/noise-share anchor input for that preset before "
+                "changing any other preset family."
+            ),
+            "repo_evidence": [
+                "Issue #108 matches PR #30 on `mtf_abs_signed_rel_mean`, `mtf20`, `mtf30`, and `mtf50`, so the residual is not a reported-MTF/readout retune problem.",
+                "Issue #108 keeps `curve_mae_mean` and `focus_preset_acutance_mae_mean` better than PR #30, so the issue #102 intrinsic main-acutance branch should not be discarded.",
+                "Quality Loss coefficients, preset overrides, and `quality_loss_om_ceiling` already match PR #30 exactly, so a coefficient/ceiling retune would ignore the checked-in evidence.",
+                "Computer Monitor Quality Loss delta is `+0.66202`, contributing `+0.13240` to the `+0.18513` overall mean delta; fixing only this preset would shrink most of the residual net gap.",
+                "Computer Monitor Acutance MAE is already better than PR #30 while Computer Monitor Quality Loss MAE is worse, which localizes the problem to the downstream Quality Loss input/mapping boundary rather than a general preset-acutance miss.",
+                "UHDTV Quality Loss is already better than PR #30, so a blanket downstream Quality Loss branch swap risks regressing an already-positive preset family.",
+            ],
+            "minimum_implementation_boundary": [
+                "Do not change reported-MTF/readout metrics or their issue-108 PR30 observed-branch bundle.",
+                "Do not change the issue #102 intrinsic main-acutance branch used for curve and focus-preset Acutance.",
+                "Do not change Quality Loss coefficients, preset overrides, or `quality_loss_om_ceiling`.",
+                "Add only enough branch selection or instrumentation to route the Computer Monitor Quality Loss preset-family input through a PR #30-compatible downstream acutance/noise-anchor input while keeping the other Quality Loss presets on the issue-108 path for comparison.",
+            ],
+            "validation_plan_for_next_issue": [
+                "Run the focused acutance/Quality Loss benchmark comparing PR #30, issue #108, and the Computer Monitor-only candidate.",
+                "Require `Computer Monitor Quality Loss` MAE to improve materially versus issue #108 while `overall_quality_loss_mae_mean` also improves.",
+                "Require `mtf_abs_signed_rel_mean`, `mtf20`, `mtf30`, and `mtf50` to remain equal to issue #108 / PR #30.",
+                "Require `curve_mae_mean` and `focus_preset_acutance_mae_mean` to remain no worse than issue #108.",
+            ],
+        },
+        {
+            "slice_id": "retune_quality_loss_coefficients_or_om_ceiling",
+            "decision": "exclude",
+            "label": "retune Quality Loss coefficients or ceilings",
+            "exclusion_reasons": [
+                "Issue #108 and PR #30 already use identical global coefficients, identical preset overrides, and identical `quality_loss_om_ceiling`.",
+                "The residual therefore comes from the Quality Loss input branch, not from a missing fitted coefficient record.",
+            ],
+        },
+        {
+            "slice_id": "retune_reported_mtf_readout_again",
+            "decision": "exclude",
+            "label": "retune reported-MTF/readout after issue #108",
+            "exclusion_reasons": [
+                "Issue #108 already matches PR #30 on `mtf_abs_signed_rel_mean`, `mtf20`, `mtf30`, and `mtf50`.",
+                "Changing the reported-MTF branch would violate the issue-111 constraint to preserve issue-108 reported-MTF parity.",
+            ],
+        },
+        {
+            "slice_id": "phone_preset_only_search",
+            "decision": "exclude",
+            "label": "reopen a Phone-only Quality Loss search",
+            "exclusion_reasons": [
+                "Phone Quality Loss contributes only `+0.01901` to the residual mean gap, far less than the Computer Monitor contribution.",
+                "Issue #111 explicitly excludes reopening Phone-preset-only searches.",
+            ],
+        },
+        {
+            "slice_id": "uhdtv_quality_loss_preset_family",
+            "decision": "exclude",
+            "label": "target UHDTV Quality Loss first",
+            "exclusion_reasons": [
+                "UHDTV Quality Loss is already better than PR #30 by `-0.18394`, so targeting it first would risk damaging an existing win.",
+            ],
+        },
+        {
+            "slice_id": "restart_broad_intrinsic_or_observable_stack_search",
+            "decision": "exclude",
+            "label": "restart broad intrinsic, matched-ori, or observable-stack search",
+            "exclusion_reasons": [
+                "The post-issue108 residual is already localized to downstream Quality Loss deltas after reported-MTF parity closed.",
+                "The issue-111 handoff asks for one bounded slice from measured issue-108 deltas, not a broad family search.",
+            ],
+        },
+    ]
+
+    payload = {
+        "issue": 111,
+        "summary_kind": SUMMARY_KIND,
+        "selected_slice_id": SELECTED_SLICE_ID,
+        "selected_summary": candidate_slices[0]["selected_summary"],
+        "source_artifacts": {
+            "issue108_summary": str(issue108_summary_path),
+            "issue108_acutance_artifact": str(issue108_acutance_artifact_path),
+            "issue105_summary": str(issue105_summary_path),
+            "comparison_basis_refs": ["pr-30", "issue-102", "issue-105", "issue-108", "pr-109"],
+            "issue105_selected_slice_id": issue105_summary["selected_slice_id"],
+        },
+        "comparison_records": {
+            CURRENT_BEST_LABEL: current_best,
+            ISSUE102_LABEL: issue102,
+            ISSUE108_LABEL: issue108,
+        },
+        "residual_quality_loss_boundaries": {
+            "issue108_vs_current_best_pr30": issue108_vs_pr30,
+            "issue108_vs_issue102": issue108_vs_issue102,
+            "quality_loss_preset_deltas": preset_deltas,
+            "acutance_preset_deltas": acutance_preset_deltas(issue108, current_best),
+            "by_mixup_quality_loss_deltas": by_mixup_quality_loss_deltas(raw_acutance_artifact),
+            "positive_preset_mean_contribution": positive_preset_contribution,
+            "top_positive_preset": top_preset,
+            "top_positive_preset_net_gap_share": float(
+                top_preset["mean_contribution"]
+                / issue108_vs_pr30["overall_quality_loss_mae_mean"]
+            ),
+            "top_positive_preset_positive_contribution_share": float(
+                top_preset["mean_contribution"] / positive_preset_contribution
+            ),
+        },
+        "boundary_evidence": {
+            "reported_mtf_parity_with_pr30": {
+                "mtf_abs_signed_rel_mean": issue108_vs_pr30["mtf_abs_signed_rel_mean"] == 0.0,
+                "mtf20": issue108_vs_pr30["mtf20"] == 0.0,
+                "mtf30": issue108_vs_pr30["mtf30"] == 0.0,
+                "mtf50": issue108_vs_pr30["mtf50"] == 0.0,
+            },
+            "issue102_intrinsic_gains_preserved_vs_pr30": {
+                "curve_mae_mean": issue108_vs_pr30["curve_mae_mean"] < 0.0,
+                "focus_preset_acutance_mae_mean": (
+                    issue108_vs_pr30["focus_preset_acutance_mae_mean"] < 0.0
+                ),
+            },
+            "quality_loss_coefficients_and_ceilings_match_pr30": quality_loss_coefficients_equal(
+                issue108,
+                current_best,
+            ),
+            "remaining_pipeline_deltas_vs_pr30": differing_pipeline_keys(issue108, current_best),
+        },
+        "candidate_slices": candidate_slices,
+        "storage_policy": {
+            "golden_reference_roots": list(GOLDEN_REFERENCE_ROOTS),
+            "new_fitted_artifact_paths": [
+                "artifacts/intrinsic_after_issue108_next_slice_benchmark.json",
+            ],
+            "rules": [
+                "Keep issue-111 discovery outputs under `docs/` and `artifacts/` only.",
+                "Do not write fitted profiles, transfer tables, or generated outputs under golden/reference roots.",
+                "Do not touch release-facing configs in this issue.",
+            ],
+        },
+    }
+    assert_storage_separation(payload)
+    return payload
+
+
+def render_markdown(payload: dict[str, Any]) -> str:
+    records = payload["comparison_records"]
+    current_best = records[CURRENT_BEST_LABEL]
+    issue108 = records[ISSUE108_LABEL]
+    selected = next(
+        row for row in payload["candidate_slices"] if row["slice_id"] == payload["selected_slice_id"]
+    )
+    residual = payload["residual_quality_loss_boundaries"]
+    top_preset = residual["top_positive_preset"]
+
+    lines = [
+        "# Intrinsic After Issue 108 Next Slice",
+        "",
+        "This note records the Issue `#111` developer-discovery pass after issue `#108` / PR `#109` grafted the PR `#30` observed-branch bundle onto the issue-102 topology.",
+        "",
+        "## Selected Slice",
+        "",
+        f"- Selected slice: `{payload['selected_slice_id']}`",
+        f"- Summary: {payload['selected_summary']}",
+        "- Prior narrowing lineage: issue `#105` / PR `#106` / PR `#107` selected the PR30 observed-branch bundle, and issue `#108` / PR `#109` implemented it while preserving issue #102 curve/focus gains.",
+        "- Remaining gap location: reported-MTF is now equal to PR `#30`, Quality Loss coefficients are equal to PR `#30`, and the largest residual is the Computer Monitor Quality Loss preset-family input boundary.",
+        "",
+        "## Comparison Table",
+        "",
+        "| Record | Curve MAE | Focus Acu MAE | Overall QL | MTF20 | MTF30 | MTF50 | Abs Signed Rel | Reading |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+        f"| {CURRENT_BEST_LABEL} | {format_metric(current_best['curve_mae_mean'])} | {format_metric(current_best['focus_preset_acutance_mae_mean'])} | {format_metric(current_best['overall_quality_loss_mae_mean'])} | {format_metric(current_best['mtf_threshold_mae']['mtf20'])} | {format_metric(current_best['mtf_threshold_mae']['mtf30'])} | {format_metric(current_best['mtf_threshold_mae']['mtf50'])} | {format_metric(current_best['mtf_abs_signed_rel_mean'])} | Current best PR30 branch. |",
+        f"| {ISSUE108_LABEL} | {format_metric(issue108['curve_mae_mean'])} | {format_metric(issue108['focus_preset_acutance_mae_mean'])} | {format_metric(issue108['overall_quality_loss_mae_mean'])} | {format_metric(issue108['mtf_threshold_mae']['mtf20'])} | {format_metric(issue108['mtf_threshold_mae']['mtf30'])} | {format_metric(issue108['mtf_threshold_mae']['mtf50'])} | {format_metric(issue108['mtf_abs_signed_rel_mean'])} | Issue-108 bounded implementation from PR #109. |",
+        "",
+        "## Residual Quality Loss Preset Deltas",
+        "",
+        "| Preset | PR30 QL MAE | Issue108 QL MAE | Delta | Mean contribution |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for row in residual["quality_loss_preset_deltas"]:
+        lines.append(
+            f"| {row['preset']} | {format_metric(row['current_best_pr30'])} | {format_metric(row['issue108'])} | {row['delta']:+.5f} | {row['mean_contribution']:+.5f} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Residual Evidence",
+            "",
+            f"- Overall Quality Loss gap after issue #108: `{residual['issue108_vs_current_best_pr30']['overall_quality_loss_mae_mean']:+.5f}`.",
+            f"- Top positive preset delta: `{top_preset['preset']}` at `{top_preset['delta']:+.5f}`, contributing `{top_preset['mean_contribution']:+.5f}` to the mean gap.",
+            f"- Top preset share of the net residual gap: `{residual['top_positive_preset_net_gap_share']:.2%}`.",
+            f"- Reported-MTF parity with PR #30: `{all(payload['boundary_evidence']['reported_mtf_parity_with_pr30'].values())}`.",
+            f"- Quality Loss coefficients, preset overrides, and `quality_loss_om_ceiling` match PR #30: `{payload['boundary_evidence']['quality_loss_coefficients_and_ceilings_match_pr30']}`.",
+            f"- Issue #108 keeps curve/focus better than PR #30: `{all(payload['boundary_evidence']['issue102_intrinsic_gains_preserved_vs_pr30'].values())}`.",
+            "- Computer Monitor Acutance MAE is already better than PR #30, but Computer Monitor Quality Loss MAE is worse. That separates the residual from a generic preset-acutance failure and points at the downstream Quality Loss input/mapping branch.",
+            "- UHDTV Quality Loss is already better than PR #30, so a blanket Quality Loss branch swap is not the next minimum slice.",
+            "",
+            "## Remaining Pipeline Deltas",
+            "",
+        ]
+    )
+    for key, delta in payload["boundary_evidence"]["remaining_pipeline_deltas_vs_pr30"].items():
+        lines.append(
+            f"- `{key}`: issue108={delta[ISSUE108_LABEL]!r}, pr30={delta[CURRENT_BEST_LABEL]!r}"
+        )
+    lines.extend(["", "## Selected Implementation Boundary", ""])
+    for row in selected["minimum_implementation_boundary"]:
+        lines.append(f"- {row}")
+    lines.extend(["", "## Excluded Routes", ""])
+    for row in payload["candidate_slices"]:
+        if row["decision"] == "exclude":
+            lines.append(f"### `{row['slice_id']}`")
+            lines.append("")
+            lines.append(f"- Route: {row['label']}")
+            for reason in row["exclusion_reasons"]:
+                lines.append(f"- {reason}")
+            lines.append("")
+    lines.extend(["## Validation Plan For The Next Implementation Issue", ""])
+    for row in selected["validation_plan_for_next_issue"]:
+        lines.append(f"- {row}")
+    lines.extend(
+        [
+            "",
+            "## Storage Separation",
+            "",
+            f"- Golden/reference roots: `{GOLDEN_REFERENCE_ROOTS[0]}`, `{GOLDEN_REFERENCE_ROOTS[1]}`, `{GOLDEN_REFERENCE_ROOTS[2]}`",
+            "- Discovery outputs for this issue stay under `docs/` and `artifacts/` only.",
+            "- Do not write new fitted profiles, transfer tables, benchmark outputs, or release-facing configs under those roots.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    repo_root = args.repo_root.resolve()
+    payload = build_payload(
+        repo_root,
+        issue108_summary_path=args.issue108_summary,
+        issue108_acutance_artifact_path=args.issue108_acutance_artifact,
+        issue105_summary_path=args.issue105_summary,
+    )
+    output_json = resolve_path(repo_root, args.output_json)
+    output_md = resolve_path(repo_root, args.output_md)
+    write_text(output_json, json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    write_text(output_md, render_markdown(payload))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/artifacts/intrinsic_after_issue108_next_slice_benchmark.json
+++ b/artifacts/intrinsic_after_issue108_next_slice_benchmark.json
@@ -1,0 +1,1001 @@
+{
+  "boundary_evidence": {
+    "issue102_intrinsic_gains_preserved_vs_pr30": {
+      "curve_mae_mean": true,
+      "focus_preset_acutance_mae_mean": true
+    },
+    "quality_loss_coefficients_and_ceilings_match_pr30": true,
+    "remaining_pipeline_deltas_vs_pr30": {
+      "acutance_noise_scale_mode": {
+        "current_best_pr30_branch": "high_frequency_noise_share_quadratic",
+        "issue108_pr30_observed_bundle_candidate": "fixed"
+      },
+      "intrinsic_full_reference_mode": {
+        "current_best_pr30_branch": "none",
+        "issue108_pr30_observed_bundle_candidate": "paired_ori_transfer"
+      },
+      "intrinsic_full_reference_scope": {
+        "current_best_pr30_branch": "replace_all",
+        "issue108_pr30_observed_bundle_candidate": "reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only"
+      },
+      "intrinsic_full_reference_transfer_mode": {
+        "current_best_pr30_branch": "magnitude_ratio",
+        "issue108_pr30_observed_bundle_candidate": "radial_real_mean"
+      },
+      "matched_ori_anchor_mode": {
+        "current_best_pr30_branch": "acutance_only",
+        "issue108_pr30_observed_bundle_candidate": "all"
+      },
+      "readout_mtf_compensation_mode": {
+        "current_best_pr30_branch": null,
+        "issue108_pr30_observed_bundle_candidate": "sensor_aperture_sinc"
+      },
+      "readout_sensor_fill_factor": {
+        "current_best_pr30_branch": null,
+        "issue108_pr30_observed_bundle_candidate": 1.5
+      }
+    },
+    "reported_mtf_parity_with_pr30": {
+      "mtf20": true,
+      "mtf30": true,
+      "mtf50": true,
+      "mtf_abs_signed_rel_mean": true
+    }
+  },
+  "candidate_slices": [
+    {
+      "adoption_reason": "Computer Monitor Quality Loss is the largest positive preset delta after issue #108 and contributes most of the net residual mean gap by itself.",
+      "decision": "advance",
+      "label": "isolate the Computer Monitor Quality Loss preset-family downstream input boundary",
+      "minimum_implementation_boundary": [
+        "Do not change reported-MTF/readout metrics or their issue-108 PR30 observed-branch bundle.",
+        "Do not change the issue #102 intrinsic main-acutance branch used for curve and focus-preset Acutance.",
+        "Do not change Quality Loss coefficients, preset overrides, or `quality_loss_om_ceiling`.",
+        "Add only enough branch selection or instrumentation to route the Computer Monitor Quality Loss preset-family input through a PR #30-compatible downstream acutance/noise-anchor input while keeping the other Quality Loss presets on the issue-108 path for comparison."
+      ],
+      "repo_evidence": [
+        "Issue #108 matches PR #30 on `mtf_abs_signed_rel_mean`, `mtf20`, `mtf30`, and `mtf50`, so the residual is not a reported-MTF/readout retune problem.",
+        "Issue #108 keeps `curve_mae_mean` and `focus_preset_acutance_mae_mean` better than PR #30, so the issue #102 intrinsic main-acutance branch should not be discarded.",
+        "Quality Loss coefficients, preset overrides, and `quality_loss_om_ceiling` already match PR #30 exactly, so a coefficient/ceiling retune would ignore the checked-in evidence.",
+        "Computer Monitor Quality Loss delta is `+0.66202`, contributing `+0.13240` to the `+0.18513` overall mean delta; fixing only this preset would shrink most of the residual net gap.",
+        "Computer Monitor Acutance MAE is already better than PR #30 while Computer Monitor Quality Loss MAE is worse, which localizes the problem to the downstream Quality Loss input/mapping boundary rather than a general preset-acutance miss.",
+        "UHDTV Quality Loss is already better than PR #30, so a blanket downstream Quality Loss branch swap risks regressing an already-positive preset family."
+      ],
+      "selected_summary": "Keep issue #108 reported-MTF parity, the issue #102 intrinsic main-acutance gains, and the existing PR #30 Quality Loss coefficients/ceilings. The next bounded implementation should isolate only the Computer Monitor downstream Quality Loss preset-family input branch, comparing an issue-108 Quality Loss input against a PR #30-compatible acutance-only/noise-share anchor input for that preset before changing any other preset family.",
+      "slice_id": "issue108_computer_monitor_quality_loss_preset_boundary",
+      "validation_plan_for_next_issue": [
+        "Run the focused acutance/Quality Loss benchmark comparing PR #30, issue #108, and the Computer Monitor-only candidate.",
+        "Require `Computer Monitor Quality Loss` MAE to improve materially versus issue #108 while `overall_quality_loss_mae_mean` also improves.",
+        "Require `mtf_abs_signed_rel_mean`, `mtf20`, `mtf30`, and `mtf50` to remain equal to issue #108 / PR #30.",
+        "Require `curve_mae_mean` and `focus_preset_acutance_mae_mean` to remain no worse than issue #108."
+      ]
+    },
+    {
+      "decision": "exclude",
+      "exclusion_reasons": [
+        "Issue #108 and PR #30 already use identical global coefficients, identical preset overrides, and identical `quality_loss_om_ceiling`.",
+        "The residual therefore comes from the Quality Loss input branch, not from a missing fitted coefficient record."
+      ],
+      "label": "retune Quality Loss coefficients or ceilings",
+      "slice_id": "retune_quality_loss_coefficients_or_om_ceiling"
+    },
+    {
+      "decision": "exclude",
+      "exclusion_reasons": [
+        "Issue #108 already matches PR #30 on `mtf_abs_signed_rel_mean`, `mtf20`, `mtf30`, and `mtf50`.",
+        "Changing the reported-MTF branch would violate the issue-111 constraint to preserve issue-108 reported-MTF parity."
+      ],
+      "label": "retune reported-MTF/readout after issue #108",
+      "slice_id": "retune_reported_mtf_readout_again"
+    },
+    {
+      "decision": "exclude",
+      "exclusion_reasons": [
+        "Phone Quality Loss contributes only `+0.01901` to the residual mean gap, far less than the Computer Monitor contribution.",
+        "Issue #111 explicitly excludes reopening Phone-preset-only searches."
+      ],
+      "label": "reopen a Phone-only Quality Loss search",
+      "slice_id": "phone_preset_only_search"
+    },
+    {
+      "decision": "exclude",
+      "exclusion_reasons": [
+        "UHDTV Quality Loss is already better than PR #30 by `-0.18394`, so targeting it first would risk damaging an existing win."
+      ],
+      "label": "target UHDTV Quality Loss first",
+      "slice_id": "uhdtv_quality_loss_preset_family"
+    },
+    {
+      "decision": "exclude",
+      "exclusion_reasons": [
+        "The post-issue108 residual is already localized to downstream Quality Loss deltas after reported-MTF parity closed.",
+        "The issue-111 handoff asks for one bounded slice from measured issue-108 deltas, not a broad family search."
+      ],
+      "label": "restart broad intrinsic, matched-ori, or observable-stack search",
+      "slice_id": "restart_broad_intrinsic_or_observable_stack_search"
+    }
+  ],
+  "comparison_records": {
+    "current_best_pr30_branch": {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": 0.013802247905288301,
+        "Computer Monitor Acutance": 0.052665183748573804,
+        "Large Print Acutance": 0.05132586418527154,
+        "Small Print Acutance": 0.046702107662187464,
+        "UHDTV Display Acutance": 0.04793875259218785
+      },
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "readout_interpolation": "linear",
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": true
+      },
+      "curve_mae_mean": 0.03678903166100513,
+      "focus_preset_acutance_mae_mean": 0.042486831218701795,
+      "label": "current_best_pr30_branch",
+      "mtf_abs_signed_rel_mean": 0.08671416893394165,
+      "mtf_band_mae": {
+        "high": 0.01764835359892083,
+        "low": 0.03704553941403868,
+        "mid": 0.03898616152003224,
+        "top": 0.07374065223652229
+      },
+      "mtf_threshold_mae": {
+        "mtf20": 0.03301077142967389,
+        "mtf30": 0.03693639342667963,
+        "mtf50": 0.009332615436071163
+      },
+      "overall_quality_loss_mae_mean": 1.2214989544377113,
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_profile.json",
+      "quality_loss_preset_mae": {
+        "5.5\" Phone Display Quality Loss": 0.14297991495607307,
+        "Computer Monitor Quality Loss": 2.902905846061304,
+        "Large Print Quality Loss": 0.9548172583377941,
+        "Small Print Quality Loss": 0.6076935256225349,
+        "UHDTV Display Quality Loss": 1.4990982272108502
+      }
+    },
+    "issue102_readout_only_sensor_comp_candidate": {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": 0.035256377739795786,
+        "Computer Monitor Acutance": 0.024146307932311834,
+        "Large Print Acutance": 0.028624302638652583,
+        "Small Print Acutance": 0.031726251556383624,
+        "UHDTV Display Acutance": 0.024849392176481848
+      },
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": null,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "reported_mtf_disconnect_readout_only_sensor_comp_quality_loss_isolation_downstream_matched_ori_only",
+        "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "none",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "readout_interpolation": "linear",
+        "readout_mtf_compensation_mode": "sensor_aperture_sinc",
+        "readout_sensor_fill_factor": 1.5,
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.0,
+        "texture_support_scale": false
+      },
+      "curve_mae_mean": 0.03280180556381627,
+      "focus_preset_acutance_mae_mean": 0.028920526408725132,
+      "label": "issue102_readout_only_sensor_comp_candidate",
+      "mtf_abs_signed_rel_mean": 0.23032739186536783,
+      "mtf_threshold_mae": {
+        "mtf20": 0.029717151352443162,
+        "mtf30": 0.04292606807428576,
+        "mtf50": 0.03094126939316686
+      },
+      "overall_quality_loss_mae_mean": 3.9474295338821266,
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_readout_only_sensor_comp_quality_loss_isolation_downstream_matched_ori_only_profile.json",
+      "quality_loss_preset_mae": {
+        "5.5\" Phone Display Quality Loss": 4.122316176755632,
+        "Computer Monitor Quality Loss": 6.1264243907692375,
+        "Large Print Quality Loss": 2.079928486542698,
+        "Small Print Quality Loss": 3.490178763693591,
+        "UHDTV Display Quality Loss": 3.918299851649472
+      }
+    },
+    "issue108_pr30_observed_bundle_candidate": {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": 0.035256377739795786,
+        "Computer Monitor Acutance": 0.024146307932311834,
+        "Large Print Acutance": 0.028624302638652583,
+        "Small Print Acutance": 0.031726251556383624,
+        "UHDTV Display Acutance": 0.024849392176481848
+      },
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only",
+        "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "readout_interpolation": "linear",
+        "readout_mtf_compensation_mode": "sensor_aperture_sinc",
+        "readout_sensor_fill_factor": 1.5,
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": true
+      },
+      "curve_mae_mean": 0.03280180556381627,
+      "focus_preset_acutance_mae_mean": 0.028920526408725132,
+      "label": "issue108_pr30_observed_bundle_candidate",
+      "mtf_abs_signed_rel_mean": 0.08671416893394165,
+      "mtf_threshold_mae": {
+        "mtf20": 0.03301077142967389,
+        "mtf30": 0.03693639342667963,
+        "mtf50": 0.009332615436071163
+      },
+      "overall_quality_loss_mae_mean": 1.4066322278046604,
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_profile.json",
+      "quality_loss_preset_mae": {
+        "5.5\" Phone Display Quality Loss": 0.23804277891732473,
+        "Computer Monitor Quality Loss": 3.5649281016968333,
+        "Large Print Quality Loss": 1.0605366314170437,
+        "Small Print Quality Loss": 0.8544992186252707,
+        "UHDTV Display Quality Loss": 1.3151544083668303
+      }
+    }
+  },
+  "issue": 111,
+  "residual_quality_loss_boundaries": {
+    "acutance_preset_deltas": [
+      {
+        "current_best_pr30": 0.013802247905288301,
+        "delta": 0.021454129834507486,
+        "issue108": 0.035256377739795786,
+        "preset": "5.5\" Phone Display Acutance"
+      },
+      {
+        "current_best_pr30": 0.052665183748573804,
+        "delta": -0.02851887581626197,
+        "issue108": 0.024146307932311834,
+        "preset": "Computer Monitor Acutance"
+      },
+      {
+        "current_best_pr30": 0.05132586418527154,
+        "delta": -0.022701561546618957,
+        "issue108": 0.028624302638652583,
+        "preset": "Large Print Acutance"
+      },
+      {
+        "current_best_pr30": 0.046702107662187464,
+        "delta": -0.01497585610580384,
+        "issue108": 0.031726251556383624,
+        "preset": "Small Print Acutance"
+      },
+      {
+        "current_best_pr30": 0.04793875259218785,
+        "delta": -0.023089360415706,
+        "issue108": 0.024849392176481848,
+        "preset": "UHDTV Display Acutance"
+      }
+    ],
+    "by_mixup_quality_loss_deltas": [
+      {
+        "current_best_pr30": 2.317792173136315,
+        "delta": 1.380384667856239,
+        "issue108": 3.698176840992554,
+        "mixup": "ori"
+      },
+      {
+        "current_best_pr30": 1.1337887188584643,
+        "delta": 0.3243058671330876,
+        "issue108": 1.458094585991552,
+        "mixup": "0.4"
+      },
+      {
+        "current_best_pr30": 0.3646116302822078,
+        "delta": 0.2885842700654284,
+        "issue108": 0.6531959003476362,
+        "mixup": "0.65"
+      },
+      {
+        "current_best_pr30": 1.0109879373437751,
+        "delta": 0.23489238459587836,
+        "issue108": 1.2458803219396535,
+        "mixup": "0.8"
+      },
+      {
+        "current_best_pr30": 1.2825995432153037,
+        "delta": -0.16571376264191584,
+        "issue108": 1.1168857805733878,
+        "mixup": "0.25"
+      },
+      {
+        "current_best_pr30": 1.3421389514230824,
+        "delta": -0.30552487157446806,
+        "issue108": 1.0366140798486143,
+        "mixup": "0.15"
+      }
+    ],
+    "issue108_vs_current_best_pr30": {
+      "curve_mae_mean": -0.0039872260971888646,
+      "focus_preset_acutance_mae_mean": -0.013566304809976663,
+      "mtf20": 0.0,
+      "mtf30": 0.0,
+      "mtf50": 0.0,
+      "mtf_abs_signed_rel_mean": 0.0,
+      "overall_quality_loss_mae_mean": 0.18513327336694907
+    },
+    "issue108_vs_issue102": {
+      "curve_mae_mean": 0.0,
+      "focus_preset_acutance_mae_mean": 0.0,
+      "mtf20": 0.003293620077230726,
+      "mtf30": -0.005989674647606136,
+      "mtf50": -0.0216086539570957,
+      "mtf_abs_signed_rel_mean": -0.14361322293142617,
+      "overall_quality_loss_mae_mean": -2.540797306077466
+    },
+    "positive_preset_mean_contribution": 0.22192203713575323,
+    "quality_loss_preset_deltas": [
+      {
+        "current_best_pr30": 2.902905846061304,
+        "delta": 0.6620222556355291,
+        "direction": "worse_than_pr30",
+        "issue108": 3.5649281016968333,
+        "mean_contribution": 0.1324044511271058,
+        "preset": "Computer Monitor Quality Loss"
+      },
+      {
+        "current_best_pr30": 0.6076935256225349,
+        "delta": 0.2468056930027358,
+        "direction": "worse_than_pr30",
+        "issue108": 0.8544992186252707,
+        "mean_contribution": 0.04936113860054716,
+        "preset": "Small Print Quality Loss"
+      },
+      {
+        "current_best_pr30": 0.9548172583377941,
+        "delta": 0.10571937307924961,
+        "direction": "worse_than_pr30",
+        "issue108": 1.0605366314170437,
+        "mean_contribution": 0.021143874615849923,
+        "preset": "Large Print Quality Loss"
+      },
+      {
+        "current_best_pr30": 0.14297991495607307,
+        "delta": 0.09506286396125166,
+        "direction": "worse_than_pr30",
+        "issue108": 0.23804277891732473,
+        "mean_contribution": 0.019012572792250333,
+        "preset": "5.5\" Phone Display Quality Loss"
+      },
+      {
+        "current_best_pr30": 1.4990982272108502,
+        "delta": -0.1839438188440199,
+        "direction": "better_than_or_equal_pr30",
+        "issue108": 1.3151544083668303,
+        "mean_contribution": -0.03678876376880398,
+        "preset": "UHDTV Display Quality Loss"
+      }
+    ],
+    "top_positive_preset": {
+      "current_best_pr30": 2.902905846061304,
+      "delta": 0.6620222556355291,
+      "direction": "worse_than_pr30",
+      "issue108": 3.5649281016968333,
+      "mean_contribution": 0.1324044511271058,
+      "preset": "Computer Monitor Quality Loss"
+    },
+    "top_positive_preset_net_gap_share": 0.7151845193417474,
+    "top_positive_preset_positive_contribution_share": 0.5966259720575289
+  },
+  "selected_slice_id": "issue108_computer_monitor_quality_loss_preset_boundary",
+  "selected_summary": "Keep issue #108 reported-MTF parity, the issue #102 intrinsic main-acutance gains, and the existing PR #30 Quality Loss coefficients/ceilings. The next bounded implementation should isolate only the Computer Monitor downstream Quality Loss preset-family input branch, comparing an issue-108 Quality Loss input against a PR #30-compatible acutance-only/noise-share anchor input for that preset before changing any other preset family.",
+  "source_artifacts": {
+    "comparison_basis_refs": [
+      "pr-30",
+      "issue-102",
+      "issue-105",
+      "issue-108",
+      "pr-109"
+    ],
+    "issue105_selected_slice_id": "issue102_topology_graft_pr30_observable_stack_onto_observed_branches",
+    "issue105_summary": "artifacts/intrinsic_after_issue102_next_slice_benchmark.json",
+    "issue108_acutance_artifact": "artifacts/issue108_intrinsic_phase_retained_pr30_observed_bundle_acutance_benchmark.json",
+    "issue108_summary": "artifacts/intrinsic_phase_retained_pr30_observed_bundle_benchmark.json"
+  },
+  "storage_policy": {
+    "golden_reference_roots": [
+      "20260318_deadleaf_13b10",
+      "release/deadleaf_13b10_release/data/20260318_deadleaf_13b10",
+      "release/deadleaf_13b10_release/config"
+    ],
+    "new_fitted_artifact_paths": [
+      "artifacts/intrinsic_after_issue108_next_slice_benchmark.json"
+    ],
+    "rules": [
+      "Keep issue-111 discovery outputs under `docs/` and `artifacts/` only.",
+      "Do not write fitted profiles, transfer tables, or generated outputs under golden/reference roots.",
+      "Do not touch release-facing configs in this issue."
+    ]
+  },
+  "summary_kind": "intrinsic_after_issue108_next_slice"
+}

--- a/docs/intrinsic_after_issue108_next_slice.md
+++ b/docs/intrinsic_after_issue108_next_slice.md
@@ -1,0 +1,99 @@
+# Intrinsic After Issue 108 Next Slice
+
+This note records the Issue `#111` developer-discovery pass after issue `#108` / PR `#109` grafted the PR `#30` observed-branch bundle onto the issue-102 topology.
+
+## Selected Slice
+
+- Selected slice: `issue108_computer_monitor_quality_loss_preset_boundary`
+- Summary: Keep issue #108 reported-MTF parity, the issue #102 intrinsic main-acutance gains, and the existing PR #30 Quality Loss coefficients/ceilings. The next bounded implementation should isolate only the Computer Monitor downstream Quality Loss preset-family input branch, comparing an issue-108 Quality Loss input against a PR #30-compatible acutance-only/noise-share anchor input for that preset before changing any other preset family.
+- Prior narrowing lineage: issue `#105` / PR `#106` / PR `#107` selected the PR30 observed-branch bundle, and issue `#108` / PR `#109` implemented it while preserving issue #102 curve/focus gains.
+- Remaining gap location: reported-MTF is now equal to PR `#30`, Quality Loss coefficients are equal to PR `#30`, and the largest residual is the Computer Monitor Quality Loss preset-family input boundary.
+
+## Comparison Table
+
+| Record | Curve MAE | Focus Acu MAE | Overall QL | MTF20 | MTF30 | MTF50 | Abs Signed Rel | Reading |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| current_best_pr30_branch | 0.03679 | 0.04249 | 1.22150 | 0.03301 | 0.03694 | 0.00933 | 0.08671 | Current best PR30 branch. |
+| issue108_pr30_observed_bundle_candidate | 0.03280 | 0.02892 | 1.40663 | 0.03301 | 0.03694 | 0.00933 | 0.08671 | Issue-108 bounded implementation from PR #109. |
+
+## Residual Quality Loss Preset Deltas
+
+| Preset | PR30 QL MAE | Issue108 QL MAE | Delta | Mean contribution |
+| --- | --- | --- | --- | --- |
+| Computer Monitor Quality Loss | 2.90291 | 3.56493 | +0.66202 | +0.13240 |
+| Small Print Quality Loss | 0.60769 | 0.85450 | +0.24681 | +0.04936 |
+| Large Print Quality Loss | 0.95482 | 1.06054 | +0.10572 | +0.02114 |
+| 5.5" Phone Display Quality Loss | 0.14298 | 0.23804 | +0.09506 | +0.01901 |
+| UHDTV Display Quality Loss | 1.49910 | 1.31515 | -0.18394 | -0.03679 |
+
+## Residual Evidence
+
+- Overall Quality Loss gap after issue #108: `+0.18513`.
+- Top positive preset delta: `Computer Monitor Quality Loss` at `+0.66202`, contributing `+0.13240` to the mean gap.
+- Top preset share of the net residual gap: `71.52%`.
+- Reported-MTF parity with PR #30: `True`.
+- Quality Loss coefficients, preset overrides, and `quality_loss_om_ceiling` match PR #30: `True`.
+- Issue #108 keeps curve/focus better than PR #30: `True`.
+- Computer Monitor Acutance MAE is already better than PR #30, but Computer Monitor Quality Loss MAE is worse. That separates the residual from a generic preset-acutance failure and points at the downstream Quality Loss input/mapping branch.
+- UHDTV Quality Loss is already better than PR #30, so a blanket Quality Loss branch swap is not the next minimum slice.
+
+## Remaining Pipeline Deltas
+
+- `acutance_noise_scale_mode`: issue108='fixed', pr30='high_frequency_noise_share_quadratic'
+- `intrinsic_full_reference_mode`: issue108='paired_ori_transfer', pr30='none'
+- `intrinsic_full_reference_scope`: issue108='reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only', pr30='replace_all'
+- `intrinsic_full_reference_transfer_mode`: issue108='radial_real_mean', pr30='magnitude_ratio'
+- `matched_ori_anchor_mode`: issue108='all', pr30='acutance_only'
+- `readout_mtf_compensation_mode`: issue108='sensor_aperture_sinc', pr30=None
+- `readout_sensor_fill_factor`: issue108=1.5, pr30=None
+
+## Selected Implementation Boundary
+
+- Do not change reported-MTF/readout metrics or their issue-108 PR30 observed-branch bundle.
+- Do not change the issue #102 intrinsic main-acutance branch used for curve and focus-preset Acutance.
+- Do not change Quality Loss coefficients, preset overrides, or `quality_loss_om_ceiling`.
+- Add only enough branch selection or instrumentation to route the Computer Monitor Quality Loss preset-family input through a PR #30-compatible downstream acutance/noise-anchor input while keeping the other Quality Loss presets on the issue-108 path for comparison.
+
+## Excluded Routes
+
+### `retune_quality_loss_coefficients_or_om_ceiling`
+
+- Route: retune Quality Loss coefficients or ceilings
+- Issue #108 and PR #30 already use identical global coefficients, identical preset overrides, and identical `quality_loss_om_ceiling`.
+- The residual therefore comes from the Quality Loss input branch, not from a missing fitted coefficient record.
+
+### `retune_reported_mtf_readout_again`
+
+- Route: retune reported-MTF/readout after issue #108
+- Issue #108 already matches PR #30 on `mtf_abs_signed_rel_mean`, `mtf20`, `mtf30`, and `mtf50`.
+- Changing the reported-MTF branch would violate the issue-111 constraint to preserve issue-108 reported-MTF parity.
+
+### `phone_preset_only_search`
+
+- Route: reopen a Phone-only Quality Loss search
+- Phone Quality Loss contributes only `+0.01901` to the residual mean gap, far less than the Computer Monitor contribution.
+- Issue #111 explicitly excludes reopening Phone-preset-only searches.
+
+### `uhdtv_quality_loss_preset_family`
+
+- Route: target UHDTV Quality Loss first
+- UHDTV Quality Loss is already better than PR #30 by `-0.18394`, so targeting it first would risk damaging an existing win.
+
+### `restart_broad_intrinsic_or_observable_stack_search`
+
+- Route: restart broad intrinsic, matched-ori, or observable-stack search
+- The post-issue108 residual is already localized to downstream Quality Loss deltas after reported-MTF parity closed.
+- The issue-111 handoff asks for one bounded slice from measured issue-108 deltas, not a broad family search.
+
+## Validation Plan For The Next Implementation Issue
+
+- Run the focused acutance/Quality Loss benchmark comparing PR #30, issue #108, and the Computer Monitor-only candidate.
+- Require `Computer Monitor Quality Loss` MAE to improve materially versus issue #108 while `overall_quality_loss_mae_mean` also improves.
+- Require `mtf_abs_signed_rel_mean`, `mtf20`, `mtf30`, and `mtf50` to remain equal to issue #108 / PR #30.
+- Require `curve_mae_mean` and `focus_preset_acutance_mae_mean` to remain no worse than issue #108.
+
+## Storage Separation
+
+- Golden/reference roots: `20260318_deadleaf_13b10`, `release/deadleaf_13b10_release/data/20260318_deadleaf_13b10`, `release/deadleaf_13b10_release/config`
+- Discovery outputs for this issue stay under `docs/` and `artifacts/` only.
+- Do not write new fitted profiles, transfer tables, benchmark outputs, or release-facing configs under those roots.

--- a/tests/test_build_intrinsic_after_issue108_next_slice.py
+++ b/tests/test_build_intrinsic_after_issue108_next_slice.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from algo.build_intrinsic_after_issue108_next_slice import (
+    SELECTED_SLICE_ID,
+    build_payload,
+    render_markdown,
+)
+
+
+class BuildIntrinsicAfterIssue108NextSliceTest(unittest.TestCase):
+    def test_payload_selects_computer_monitor_quality_loss_boundary(self) -> None:
+        payload = build_payload(
+            self.repo_root(),
+            issue108_summary_path=Path(
+                "artifacts/intrinsic_phase_retained_pr30_observed_bundle_benchmark.json"
+            ),
+            issue108_acutance_artifact_path=Path(
+                "artifacts/issue108_intrinsic_phase_retained_pr30_observed_bundle_acutance_benchmark.json"
+            ),
+            issue105_summary_path=Path("artifacts/intrinsic_after_issue102_next_slice_benchmark.json"),
+        )
+
+        self.assertEqual(payload["issue"], 111)
+        self.assertEqual(payload["summary_kind"], "intrinsic_after_issue108_next_slice")
+        self.assertEqual(payload["selected_slice_id"], SELECTED_SLICE_ID)
+        selected = next(
+            row for row in payload["candidate_slices"] if row["slice_id"] == SELECTED_SLICE_ID
+        )
+        self.assertEqual(selected["decision"], "advance")
+        self.assertIn("Computer Monitor", selected["selected_summary"])
+
+        residual = payload["residual_quality_loss_boundaries"]
+        top_preset = residual["top_positive_preset"]
+        self.assertEqual(top_preset["preset"], "Computer Monitor Quality Loss")
+        self.assertGreater(top_preset["delta"], 0.66)
+        self.assertGreater(top_preset["mean_contribution"], 0.13)
+        self.assertGreater(residual["top_positive_preset_net_gap_share"], 0.70)
+
+        self.assertTrue(
+            all(payload["boundary_evidence"]["reported_mtf_parity_with_pr30"].values())
+        )
+        self.assertTrue(
+            payload["boundary_evidence"]["quality_loss_coefficients_and_ceilings_match_pr30"]
+        )
+        self.assertTrue(
+            all(
+                payload["boundary_evidence"][
+                    "issue102_intrinsic_gains_preserved_vs_pr30"
+                ].values()
+            )
+        )
+
+        excluded = {
+            row["slice_id"]: row for row in payload["candidate_slices"] if row["decision"] == "exclude"
+        }
+        self.assertIn("retune_quality_loss_coefficients_or_om_ceiling", excluded)
+        self.assertIn("retune_reported_mtf_readout_again", excluded)
+        self.assertIn("phone_preset_only_search", excluded)
+        self.assertIn("uhdtv_quality_loss_preset_family", excluded)
+
+        for path in payload["storage_policy"]["new_fitted_artifact_paths"]:
+            self.assertFalse(path.startswith("20260318_deadleaf_13b10"))
+            self.assertFalse(
+                path.startswith("release/deadleaf_13b10_release/data/20260318_deadleaf_13b10")
+            )
+            self.assertFalse(path.startswith("release/deadleaf_13b10_release/config"))
+
+    def test_markdown_mentions_evidence_and_storage(self) -> None:
+        payload = build_payload(
+            self.repo_root(),
+            issue108_summary_path=Path(
+                "artifacts/intrinsic_phase_retained_pr30_observed_bundle_benchmark.json"
+            ),
+            issue108_acutance_artifact_path=Path(
+                "artifacts/issue108_intrinsic_phase_retained_pr30_observed_bundle_acutance_benchmark.json"
+            ),
+            issue105_summary_path=Path("artifacts/intrinsic_after_issue102_next_slice_benchmark.json"),
+        )
+        markdown = render_markdown(payload)
+
+        self.assertIn("# Intrinsic After Issue 108 Next Slice", markdown)
+        self.assertIn("Issue `#111`", markdown)
+        self.assertIn("Computer Monitor Quality Loss", markdown)
+        self.assertIn("reported-MTF", markdown)
+        self.assertIn("Quality Loss coefficients", markdown)
+        self.assertIn("UHDTV Quality Loss", markdown)
+        self.assertIn("Storage Separation", markdown)
+
+    @staticmethod
+    def repo_root() -> Path:
+        return Path(__file__).resolve().parents[1]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs #29
Refs #102
Refs #105
Refs #108
Refs #111
Context from #109

## Summary
- add an issue-111 developer-discovery builder for the post-issue108 residual Quality Loss gap
- generate the checked-in artifact artifacts/intrinsic_after_issue108_next_slice_benchmark.json and note docs/intrinsic_after_issue108_next_slice.md
- select the next bounded slice as the Computer Monitor Quality Loss preset-family downstream input boundary, while preserving issue-108 reported-MTF parity and issue-102 curve/focus gains

## Result
- issue #108 and PR #30 match on reported-MTF metrics, so reported-MTF/readout retuning is excluded
- Quality Loss coefficients, preset overrides, and ceilings already match PR #30, so coefficient/ceiling retuning is excluded
- Computer Monitor Quality Loss is the largest positive preset delta: +0.66202, contributing +0.13240 of the +0.18513 mean gap
- UHDTV Quality Loss is already better than PR #30, so a blanket downstream branch swap is excluded

## Validation
- python3 -m algo.build_intrinsic_after_issue108_next_slice
- python3 -m py_compile algo/build_intrinsic_after_issue108_next_slice.py
- python3 -m pytest tests/test_build_intrinsic_after_issue108_next_slice.py
- python3 -m pytest tests/test_build_intrinsic_phase_retained_pr30_observed_bundle_followup.py tests/test_build_intrinsic_after_issue108_next_slice.py