### PR TITLE
Issue #111: fix raw by-mixup profile selection

### DIFF
--- a/algo/build_intrinsic_after_issue108_next_slice.py
+++ b/algo/build_intrinsic_after_issue108_next_slice.py
@@ -11,6 +11,15 @@ CURRENT_BEST_LABEL = "current_best_pr30_branch"
 ISSUE102_LABEL = "issue102_readout_only_sensor_comp_candidate"
 ISSUE108_LABEL = "issue108_pr30_observed_bundle_candidate"
 SELECTED_SLICE_ID = "issue108_computer_monitor_quality_loss_preset_boundary"
+RAW_CURRENT_BEST_PROFILE_PATH = (
+    "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_"
+    "curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json"
+)
+RAW_ISSUE108_PROFILE_PATH = (
+    "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_"
+    "reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_"
+    "downstream_matched_ori_only_profile.json"
+)
 GOLDEN_REFERENCE_ROOTS = (
     "20260318_deadleaf_13b10",
     "release/deadleaf_13b10_release/data/20260318_deadleaf_13b10",
@@ -135,9 +144,32 @@ def acutance_preset_deltas(
     ]
 
 
-def by_mixup_quality_loss_deltas(raw_acutance_artifact: dict[str, Any]) -> list[dict[str, Any]]:
-    current_best = raw_acutance_artifact["profiles"][0]["by_mixup_quality_loss_mae_mean"]
-    issue108 = raw_acutance_artifact["profiles"][2]["by_mixup_quality_loss_mae_mean"]
+def select_raw_profile(
+    raw_acutance_artifact: dict[str, Any],
+    *,
+    profile_path: str,
+) -> dict[str, Any]:
+    for profile in raw_acutance_artifact["profiles"]:
+        if profile["profile_path"] == profile_path:
+            return profile
+    available = ", ".join(profile["profile_path"] for profile in raw_acutance_artifact["profiles"])
+    raise ValueError(f"Raw acutance profile {profile_path!r} not found. Available: {available}")
+
+
+def by_mixup_quality_loss_deltas(
+    raw_acutance_artifact: dict[str, Any],
+    *,
+    current_best_profile_path: str = RAW_CURRENT_BEST_PROFILE_PATH,
+    issue108_profile_path: str = RAW_ISSUE108_PROFILE_PATH,
+) -> list[dict[str, Any]]:
+    current_best = select_raw_profile(
+        raw_acutance_artifact,
+        profile_path=current_best_profile_path,
+    )["by_mixup_quality_loss_mae_mean"]
+    issue108 = select_raw_profile(
+        raw_acutance_artifact,
+        profile_path=issue108_profile_path,
+    )["by_mixup_quality_loss_mae_mean"]
     rows = [
         {
             "mixup": mixup,

--- a/tests/test_build_intrinsic_after_issue108_next_slice.py
+++ b/tests/test_build_intrinsic_after_issue108_next_slice.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -88,6 +90,43 @@ class BuildIntrinsicAfterIssue108NextSliceTest(unittest.TestCase):
         self.assertIn("Quality Loss coefficients", markdown)
         self.assertIn("UHDTV Quality Loss", markdown)
         self.assertIn("Storage Separation", markdown)
+
+    def test_by_mixup_evidence_is_independent_of_raw_profile_order(self) -> None:
+        repo_root = self.repo_root()
+        raw_path = (
+            repo_root
+            / "artifacts/issue108_intrinsic_phase_retained_pr30_observed_bundle_acutance_benchmark.json"
+        )
+        raw_payload = json.loads(raw_path.read_text(encoding="utf-8"))
+        raw_payload["profiles"] = list(reversed(raw_payload["profiles"]))
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            reordered_path = Path(tmp_dir) / "reordered_issue108_acutance.json"
+            reordered_path.write_text(json.dumps(raw_payload, sort_keys=True), encoding="utf-8")
+
+            baseline = build_payload(
+                repo_root,
+                issue108_summary_path=Path(
+                    "artifacts/intrinsic_phase_retained_pr30_observed_bundle_benchmark.json"
+                ),
+                issue108_acutance_artifact_path=Path(
+                    "artifacts/issue108_intrinsic_phase_retained_pr30_observed_bundle_acutance_benchmark.json"
+                ),
+                issue105_summary_path=Path("artifacts/intrinsic_after_issue102_next_slice_benchmark.json"),
+            )
+            reordered = build_payload(
+                repo_root,
+                issue108_summary_path=Path(
+                    "artifacts/intrinsic_phase_retained_pr30_observed_bundle_benchmark.json"
+                ),
+                issue108_acutance_artifact_path=reordered_path,
+                issue105_summary_path=Path("artifacts/intrinsic_after_issue102_next_slice_benchmark.json"),
+            )
+
+        self.assertEqual(
+            baseline["residual_quality_loss_boundaries"]["by_mixup_quality_loss_deltas"],
+            reordered["residual_quality_loss_boundaries"]["by_mixup_quality_loss_deltas"],
+        )
 
     @staticmethod
     def repo_root() -> Path:


### PR DESCRIPTION
Refs #29
Refs #102
Refs #105
Refs #108
Refs #111
Context from #109
Follow-up to #112

## Summary
- select raw acutance benchmark profiles by expected profile_path instead of list position when computing issue-111 by-mixup Quality Loss deltas
- add regression coverage that reverses the raw issue-108 profile order and verifies by-mixup evidence is unchanged
- regenerate the issue-111 artifact; it remains byte-stable because the checked-in raw artifact already had the expected order

## Validation
- python3 -m algo.build_intrinsic_after_issue108_next_slice
- python3 -m py_compile algo/build_intrinsic_after_issue108_next_slice.py
- python3 -m pytest tests/test_build_intrinsic_after_issue108_next_slice.py tests/test_build_intrinsic_phase_retained_pr30_observed_bundle_followup.py