### PR TITLE
Issue #114: isolate Computer Monitor Quality Loss input

### DIFF
--- a/algo/benchmark_parity_acutance_quality_loss.py
+++ b/algo/benchmark_parity_acutance_quality_loss.py
@@ -173,6 +173,7 @@ class Profile:
     quality_loss_om_ceiling: float = 0.8851
     quality_loss_coefficients: tuple[float, float, float] = (64.99250542, 9.37974246, 0.72233291)
     quality_loss_preset_overrides: dict[str, dict[str, object]] | None = None
+    quality_loss_preset_input_profile_overrides: dict[str, str] | None = None
     acutance_preset_overrides: dict[str, dict[str, float | str | None]] | None = None
     texture_support_scale: bool = False
     mtf_compensation_mode: str = "none"
@@ -292,6 +293,61 @@ def build_acutance_presets(
     return tuple(presets)
 
 
+def resolve_profile_override_path(profile_path: Path, override_path: str) -> Path:
+    candidate = Path(override_path)
+    if candidate.is_absolute() or candidate.exists():
+        return candidate
+    sibling = profile_path.parent / candidate.name
+    if sibling.exists():
+        return sibling
+    return candidate
+
+
+def build_quality_loss_input_override_records(
+    *,
+    dataset_root: Path,
+    profile_path: Path,
+    profile: Profile,
+    width: int,
+    height: int,
+    override_stack: frozenset[str],
+) -> dict[str, dict[str, float]]:
+    overrides = profile.quality_loss_preset_input_profile_overrides or {}
+    records_by_preset: dict[str, dict[str, float]] = {}
+    for quality_loss_preset, override_profile_path_text in overrides.items():
+        override_profile_path = resolve_profile_override_path(
+            profile_path,
+            override_profile_path_text,
+        )
+        override_key = str(override_profile_path)
+        if override_key in override_stack:
+            raise ValueError(
+                "Recursive quality-loss input profile override detected for "
+                f"{override_profile_path_text!r}"
+            )
+        override_payload = summarize_profile(
+            dataset_root=dataset_root,
+            profile_path=override_profile_path,
+            profile=load_profile(override_profile_path),
+            width=width,
+            height=height,
+            include_quality_loss_records=True,
+            override_stack=override_stack | {override_key},
+        )
+        preset_records = {
+            str(record["csv_path"]): float(record["predicted_acutance"])
+            for record in override_payload["quality_loss_records"]
+            if record["preset_name"] == quality_loss_preset
+        }
+        if not preset_records:
+            raise ValueError(
+                f"Quality Loss preset {quality_loss_preset!r} not found in "
+                f"override profile {override_profile_path_text!r}"
+            )
+        records_by_preset[quality_loss_preset] = preset_records
+    return records_by_preset
+
+
 def summarize_profile(
     *,
     dataset_root: Path,
@@ -301,6 +357,7 @@ def summarize_profile(
     height: int,
     include_acutance_records: bool = False,
     include_quality_loss_records: bool = False,
+    override_stack: frozenset[str] = frozenset(),
 ) -> dict[str, object]:
     calibration = load_ideal_psd_calibration(profile.calibration_file)
     use_ori_reference = any(
@@ -325,6 +382,14 @@ def summarize_profile(
     by_mixup_quality_loss_mae: dict[str, list[float]] = {}
     acutance_records: list[dict[str, object]] = []
     quality_loss_records: list[dict[str, object]] = []
+    quality_loss_input_override_records = build_quality_loss_input_override_records(
+        dataset_root=dataset_root,
+        profile_path=profile_path,
+        profile=profile,
+        width=width,
+        height=height,
+        override_stack=override_stack | {str(profile_path)},
+    )
 
     def maybe_anchor_acutance_results(
         *,
@@ -977,7 +1042,13 @@ def summarize_profile(
                 roi_height=estimate.roi.height,
             )
         else:
-            quality_loss_acutance = acutance
+            quality_loss_acutance = dict(acutance)
+        for quality_loss_preset, override_records in quality_loss_input_override_records.items():
+            override_acutance = override_records.get(str(csv_path))
+            if override_acutance is None:
+                continue
+            acutance_preset = quality_loss_preset.replace("Quality Loss", "Acutance")
+            quality_loss_acutance[acutance_preset] = override_acutance
         curve_cmp = compare_acutance_curves(curve, reference.acutance_table)
         if curve_cmp.get("count", 0):
             curve_mae.append(float(curve_cmp["mae"]))
@@ -1120,6 +1191,9 @@ def summarize_profile(
             "quality_loss_om_ceiling": profile.quality_loss_om_ceiling,
             "quality_loss_coefficients": profile.quality_loss_coefficients,
             "quality_loss_preset_overrides": profile.quality_loss_preset_overrides,
+            "quality_loss_preset_input_profile_overrides": (
+                profile.quality_loss_preset_input_profile_overrides
+            ),
             "frequency_scale": profile.frequency_scale,
             "readout_smoothing_window": profile.readout_smoothing_window,
             "readout_interpolation": profile.readout_interpolation,

--- a/algo/benchmark_parity_psd_mtf.py
+++ b/algo/benchmark_parity_psd_mtf.py
@@ -167,6 +167,7 @@ class Profile:
     quality_loss_om_ceiling: float = 0.8851
     quality_loss_coefficients: tuple[float, float, float] = (64.99250542, 9.37974246, 0.72233291)
     quality_loss_preset_overrides: dict[str, dict[str, object]] | None = None
+    quality_loss_preset_input_profile_overrides: dict[str, str] | None = None
     acutance_preset_overrides: dict[str, dict[str, float | str | None]] | None = None
 
 
@@ -830,6 +831,9 @@ def profile_payload(
             "calibration_file": profile.calibration_file,
             "mtf_compensation_mode": profile.mtf_compensation_mode,
             "sensor_fill_factor": profile.sensor_fill_factor,
+            "quality_loss_preset_input_profile_overrides": (
+                profile.quality_loss_preset_input_profile_overrides
+            ),
             "readout_mtf_compensation_mode": readout_mtf_compensation_mode,
             "readout_sensor_fill_factor": readout_sensor_fill_factor,
             "chart_fill_factor": profile.chart_fill_factor,

--- a/algo/build_intrinsic_after_issue111_quality_loss_boundary_followup.py
+++ b/algo/build_intrinsic_after_issue111_quality_loss_boundary_followup.py
@@ -1,0 +1,414 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+CURRENT_BEST_LABEL = "current_best_pr30_branch"
+ISSUE108_LABEL = "issue108_pr30_observed_bundle_candidate"
+CANDIDATE_LABEL = "issue114_computer_monitor_quality_loss_input_boundary_candidate"
+SUMMARY_KIND = "intrinsic_after_issue111_quality_loss_boundary_followup"
+COMPUTER_MONITOR_QUALITY_LOSS = "Computer Monitor Quality Loss"
+SELECTED_SLICE_ID = "issue108_computer_monitor_quality_loss_preset_boundary"
+ISSUE108_PROFILE_PATH = (
+    "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_"
+    "reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_"
+    "downstream_matched_ori_only_profile.json"
+)
+CANDIDATE_PROFILE_PATH = (
+    "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_"
+    "reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_"
+    "matched_ori_only_computer_monitor_pr30_input_profile.json"
+)
+GOLDEN_REFERENCE_ROOTS = (
+    "20260318_deadleaf_13b10",
+    "release/deadleaf_13b10_release/data/20260318_deadleaf_13b10",
+    "release/deadleaf_13b10_release/config",
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build the issue-114 Computer Monitor Quality Loss boundary summary."
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Repository root. Defaults to the parent of this script.",
+    )
+    parser.add_argument(
+        "--issue108-summary",
+        type=Path,
+        default=Path("artifacts/intrinsic_phase_retained_pr30_observed_bundle_benchmark.json"),
+        help="Repo-relative issue-108 summary artifact path.",
+    )
+    parser.add_argument(
+        "--issue111-summary",
+        type=Path,
+        default=Path("artifacts/intrinsic_after_issue108_next_slice_benchmark.json"),
+        help="Repo-relative issue-111 selected-slice artifact path.",
+    )
+    parser.add_argument(
+        "--acutance-artifact",
+        type=Path,
+        default=Path(
+            "artifacts/issue114_computer_monitor_quality_loss_boundary_acutance_benchmark.json"
+        ),
+        help="Repo-relative issue-114 acutance/Quality Loss benchmark artifact path.",
+    )
+    parser.add_argument(
+        "--psd-artifact",
+        type=Path,
+        default=Path("artifacts/issue114_computer_monitor_quality_loss_boundary_psd_benchmark.json"),
+        help="Repo-relative issue-114 PSD/MTF benchmark artifact path.",
+    )
+    parser.add_argument(
+        "--output-json",
+        type=Path,
+        default=Path(
+            "artifacts/intrinsic_after_issue111_quality_loss_boundary_benchmark.json"
+        ),
+        help="Repo-relative output path for the machine-readable artifact.",
+    )
+    parser.add_argument(
+        "--output-md",
+        type=Path,
+        default=Path("docs/intrinsic_after_issue111_quality_loss_boundary.md"),
+        help="Repo-relative output path for the Markdown note.",
+    )
+    return parser
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def resolve_path(repo_root: Path, path: Path) -> Path:
+    return path if path.is_absolute() else repo_root / path
+
+
+def format_metric(value: float) -> str:
+    return f"{value:.5f}"
+
+
+def select_profile(payload: dict[str, Any], profile_path: str) -> dict[str, Any]:
+    for profile in payload["profiles"]:
+        if profile["profile_path"] == profile_path:
+            return profile
+    available = ", ".join(profile["profile_path"] for profile in payload["profiles"])
+    raise ValueError(f"Profile {profile_path!r} not found. Available: {available}")
+
+
+def summarize_candidate(
+    *,
+    acutance_payload: dict[str, Any],
+    psd_payload: dict[str, Any],
+    profile_path: str,
+) -> dict[str, Any]:
+    acutance_profile = select_profile(acutance_payload, profile_path)
+    psd_profile = select_profile(psd_payload, profile_path)
+    acutance_overall = acutance_profile["overall"]
+    psd_overall = psd_profile["overall"]
+    return {
+        "label": CANDIDATE_LABEL,
+        "profile_path": profile_path,
+        "analysis_pipeline": acutance_profile["analysis_pipeline"],
+        "curve_mae_mean": float(acutance_overall["curve_mae_mean"]),
+        "focus_preset_acutance_mae_mean": float(
+            acutance_overall["acutance_focus_preset_mae_mean"]
+        ),
+        "overall_quality_loss_mae_mean": float(acutance_overall["overall_quality_loss_mae_mean"]),
+        "quality_loss_preset_mae": {
+            key: float(value) for key, value in acutance_overall["quality_loss_preset_mae"].items()
+        },
+        "acutance_preset_mae": {
+            key: float(value) for key, value in acutance_overall["acutance_preset_mae"].items()
+        },
+        "mtf_abs_signed_rel_mean": float(psd_overall["mtf_abs_signed_rel_mean"]),
+        "mtf_threshold_mae": {
+            key: float(value) for key, value in psd_overall["mtf_threshold_mae"].items()
+        },
+    }
+
+
+def delta_map(candidate: dict[str, Any], baseline: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "curve_mae_mean": float(candidate["curve_mae_mean"] - baseline["curve_mae_mean"]),
+        "focus_preset_acutance_mae_mean": float(
+            candidate["focus_preset_acutance_mae_mean"]
+            - baseline["focus_preset_acutance_mae_mean"]
+        ),
+        "overall_quality_loss_mae_mean": float(
+            candidate["overall_quality_loss_mae_mean"] - baseline["overall_quality_loss_mae_mean"]
+        ),
+        "quality_loss_preset_mae": {
+            key: float(candidate["quality_loss_preset_mae"][key] - baseline["quality_loss_preset_mae"][key])
+            for key in sorted(candidate["quality_loss_preset_mae"])
+        },
+        "acutance_preset_mae": {
+            key: float(candidate["acutance_preset_mae"][key] - baseline["acutance_preset_mae"][key])
+            for key in sorted(candidate["acutance_preset_mae"])
+        },
+        "mtf_abs_signed_rel_mean": float(
+            candidate["mtf_abs_signed_rel_mean"] - baseline["mtf_abs_signed_rel_mean"]
+        ),
+        "mtf_threshold_mae": {
+            key: float(candidate["mtf_threshold_mae"][key] - baseline["mtf_threshold_mae"][key])
+            for key in ("mtf20", "mtf30", "mtf50")
+        },
+    }
+
+
+def assert_storage_separation(payload: dict[str, Any]) -> None:
+    for path in payload["storage"]["new_fitted_artifact_paths"]:
+        for root in GOLDEN_REFERENCE_ROOTS:
+            if path.startswith(root):
+                raise ValueError(f"Path {path} leaks into golden/reference root {root}")
+
+
+def build_conclusion(acceptance: dict[str, bool], candidate_vs_pr30: dict[str, Any]) -> dict[str, str]:
+    if acceptance["all_issue114_gates_pass"]:
+        if candidate_vs_pr30["overall_quality_loss_mae_mean"] <= 0.0:
+            return {
+                "status": "issue114_current_best_candidate",
+                "summary": (
+                    "The Computer Monitor-only Quality Loss input boundary closes the remaining "
+                    "overall Quality Loss delta while preserving the issue-108 reported-MTF/readout path."
+                ),
+                "next_step": "Promote the candidate for review against the current PR #30 branch.",
+            }
+        return {
+            "status": "issue114_positive_partial_result",
+            "summary": (
+                "The Computer Monitor-only Quality Loss input boundary materially improves the "
+                "largest residual preset and overall Quality Loss versus issue #108, but a smaller "
+                "residual still remains versus PR #30."
+            ),
+            "next_step": (
+                "Keep this as the issue-114 bounded implementation record and split the next "
+                "residual Quality Loss boundary from the checked-in candidate-vs-PR30 deltas."
+            ),
+        }
+    return {
+        "status": "issue114_bounded_negative_or_mixed_result",
+        "summary": (
+            "The Computer Monitor-only Quality Loss input boundary did not satisfy every issue-114 "
+            "gate, so the issue should close as a bounded tradeoff record rather than broadening scope."
+        ),
+        "next_step": "Use the failed gates to decide whether another bounded discovery pass is warranted.",
+    }
+
+
+def build_payload(
+    repo_root: Path,
+    *,
+    issue108_summary_path: Path,
+    issue111_summary_path: Path,
+    acutance_artifact_path: Path,
+    psd_artifact_path: Path,
+) -> dict[str, Any]:
+    issue108_summary = load_json(resolve_path(repo_root, issue108_summary_path))
+    issue111_summary = load_json(resolve_path(repo_root, issue111_summary_path))
+    acutance_payload = load_json(resolve_path(repo_root, acutance_artifact_path))
+    psd_payload = load_json(resolve_path(repo_root, psd_artifact_path))
+
+    current_best = issue108_summary["profiles"][CURRENT_BEST_LABEL]
+    issue108 = issue108_summary["profiles"][ISSUE108_LABEL]
+    candidate = summarize_candidate(
+        acutance_payload=acutance_payload,
+        psd_payload=psd_payload,
+        profile_path=CANDIDATE_PROFILE_PATH,
+    )
+
+    candidate_vs_issue108 = delta_map(candidate, issue108)
+    candidate_vs_pr30 = delta_map(candidate, current_best)
+    issue108_vs_pr30 = delta_map(issue108, current_best)
+
+    unchanged_quality_loss_presets = {
+        preset: delta == 0.0
+        for preset, delta in candidate_vs_issue108["quality_loss_preset_mae"].items()
+        if preset != COMPUTER_MONITOR_QUALITY_LOSS
+    }
+    reported_mtf_equal_issue108 = {
+        "mtf_abs_signed_rel_mean": candidate_vs_issue108["mtf_abs_signed_rel_mean"] == 0.0,
+        "mtf20": candidate_vs_issue108["mtf_threshold_mae"]["mtf20"] == 0.0,
+        "mtf30": candidate_vs_issue108["mtf_threshold_mae"]["mtf30"] == 0.0,
+        "mtf50": candidate_vs_issue108["mtf_threshold_mae"]["mtf50"] == 0.0,
+    }
+    pipeline = candidate["analysis_pipeline"]
+    acceptance = {
+        "selected_slice_matches_issue111": issue111_summary["selected_slice_id"] == SELECTED_SLICE_ID,
+        "computer_monitor_quality_loss_improved_vs_issue108": (
+            candidate_vs_issue108["quality_loss_preset_mae"][COMPUTER_MONITOR_QUALITY_LOSS] < -0.01
+        ),
+        "overall_quality_loss_improved_vs_issue108": (
+            candidate_vs_issue108["overall_quality_loss_mae_mean"] < -0.01
+        ),
+        "curve_mae_non_worse_than_issue108": candidate_vs_issue108["curve_mae_mean"] <= 0.0,
+        "focus_preset_acutance_non_worse_than_issue108": (
+            candidate_vs_issue108["focus_preset_acutance_mae_mean"] <= 0.0
+        ),
+        "reported_mtf_equal_to_issue108": all(reported_mtf_equal_issue108.values()),
+        "only_computer_monitor_quality_loss_input_overridden": (
+            pipeline.get("quality_loss_preset_input_profile_overrides")
+            == {
+                COMPUTER_MONITOR_QUALITY_LOSS: (
+                    "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_"
+                    "curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json"
+                )
+            }
+            and all(unchanged_quality_loss_presets.values())
+        ),
+        "quality_loss_coefficients_preserved": (
+            pipeline["quality_loss_coefficients"]
+            == issue108["analysis_pipeline"]["quality_loss_coefficients"]
+            == current_best["analysis_pipeline"]["quality_loss_coefficients"]
+            and pipeline["quality_loss_om_ceiling"]
+            == issue108["analysis_pipeline"]["quality_loss_om_ceiling"]
+            == current_best["analysis_pipeline"]["quality_loss_om_ceiling"]
+            and pipeline["quality_loss_preset_overrides"]
+            == issue108["analysis_pipeline"]["quality_loss_preset_overrides"]
+            == current_best["analysis_pipeline"]["quality_loss_preset_overrides"]
+        ),
+    }
+    acceptance["all_issue114_gates_pass"] = all(acceptance.values())
+
+    payload = {
+        "issue": 114,
+        "summary_kind": SUMMARY_KIND,
+        "selected_slice_id": SELECTED_SLICE_ID,
+        "dataset_root": acutance_payload["dataset_root"],
+        "profiles": {
+            CURRENT_BEST_LABEL: current_best,
+            ISSUE108_LABEL: issue108,
+            CANDIDATE_LABEL: candidate,
+        },
+        "comparisons": {
+            "issue108_vs_current_best_pr30": {"delta": issue108_vs_pr30},
+            "candidate_vs_issue108": {"delta": candidate_vs_issue108},
+            "candidate_vs_current_best_pr30": {"delta": candidate_vs_pr30},
+        },
+        "acceptance": acceptance,
+        "implementation_change": {
+            "selected_slice_source": {
+                "issue": 111,
+                "selected_slice_id": issue111_summary["selected_slice_id"],
+            },
+            "basis_profile_path": ISSUE108_PROFILE_PATH,
+            "candidate_profile_path": CANDIDATE_PROFILE_PATH,
+            "quality_loss_preset_input_profile_overrides": pipeline[
+                "quality_loss_preset_input_profile_overrides"
+            ],
+            "reported_mtf_equal_to_issue108": reported_mtf_equal_issue108,
+            "unchanged_non_target_quality_loss_presets": unchanged_quality_loss_presets,
+            "change": (
+                "Keep the issue-108 reported-MTF/readout and intrinsic main-acutance paths, "
+                "but route only `Computer Monitor Quality Loss` through the PR #30-compatible "
+                "acutance-only/noise-share anchor input."
+            ),
+        },
+        "conclusion": build_conclusion(acceptance, candidate_vs_pr30),
+        "storage": {
+            "golden_reference_roots": list(GOLDEN_REFERENCE_ROOTS),
+            "new_fitted_artifact_paths": [
+                CANDIDATE_PROFILE_PATH,
+                "artifacts/issue114_computer_monitor_quality_loss_boundary_acutance_benchmark.json",
+                "artifacts/issue114_computer_monitor_quality_loss_boundary_psd_benchmark.json",
+                "artifacts/intrinsic_after_issue111_quality_loss_boundary_benchmark.json",
+            ],
+            "rules": [
+                "Keep issue-114 fitted outputs under `algo/` and `artifacts/` only.",
+                "Do not write fitted profiles, transfer tables, or generated outputs under golden/reference roots.",
+                "Do not touch release-facing configs in this issue.",
+            ],
+        },
+    }
+    assert_storage_separation(payload)
+    return payload
+
+
+def render_markdown(payload: dict[str, Any]) -> str:
+    profiles = payload["profiles"]
+    current_best = profiles[CURRENT_BEST_LABEL]
+    issue108 = profiles[ISSUE108_LABEL]
+    candidate = profiles[CANDIDATE_LABEL]
+    candidate_vs_issue108 = payload["comparisons"]["candidate_vs_issue108"]["delta"]
+    candidate_vs_pr30 = payload["comparisons"]["candidate_vs_current_best_pr30"]["delta"]
+
+    lines = [
+        "# Intrinsic After Issue 111 Quality Loss Boundary",
+        "",
+        "Issue `#114` implements the bounded slice selected by issue `#111`: isolate only the `Computer Monitor Quality Loss` preset-family input boundary after issue `#108` matched PR `#30` on reported-MTF metrics.",
+        "",
+        "## Scope",
+        "",
+        f"- Basis issue `#108` profile: `{ISSUE108_PROFILE_PATH}`",
+        f"- Candidate profile: `{CANDIDATE_PROFILE_PATH}`",
+        "- Targeted override: `Computer Monitor Quality Loss` uses the PR `#30` acutance-only / noise-share anchor input.",
+        "- Non-target Quality Loss presets stay on the issue-108 path.",
+        "- Quality Loss coefficients, preset overrides, and `quality_loss_om_ceiling` are unchanged.",
+        "",
+        "## Result",
+        "",
+        "| Record | Curve MAE | Focus Acu MAE | Overall QL | Computer Monitor QL | MTF20 | MTF30 | MTF50 | Abs Signed Rel |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+        f"| {CURRENT_BEST_LABEL} | {format_metric(current_best['curve_mae_mean'])} | {format_metric(current_best['focus_preset_acutance_mae_mean'])} | {format_metric(current_best['overall_quality_loss_mae_mean'])} | {format_metric(current_best['quality_loss_preset_mae'][COMPUTER_MONITOR_QUALITY_LOSS])} | {format_metric(current_best['mtf_threshold_mae']['mtf20'])} | {format_metric(current_best['mtf_threshold_mae']['mtf30'])} | {format_metric(current_best['mtf_threshold_mae']['mtf50'])} | {format_metric(current_best['mtf_abs_signed_rel_mean'])} |",
+        f"| {ISSUE108_LABEL} | {format_metric(issue108['curve_mae_mean'])} | {format_metric(issue108['focus_preset_acutance_mae_mean'])} | {format_metric(issue108['overall_quality_loss_mae_mean'])} | {format_metric(issue108['quality_loss_preset_mae'][COMPUTER_MONITOR_QUALITY_LOSS])} | {format_metric(issue108['mtf_threshold_mae']['mtf20'])} | {format_metric(issue108['mtf_threshold_mae']['mtf30'])} | {format_metric(issue108['mtf_threshold_mae']['mtf50'])} | {format_metric(issue108['mtf_abs_signed_rel_mean'])} |",
+        f"| {CANDIDATE_LABEL} | {format_metric(candidate['curve_mae_mean'])} | {format_metric(candidate['focus_preset_acutance_mae_mean'])} | {format_metric(candidate['overall_quality_loss_mae_mean'])} | {format_metric(candidate['quality_loss_preset_mae'][COMPUTER_MONITOR_QUALITY_LOSS])} | {format_metric(candidate['mtf_threshold_mae']['mtf20'])} | {format_metric(candidate['mtf_threshold_mae']['mtf30'])} | {format_metric(candidate['mtf_threshold_mae']['mtf50'])} | {format_metric(candidate['mtf_abs_signed_rel_mean'])} |",
+        "",
+        "## Deltas",
+        "",
+        f"- Candidate versus issue `#108`: `Computer Monitor Quality Loss = {candidate_vs_issue108['quality_loss_preset_mae'][COMPUTER_MONITOR_QUALITY_LOSS]:+.5f}`, `overall_quality_loss_mae_mean = {candidate_vs_issue108['overall_quality_loss_mae_mean']:+.5f}`.",
+        f"- Candidate versus PR `#30`: `Computer Monitor Quality Loss = {candidate_vs_pr30['quality_loss_preset_mae'][COMPUTER_MONITOR_QUALITY_LOSS]:+.5f}`, `overall_quality_loss_mae_mean = {candidate_vs_pr30['overall_quality_loss_mae_mean']:+.5f}`.",
+        f"- Reported-MTF equality versus issue `#108`: `{payload['acceptance']['reported_mtf_equal_to_issue108']}`.",
+        f"- Non-target Quality Loss presets unchanged versus issue `#108`: `{all(payload['implementation_change']['unchanged_non_target_quality_loss_presets'].values())}`.",
+        "",
+        "## Acceptance",
+        "",
+    ]
+    for key, value in payload["acceptance"].items():
+        lines.append(f"- `{key}`: `{value}`")
+    lines.extend(
+        [
+            "",
+            "## Conclusion",
+            "",
+            f"- Status: `{payload['conclusion']['status']}`",
+            f"- Summary: {payload['conclusion']['summary']}",
+            f"- Next step: {payload['conclusion']['next_step']}",
+            "",
+            "## Storage Separation",
+            "",
+            f"- Golden/reference roots: `{GOLDEN_REFERENCE_ROOTS[0]}`, `{GOLDEN_REFERENCE_ROOTS[1]}`, `{GOLDEN_REFERENCE_ROOTS[2]}`",
+            "- Fitted outputs for this issue stay under `algo/` and `artifacts/` only.",
+            "- No release-facing config is promoted in this issue.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    repo_root = args.repo_root.resolve()
+    payload = build_payload(
+        repo_root,
+        issue108_summary_path=args.issue108_summary,
+        issue111_summary_path=args.issue111_summary,
+        acutance_artifact_path=args.acutance_artifact,
+        psd_artifact_path=args.psd_artifact,
+    )
+    write_text(resolve_path(repo_root, args.output_json), json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    write_text(resolve_path(repo_root, args.output_md), render_markdown(payload))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_computer_monitor_pr30_input_profile.json
+++ b/algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_computer_monitor_pr30_input_profile.json
@@ -1,0 +1,189 @@
+{
+  "name": "deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_computer_monitor_pr30_input",
+  "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+  "gamma": 0.5,
+  "linearization_mode": "toe_power",
+  "linearization_toe": 0.12,
+  "bayer_pattern": "RGGB",
+  "bayer_mode": "demosaic_red",
+  "roi_source": "reference_refined",
+  "roi_width": 1655,
+  "roi_height": 1673,
+  "roi_refine_percentile": 45.0,
+  "roi_refine_sigma": 5.0,
+  "roi_refine_min_border_margin": 8,
+  "roi_refine_search_radius": 4,
+  "roi_refine_step": 2,
+  "roi_refine_area_tolerance": 0.98,
+  "intrinsic_full_reference_mode": "paired_ori_transfer",
+  "intrinsic_full_reference_scope": "reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only",
+  "intrinsic_full_reference_clip_lo": 0.5,
+  "intrinsic_full_reference_clip_hi": 1.5,
+  "intrinsic_full_reference_registration_mode": "phase_correlation",
+  "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+  "matched_ori_reference_anchor": true,
+  "matched_ori_correction_clip_lo": 0.5,
+  "matched_ori_correction_clip_hi": 2.0,
+  "matched_ori_anchor_mode": "all",
+  "matched_ori_strength_curve_frequencies": [
+    0.0,
+    0.12,
+    0.22,
+    0.35,
+    0.5
+  ],
+  "matched_ori_strength_curve_values": [
+    1.0,
+    1.0,
+    0.82,
+    0.95,
+    1.0
+  ],
+  "matched_ori_acutance_reference_anchor": true,
+  "matched_ori_acutance_correction_clip_lo": 0.9,
+  "matched_ori_acutance_correction_clip_hi": 1.1,
+  "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+  "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+    0.0,
+    0.25,
+    0.6,
+    0.8,
+    1.6,
+    2.5
+  ],
+  "matched_ori_acutance_curve_correction_clip_hi_values": [
+    1.02,
+    1.03,
+    0.895,
+    0.895,
+    1.05,
+    1.06
+  ],
+  "matched_ori_acutance_strength_curve_relative_scales": [
+    0.0,
+    0.2,
+    0.8,
+    1.6,
+    2.5
+  ],
+  "matched_ori_acutance_strength_curve_values": [
+    0.7,
+    0.69,
+    0.64,
+    0.62,
+    0.6
+  ],
+  "matched_ori_acutance_correction_delta_power": 1.0,
+  "matched_ori_acutance_curve_correction_delta_power": 0.95,
+  "matched_ori_acutance_preset_correction_delta_power": null,
+  "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+    0.0,
+    4.5,
+    5.8,
+    6.2
+  ],
+  "matched_ori_acutance_preset_correction_delta_power_values": [
+    1.05,
+    1.05,
+    1.85,
+    1.85
+  ],
+  "matched_ori_acutance_preset_strength_curve_relative_scales": [
+    0.0,
+    3.0,
+    4.5,
+    5.8,
+    6.2
+  ],
+  "matched_ori_acutance_preset_strength_curve_values": [
+    1.0,
+    1.0,
+    0.85,
+    0.45,
+    0.45
+  ],
+  "frequency_scale": 1.0,
+  "normalization_band_lo": 0.01,
+  "normalization_band_hi": 0.03,
+  "normalization_mode": "max",
+  "acutance_band_lo": 0.017,
+  "acutance_band_hi": 0.035,
+  "acutance_band_mode": "mean",
+  "noise_psd_model": "empirical",
+  "noise_psd_scale": 1.0,
+  "quality_loss_om_ceiling": 0.8851,
+  "quality_loss_coefficients": [
+    37.240228358776136,
+    26.54550669779819,
+    0.4538662637619741
+  ],
+  "quality_loss_preset_overrides": {
+    "Computer Monitor Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        5677361.198044325,
+        -16715685.9524707,
+        20317567.326582585,
+        -13046703.33912079,
+        4667794.619228022,
+        -882296.9160375095,
+        68863.59709647154
+      ]
+    },
+    "5.5\" Phone Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        -110912321.41149135,
+        50461107.51563171,
+        -9079490.127807735,
+        815148.8697247265,
+        -37712.984407641874,
+        854.6941149036079,
+        -6.261149027919645
+      ]
+    },
+    "UHDTV Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        1783462.6221675149,
+        -3813432.5606394163,
+        3326218.4642961356,
+        -1514886.1959663907,
+        380334.163146246,
+        -49956.87092015135,
+        2692.9566508574017
+      ]
+    },
+    "Small Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        6690980.837239251,
+        -12955277.716404187,
+        10300283.291740375,
+        -4303759.200708971,
+        996904.2653558743,
+        -121409.71509269004,
+        6084.6471373306085
+      ]
+    },
+    "Large Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        2355074.475971866,
+        -5276146.244338096,
+        4846781.143787682,
+        -2336594.295523967,
+        623766.4933095274,
+        -87476.30712136331,
+        5049.882965558553
+      ]
+    }
+  },
+  "quality_loss_preset_input_profile_overrides": {
+    "Computer Monitor Quality Loss": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json"
+  },
+  "mtf_compensation_mode": "sensor_aperture_sinc",
+  "sensor_fill_factor": 1.5,
+  "texture_support_scale": true,
+  "high_frequency_guard_start_cpp": 0.36
+}

--- a/artifacts/intrinsic_after_issue111_quality_loss_boundary_benchmark.json
+++ b/artifacts/intrinsic_after_issue111_quality_loss_boundary_benchmark.json
@@ -1,0 +1,856 @@
+{
+  "acceptance": {
+    "all_issue114_gates_pass": true,
+    "computer_monitor_quality_loss_improved_vs_issue108": true,
+    "curve_mae_non_worse_than_issue108": true,
+    "focus_preset_acutance_non_worse_than_issue108": true,
+    "only_computer_monitor_quality_loss_input_overridden": true,
+    "overall_quality_loss_improved_vs_issue108": true,
+    "quality_loss_coefficients_preserved": true,
+    "reported_mtf_equal_to_issue108": true,
+    "selected_slice_matches_issue111": true
+  },
+  "comparisons": {
+    "candidate_vs_current_best_pr30": {
+      "delta": {
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.021454129834507486,
+          "Computer Monitor Acutance": -0.02851887581626197,
+          "Large Print Acutance": -0.022701561546618957,
+          "Small Print Acutance": -0.01497585610580384,
+          "UHDTV Display Acutance": -0.023089360415706
+        },
+        "curve_mae_mean": -0.0039872260971888646,
+        "focus_preset_acutance_mae_mean": -0.013566304809976663,
+        "mtf_abs_signed_rel_mean": 0.0,
+        "mtf_threshold_mae": {
+          "mtf20": 0.0,
+          "mtf30": 0.0,
+          "mtf50": 0.0
+        },
+        "overall_quality_loss_mae_mean": 0.05337000984280316,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 0.09506286396125166,
+          "Computer Monitor Quality Loss": 0.003205938014798626,
+          "Large Print Quality Loss": 0.10571937307924961,
+          "Small Print Quality Loss": 0.2468056930027358,
+          "UHDTV Display Quality Loss": -0.1839438188440199
+        }
+      }
+    },
+    "candidate_vs_issue108": {
+      "delta": {
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.0,
+          "Computer Monitor Acutance": 0.0,
+          "Large Print Acutance": 0.0,
+          "Small Print Acutance": 0.0,
+          "UHDTV Display Acutance": 0.0
+        },
+        "curve_mae_mean": 0.0,
+        "focus_preset_acutance_mae_mean": 0.0,
+        "mtf_abs_signed_rel_mean": 0.0,
+        "mtf_threshold_mae": {
+          "mtf20": 0.0,
+          "mtf30": 0.0,
+          "mtf50": 0.0
+        },
+        "overall_quality_loss_mae_mean": -0.1317632635241459,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 0.0,
+          "Computer Monitor Quality Loss": -0.6588163176207305,
+          "Large Print Quality Loss": 0.0,
+          "Small Print Quality Loss": 0.0,
+          "UHDTV Display Quality Loss": 0.0
+        }
+      }
+    },
+    "issue108_vs_current_best_pr30": {
+      "delta": {
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.021454129834507486,
+          "Computer Monitor Acutance": -0.02851887581626197,
+          "Large Print Acutance": -0.022701561546618957,
+          "Small Print Acutance": -0.01497585610580384,
+          "UHDTV Display Acutance": -0.023089360415706
+        },
+        "curve_mae_mean": -0.0039872260971888646,
+        "focus_preset_acutance_mae_mean": -0.013566304809976663,
+        "mtf_abs_signed_rel_mean": 0.0,
+        "mtf_threshold_mae": {
+          "mtf20": 0.0,
+          "mtf30": 0.0,
+          "mtf50": 0.0
+        },
+        "overall_quality_loss_mae_mean": 0.18513327336694907,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 0.09506286396125166,
+          "Computer Monitor Quality Loss": 0.6620222556355291,
+          "Large Print Quality Loss": 0.10571937307924961,
+          "Small Print Quality Loss": 0.2468056930027358,
+          "UHDTV Display Quality Loss": -0.1839438188440199
+        }
+      }
+    }
+  },
+  "conclusion": {
+    "next_step": "Keep this as the issue-114 bounded implementation record and split the next residual Quality Loss boundary from the checked-in candidate-vs-PR30 deltas.",
+    "status": "issue114_positive_partial_result",
+    "summary": "The Computer Monitor-only Quality Loss input boundary materially improves the largest residual preset and overall Quality Loss versus issue #108, but a smaller residual still remains versus PR #30."
+  },
+  "dataset_root": "20260318_deadleaf_13b10",
+  "implementation_change": {
+    "basis_profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_profile.json",
+    "candidate_profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_computer_monitor_pr30_input_profile.json",
+    "change": "Keep the issue-108 reported-MTF/readout and intrinsic main-acutance paths, but route only `Computer Monitor Quality Loss` through the PR #30-compatible acutance-only/noise-share anchor input.",
+    "quality_loss_preset_input_profile_overrides": {
+      "Computer Monitor Quality Loss": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json"
+    },
+    "reported_mtf_equal_to_issue108": {
+      "mtf20": true,
+      "mtf30": true,
+      "mtf50": true,
+      "mtf_abs_signed_rel_mean": true
+    },
+    "selected_slice_source": {
+      "issue": 111,
+      "selected_slice_id": "issue108_computer_monitor_quality_loss_preset_boundary"
+    },
+    "unchanged_non_target_quality_loss_presets": {
+      "5.5\" Phone Display Quality Loss": true,
+      "Large Print Quality Loss": true,
+      "Small Print Quality Loss": true,
+      "UHDTV Display Quality Loss": true
+    }
+  },
+  "issue": 114,
+  "profiles": {
+    "current_best_pr30_branch": {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": 0.013802247905288301,
+        "Computer Monitor Acutance": 0.052665183748573804,
+        "Large Print Acutance": 0.05132586418527154,
+        "Small Print Acutance": 0.046702107662187464,
+        "UHDTV Display Acutance": 0.04793875259218785
+      },
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "readout_interpolation": "linear",
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": true
+      },
+      "curve_mae_mean": 0.03678903166100513,
+      "focus_preset_acutance_mae_mean": 0.042486831218701795,
+      "label": "current_best_pr30_branch",
+      "mtf_abs_signed_rel_mean": 0.08671416893394165,
+      "mtf_band_mae": {
+        "high": 0.01764835359892083,
+        "low": 0.03704553941403868,
+        "mid": 0.03898616152003224,
+        "top": 0.07374065223652229
+      },
+      "mtf_threshold_mae": {
+        "mtf20": 0.03301077142967389,
+        "mtf30": 0.03693639342667963,
+        "mtf50": 0.009332615436071163
+      },
+      "overall_quality_loss_mae_mean": 1.2214989544377113,
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_profile.json",
+      "quality_loss_preset_mae": {
+        "5.5\" Phone Display Quality Loss": 0.14297991495607307,
+        "Computer Monitor Quality Loss": 2.902905846061304,
+        "Large Print Quality Loss": 0.9548172583377941,
+        "Small Print Quality Loss": 0.6076935256225349,
+        "UHDTV Display Quality Loss": 1.4990982272108502
+      }
+    },
+    "issue108_pr30_observed_bundle_candidate": {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": 0.035256377739795786,
+        "Computer Monitor Acutance": 0.024146307932311834,
+        "Large Print Acutance": 0.028624302638652583,
+        "Small Print Acutance": 0.031726251556383624,
+        "UHDTV Display Acutance": 0.024849392176481848
+      },
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only",
+        "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "readout_interpolation": "linear",
+        "readout_mtf_compensation_mode": "sensor_aperture_sinc",
+        "readout_sensor_fill_factor": 1.5,
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": true
+      },
+      "curve_mae_mean": 0.03280180556381627,
+      "focus_preset_acutance_mae_mean": 0.028920526408725132,
+      "label": "issue108_pr30_observed_bundle_candidate",
+      "mtf_abs_signed_rel_mean": 0.08671416893394165,
+      "mtf_threshold_mae": {
+        "mtf20": 0.03301077142967389,
+        "mtf30": 0.03693639342667963,
+        "mtf50": 0.009332615436071163
+      },
+      "overall_quality_loss_mae_mean": 1.4066322278046604,
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_profile.json",
+      "quality_loss_preset_mae": {
+        "5.5\" Phone Display Quality Loss": 0.23804277891732473,
+        "Computer Monitor Quality Loss": 3.5649281016968333,
+        "Large Print Quality Loss": 1.0605366314170437,
+        "Small Print Quality Loss": 0.8544992186252707,
+        "UHDTV Display Quality Loss": 1.3151544083668303
+      }
+    },
+    "issue114_computer_monitor_quality_loss_input_boundary_candidate": {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": 0.035256377739795786,
+        "Computer Monitor Acutance": 0.024146307932311834,
+        "Large Print Acutance": 0.028624302638652583,
+        "Small Print Acutance": 0.031726251556383624,
+        "UHDTV Display Acutance": 0.024849392176481848
+      },
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only",
+        "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_input_profile_overrides": {
+          "Computer Monitor Quality Loss": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json"
+        },
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "readout_interpolation": "linear",
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": true
+      },
+      "curve_mae_mean": 0.03280180556381627,
+      "focus_preset_acutance_mae_mean": 0.028920526408725132,
+      "label": "issue114_computer_monitor_quality_loss_input_boundary_candidate",
+      "mtf_abs_signed_rel_mean": 0.08671416893394165,
+      "mtf_threshold_mae": {
+        "mtf20": 0.03301077142967389,
+        "mtf30": 0.03693639342667963,
+        "mtf50": 0.009332615436071163
+      },
+      "overall_quality_loss_mae_mean": 1.2748689642805144,
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_computer_monitor_pr30_input_profile.json",
+      "quality_loss_preset_mae": {
+        "5.5\" Phone Display Quality Loss": 0.23804277891732473,
+        "Computer Monitor Quality Loss": 2.906111784076103,
+        "Large Print Quality Loss": 1.0605366314170437,
+        "Small Print Quality Loss": 0.8544992186252707,
+        "UHDTV Display Quality Loss": 1.3151544083668303
+      }
+    }
+  },
+  "selected_slice_id": "issue108_computer_monitor_quality_loss_preset_boundary",
+  "storage": {
+    "golden_reference_roots": [
+      "20260318_deadleaf_13b10",
+      "release/deadleaf_13b10_release/data/20260318_deadleaf_13b10",
+      "release/deadleaf_13b10_release/config"
+    ],
+    "new_fitted_artifact_paths": [
+      "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_computer_monitor_pr30_input_profile.json",
+      "artifacts/issue114_computer_monitor_quality_loss_boundary_acutance_benchmark.json",
+      "artifacts/issue114_computer_monitor_quality_loss_boundary_psd_benchmark.json",
+      "artifacts/intrinsic_after_issue111_quality_loss_boundary_benchmark.json"
+    ],
+    "rules": [
+      "Keep issue-114 fitted outputs under `algo/` and `artifacts/` only.",
+      "Do not write fitted profiles, transfer tables, or generated outputs under golden/reference roots.",
+      "Do not touch release-facing configs in this issue."
+    ]
+  },
+  "summary_kind": "intrinsic_after_issue111_quality_loss_boundary_followup"
+}

--- a/artifacts/issue114_computer_monitor_quality_loss_boundary_acutance_benchmark.json
+++ b/artifacts/issue114_computer_monitor_quality_loss_boundary_acutance_benchmark.json
@@ -1,0 +1,754 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_input_profile_overrides": null,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "readout_interpolation": "linear",
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.0426419082983667,
+        "0.25": 0.03450723056011866,
+        "0.4": 0.028162391114511045,
+        "0.65": 0.03351676542287892,
+        "0.8": 0.039890883676316505,
+        "ori": 0.044422165524720086
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 1.3421389514230824,
+        "0.25": 1.2825995432153037,
+        "0.4": 1.1337887188584643,
+        "0.65": 0.3646116302822078,
+        "0.8": 1.0109879373437751,
+        "ori": 2.317792173136315
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.04249131400289711,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.013802151888956607,
+          "Computer Monitor Acutance": 0.052691955741307875,
+          "Large Print Acutance": 0.05132126004290283,
+          "Small Print Acutance": 0.04670043959486586,
+          "UHDTV Display Acutance": 0.047940762746452356
+        },
+        "curve_mae_mean": 0.03683437582462248,
+        "overall_quality_loss_mae_mean": 1.2221434105099775,
+        "quality_loss_focus_preset_mae_mean": 1.2221434105099775,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 0.14297762642651196,
+          "Computer Monitor Quality Loss": 2.906111784076103,
+          "Large Print Quality Loss": 0.9547911309308169,
+          "Small Print Quality Loss": 0.6076983310559123,
+          "UHDTV Display Quality Loss": 1.499138180060543
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json"
+    },
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only",
+        "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_input_profile_overrides": null,
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "readout_interpolation": "linear",
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.029378599163150443,
+        "0.25": 0.02479729017929424,
+        "0.4": 0.019363342842858032,
+        "0.65": 0.011953815251775047,
+        "0.8": 0.04482380483621107,
+        "ori": 0.07933816634336006
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 1.0366140798486143,
+        "0.25": 1.1168857805733878,
+        "0.4": 1.458094585991552,
+        "0.65": 0.6531959003476362,
+        "0.8": 1.2458803219396535,
+        "ori": 3.698176840992554
+      },
+      "delta_vs_first_profile": {
+        "acutance_focus_preset_mae_mean": -0.013570787594171976,
+        "curve_mae_mean": -0.004032570260806209,
+        "overall_quality_loss_mae_mean": 0.1844888172946828,
+        "quality_loss_focus_preset_mae_mean": 0.1844888172946828
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.028920526408725132,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.035256377739795786,
+          "Computer Monitor Acutance": 0.024146307932311834,
+          "Large Print Acutance": 0.028624302638652583,
+          "Small Print Acutance": 0.031726251556383624,
+          "UHDTV Display Acutance": 0.024849392176481848
+        },
+        "curve_mae_mean": 0.03280180556381627,
+        "overall_quality_loss_mae_mean": 1.4066322278046604,
+        "quality_loss_focus_preset_mae_mean": 1.4066322278046604,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 0.23804277891732473,
+          "Computer Monitor Quality Loss": 3.5649281016968333,
+          "Large Print Quality Loss": 1.0605366314170437,
+          "Small Print Quality Loss": 0.8544992186252707,
+          "UHDTV Display Quality Loss": 1.3151544083668303
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_profile.json"
+    },
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only",
+        "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_input_profile_overrides": {
+          "Computer Monitor Quality Loss": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json"
+        },
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "readout_interpolation": "linear",
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.029378599163150443,
+        "0.25": 0.02479729017929424,
+        "0.4": 0.019363342842858032,
+        "0.65": 0.011953815251775047,
+        "0.8": 0.04482380483621107,
+        "ori": 0.07933816634336006
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 1.1322134082888269,
+        "0.25": 1.1637772261893717,
+        "0.4": 1.3625946036628651,
+        "0.65": 0.5721882984430755,
+        "0.8": 1.162137205653885,
+        "ori": 2.535056456772171
+      },
+      "delta_vs_first_profile": {
+        "acutance_focus_preset_mae_mean": -0.013570787594171976,
+        "curve_mae_mean": -0.004032570260806209,
+        "overall_quality_loss_mae_mean": 0.05272555377053689,
+        "quality_loss_focus_preset_mae_mean": 0.05272555377053689
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.028920526408725132,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.035256377739795786,
+          "Computer Monitor Acutance": 0.024146307932311834,
+          "Large Print Acutance": 0.028624302638652583,
+          "Small Print Acutance": 0.031726251556383624,
+          "UHDTV Display Acutance": 0.024849392176481848
+        },
+        "curve_mae_mean": 0.03280180556381627,
+        "overall_quality_loss_mae_mean": 1.2748689642805144,
+        "quality_loss_focus_preset_mae_mean": 1.2748689642805144,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 0.23804277891732473,
+          "Computer Monitor Quality Loss": 2.906111784076103,
+          "Large Print Quality Loss": 1.0605366314170437,
+          "Small Print Quality Loss": 0.8544992186252707,
+          "UHDTV Display Quality Loss": 1.3151544083668303
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_computer_monitor_pr30_input_profile.json"
+    }
+  ]
+}

--- a/artifacts/issue114_computer_monitor_quality_loss_boundary_psd_benchmark.json
+++ b/artifacts/issue114_computer_monitor_quality_loss_boundary_psd_benchmark.json
@@ -1,0 +1,574 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "high_frequency_noise_share_quadratic",
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "none",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "replace_all",
+        "intrinsic_full_reference_transfer_mode": "magnitude_ratio",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "acutance_only",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_preset_input_profile_overrides": null,
+        "readout_interpolation": "linear",
+        "readout_mtf_compensation_mode": "sensor_aperture_sinc",
+        "readout_sensor_fill_factor": 1.5,
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.045132331541343135,
+        "0.25": 0.03837972282290488,
+        "0.4": 0.03424583283108843,
+        "0.65": 0.04020915188141205,
+        "0.8": 0.049664991465143526,
+        "ori": 0.055589288189657284
+      },
+      "overall": {
+        "curve_mae_mean": 0.04306441973920293,
+        "mtf_abs_signed_rel_mean": 0.08692955889841379,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.017639268013990343,
+            "mre_mean": 0.08883603386012136,
+            "signed_rel_mean": 0.04964177427444007
+          },
+          "low": {
+            "mae_mean": 0.03704553941403868,
+            "mre_mean": 0.046572470331734825,
+            "signed_rel_mean": 0.0237949421475065
+          },
+          "mid": {
+            "mae_mean": 0.03898616152003224,
+            "mre_mean": 0.12397538768693758,
+            "signed_rel_mean": 0.10965436746685472
+          },
+          "top": {
+            "mae_mean": 0.0738124428343438,
+            "mre_mean": 0.20207246214765648,
+            "signed_rel_mean": -0.16462715170485387
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.033009025007104606,
+          "mtf30": 0.03693523768742383,
+          "mtf50": 0.009332615436071163
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.014469243052711292,
+          "Computer Monitor Acutance": 0.06145640899956405,
+          "Large Print Acutance": 0.05374582109239643,
+          "Small Print Acutance": 0.061691355516267324,
+          "UHDTV Display Acutance": 0.056009600718383366
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json"
+    },
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only",
+        "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_preset_input_profile_overrides": null,
+        "readout_interpolation": "linear",
+        "readout_mtf_compensation_mode": "sensor_aperture_sinc",
+        "readout_sensor_fill_factor": 1.5,
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.029378599163150443,
+        "0.25": 0.02479729017929424,
+        "0.4": 0.019363342842858032,
+        "0.65": 0.011953815251775047,
+        "0.8": 0.04482380483621107,
+        "ori": 0.07933816634336006
+      },
+      "overall": {
+        "curve_mae_mean": 0.03280180556381627,
+        "mtf_abs_signed_rel_mean": 0.08671416893394165,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.01764835359892083,
+            "mre_mean": 0.088865357734797,
+            "signed_rel_mean": 0.04982888092128941
+          },
+          "low": {
+            "mae_mean": 0.03704553941403868,
+            "mre_mean": 0.046572470331734825,
+            "signed_rel_mean": 0.0237949421475065
+          },
+          "mid": {
+            "mae_mean": 0.03898616152003224,
+            "mre_mean": 0.12397538768693758,
+            "signed_rel_mean": 0.10965436746685472
+          },
+          "top": {
+            "mae_mean": 0.07374065223652229,
+            "mre_mean": 0.20171750026037474,
+            "signed_rel_mean": -0.16357848520011598
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.03301077142967389,
+          "mtf30": 0.03693639342667963,
+          "mtf50": 0.009332615436071163
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.035256377739795786,
+          "Computer Monitor Acutance": 0.024146307932311834,
+          "Large Print Acutance": 0.028624302638652583,
+          "Small Print Acutance": 0.031726251556383624,
+          "UHDTV Display Acutance": 0.024849392176481848
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_profile.json"
+    },
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only",
+        "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_preset_input_profile_overrides": {
+          "Computer Monitor Quality Loss": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json"
+        },
+        "readout_interpolation": "linear",
+        "readout_mtf_compensation_mode": "sensor_aperture_sinc",
+        "readout_sensor_fill_factor": 1.5,
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.029378599163150443,
+        "0.25": 0.02479729017929424,
+        "0.4": 0.019363342842858032,
+        "0.65": 0.011953815251775047,
+        "0.8": 0.04482380483621107,
+        "ori": 0.07933816634336006
+      },
+      "overall": {
+        "curve_mae_mean": 0.03280180556381627,
+        "mtf_abs_signed_rel_mean": 0.08671416893394165,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.01764835359892083,
+            "mre_mean": 0.088865357734797,
+            "signed_rel_mean": 0.04982888092128941
+          },
+          "low": {
+            "mae_mean": 0.03704553941403868,
+            "mre_mean": 0.046572470331734825,
+            "signed_rel_mean": 0.0237949421475065
+          },
+          "mid": {
+            "mae_mean": 0.03898616152003224,
+            "mre_mean": 0.12397538768693758,
+            "signed_rel_mean": 0.10965436746685472
+          },
+          "top": {
+            "mae_mean": 0.07374065223652229,
+            "mre_mean": 0.20171750026037474,
+            "signed_rel_mean": -0.16357848520011598
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.03301077142967389,
+          "mtf30": 0.03693639342667963,
+          "mtf50": 0.009332615436071163
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.035256377739795786,
+          "Computer Monitor Acutance": 0.024146307932311834,
+          "Large Print Acutance": 0.028624302638652583,
+          "Small Print Acutance": 0.031726251556383624,
+          "UHDTV Display Acutance": 0.024849392176481848
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_computer_monitor_pr30_input_profile.json"
+    }
+  ]
+}

--- a/docs/intrinsic_after_issue111_quality_loss_boundary.md
+++ b/docs/intrinsic_after_issue111_quality_loss_boundary.md
@@ -1,0 +1,50 @@
+# Intrinsic After Issue 111 Quality Loss Boundary
+
+Issue `#114` implements the bounded slice selected by issue `#111`: isolate only the `Computer Monitor Quality Loss` preset-family input boundary after issue `#108` matched PR `#30` on reported-MTF metrics.
+
+## Scope
+
+- Basis issue `#108` profile: `algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_profile.json`
+- Candidate profile: `algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_computer_monitor_pr30_input_profile.json`
+- Targeted override: `Computer Monitor Quality Loss` uses the PR `#30` acutance-only / noise-share anchor input.
+- Non-target Quality Loss presets stay on the issue-108 path.
+- Quality Loss coefficients, preset overrides, and `quality_loss_om_ceiling` are unchanged.
+
+## Result
+
+| Record | Curve MAE | Focus Acu MAE | Overall QL | Computer Monitor QL | MTF20 | MTF30 | MTF50 | Abs Signed Rel |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| current_best_pr30_branch | 0.03679 | 0.04249 | 1.22150 | 2.90291 | 0.03301 | 0.03694 | 0.00933 | 0.08671 |
+| issue108_pr30_observed_bundle_candidate | 0.03280 | 0.02892 | 1.40663 | 3.56493 | 0.03301 | 0.03694 | 0.00933 | 0.08671 |
+| issue114_computer_monitor_quality_loss_input_boundary_candidate | 0.03280 | 0.02892 | 1.27487 | 2.90611 | 0.03301 | 0.03694 | 0.00933 | 0.08671 |
+
+## Deltas
+
+- Candidate versus issue `#108`: `Computer Monitor Quality Loss = -0.65882`, `overall_quality_loss_mae_mean = -0.13176`.
+- Candidate versus PR `#30`: `Computer Monitor Quality Loss = +0.00321`, `overall_quality_loss_mae_mean = +0.05337`.
+- Reported-MTF equality versus issue `#108`: `True`.
+- Non-target Quality Loss presets unchanged versus issue `#108`: `True`.
+
+## Acceptance
+
+- `selected_slice_matches_issue111`: `True`
+- `computer_monitor_quality_loss_improved_vs_issue108`: `True`
+- `overall_quality_loss_improved_vs_issue108`: `True`
+- `curve_mae_non_worse_than_issue108`: `True`
+- `focus_preset_acutance_non_worse_than_issue108`: `True`
+- `reported_mtf_equal_to_issue108`: `True`
+- `only_computer_monitor_quality_loss_input_overridden`: `True`
+- `quality_loss_coefficients_preserved`: `True`
+- `all_issue114_gates_pass`: `True`
+
+## Conclusion
+
+- Status: `issue114_positive_partial_result`
+- Summary: The Computer Monitor-only Quality Loss input boundary materially improves the largest residual preset and overall Quality Loss versus issue #108, but a smaller residual still remains versus PR #30.
+- Next step: Keep this as the issue-114 bounded implementation record and split the next residual Quality Loss boundary from the checked-in candidate-vs-PR30 deltas.
+
+## Storage Separation
+
+- Golden/reference roots: `20260318_deadleaf_13b10`, `release/deadleaf_13b10_release/data/20260318_deadleaf_13b10`, `release/deadleaf_13b10_release/config`
+- Fitted outputs for this issue stay under `algo/` and `artifacts/` only.
+- No release-facing config is promoted in this issue.

--- a/tests/test_benchmark_parity_acutance_quality_loss.py
+++ b/tests/test_benchmark_parity_acutance_quality_loss.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import tempfile
 import unittest
 from pathlib import Path
@@ -87,6 +88,19 @@ class BenchmarkParityAcutanceQualityLossTest(unittest.TestCase):
         self.assertEqual(profile.readout_smoothing_window, 7)
         self.assertEqual(profile.readout_interpolation, "linear")
 
+    def test_profile_allows_quality_loss_preset_input_overrides(self) -> None:
+        profile = Profile(
+            name="test",
+            calibration_file="algo/deadleaf_13b10_psd_calibration.json",
+            quality_loss_preset_input_profile_overrides={
+                "Computer Monitor Quality Loss": "algo/pr30_anchor.json",
+            },
+        )
+        self.assertEqual(
+            profile.quality_loss_preset_input_profile_overrides,
+            {"Computer Monitor Quality Loss": "algo/pr30_anchor.json"},
+        )
+
     def test_choose_roi_reference_refined_uses_reference_seed(self) -> None:
         image = np.zeros((20, 20), dtype=np.float32)
         reference = SimpleNamespace(lrtb=RoiBounds(left=4, right=9, top=5, bottom=10))
@@ -99,6 +113,154 @@ class BenchmarkParityAcutanceQualityLossTest(unittest.TestCase):
             actual = choose_roi(profile, reference, image)
         self.assertEqual(actual, expected)
         self.assertEqual(refine.call_args.kwargs["seed_roi"], reference.lrtb)
+
+    def test_quality_loss_preset_input_override_substitutes_only_target_preset(self) -> None:
+        capture_key = "OV13b10_AG8_ET5500_deadleaf_12M_40"
+        preset_names = (
+            '5.5" Phone Display Acutance',
+            "Computer Monitor Acutance",
+            "UHDTV Display Acutance",
+            "Small Print Acutance",
+            "Large Print Acutance",
+        )
+        quality_names = tuple(name.replace("Acutance", "Quality Loss") for name in preset_names)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dataset_root = Path(tmpdir)
+            variant_root = dataset_root / "OV13B10_AI_NR_OV13B10_ppqpkl_0.10"
+            results_dir = variant_root / "Results"
+            results_dir.mkdir(parents=True)
+            stem = f"{capture_key}_variantA"
+            csv_path = results_dir / f"{stem}_R_Random.csv"
+            raw_path = variant_root / f"{stem}.raw"
+            csv_path.write_text("", encoding="utf-8")
+            raw_path.write_bytes(b"")
+            override_path = dataset_root / "override_profile.json"
+            override_path.write_text(
+                json.dumps({"name": "override", "calibration_file": "override_calibration"}),
+                encoding="utf-8",
+            )
+
+            reference = SimpleNamespace(
+                lrtb=RoiBounds(left=0, right=1, top=0, bottom=1),
+                frequencies_cpp=np.array([0.02, 0.1, 0.25, 0.4], dtype=np.float64),
+                mtf=np.array([1.0, 0.9, 0.8, 0.7], dtype=np.float64),
+                acutance_table=[
+                    AcutancePoint(print_height_cm=40.0, viewing_distance_cm=10.0, acutance=0.0)
+                ],
+                reported_acutance={name: 0.0 for name in preset_names},
+                reported_quality_loss={name: 0.0 for name in quality_names},
+            )
+
+            def estimate_side_effect(*_args, **kwargs):
+                value = 2.0 if kwargs["ideal_psd_calibration"] == "override_calibration" else 1.0
+                return SimpleNamespace(
+                    roi=RoiBounds(left=0, right=1, top=0, bottom=1),
+                    frequencies_cpp=np.array([0.02, 0.1], dtype=np.float64),
+                    mtf_for_acutance=np.array([value, value], dtype=np.float64),
+                    acutance_high_frequency_noise_share=0.0,
+                )
+
+            def acutance_from_mtf(_frequencies, mtf, **_kwargs):
+                value = float(np.asarray(mtf, dtype=np.float64)[0])
+                return {name: value for name in preset_names}
+
+            profile = Profile(
+                name="candidate",
+                calibration_file="candidate_calibration",
+                quality_loss_preset_input_profile_overrides={
+                    "Computer Monitor Quality Loss": str(override_path),
+                },
+            )
+            with (
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.load_ideal_psd_calibration",
+                    side_effect=lambda path: path,
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.parse_imatest_random_csv",
+                    return_value=reference,
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.load_raw_u16",
+                    return_value=np.zeros((2, 2), dtype=np.uint16),
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.extract_analysis_plane",
+                    return_value=np.zeros((2, 2), dtype=np.float32),
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.normalize_for_analysis",
+                    return_value=np.zeros((2, 2), dtype=np.float32),
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.detect_texture_roi",
+                    return_value=RoiBounds(left=0, right=1, top=0, bottom=1),
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.estimate_dead_leaves_mtf",
+                    side_effect=estimate_side_effect,
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.acutance_curve_from_mtf",
+                    return_value=[
+                        AcutancePoint(
+                            print_height_cm=40.0,
+                            viewing_distance_cm=10.0,
+                            acutance=1.0,
+                        )
+                    ],
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.acutance_presets_from_mtf",
+                    side_effect=acutance_from_mtf,
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.compare_acutance_curves",
+                    return_value={"count": 1, "mae": 0.0},
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.compare_acutance_presets",
+                    side_effect=lambda estimate_map, reference_map: {
+                        name: {
+                            "abs_error": abs(float(estimate_map[name]) - float(reference_map[name])),
+                            "estimate": float(estimate_map[name]),
+                            "reference": float(reference_map[name]),
+                        }
+                        for name in estimate_map
+                    },
+                ),
+                patch(
+                    "algo.benchmark_parity_acutance_quality_loss.quality_loss_presets_from_acutance",
+                    side_effect=lambda acutance, **_kwargs: {
+                        name.replace("Acutance", "Quality Loss"): value
+                        for name, value in acutance.items()
+                    },
+                ),
+            ):
+                payload = summarize_profile(
+                    dataset_root=dataset_root,
+                    profile_path=dataset_root / "candidate_profile.json",
+                    profile=profile,
+                    width=2,
+                    height=2,
+                )
+
+            self.assertEqual(
+                payload["overall"]["acutance_preset_mae"]["Computer Monitor Acutance"],
+                1.0,
+            )
+            self.assertEqual(
+                payload["overall"]["quality_loss_preset_mae"]["Computer Monitor Quality Loss"],
+                2.0,
+            )
+            self.assertEqual(
+                payload["overall"]["quality_loss_preset_mae"]['5.5" Phone Display Quality Loss'],
+                1.0,
+            )
+            self.assertEqual(
+                payload["analysis_pipeline"]["quality_loss_preset_input_profile_overrides"],
+                {"Computer Monitor Quality Loss": str(override_path)},
+            )
 
     def test_summarize_profile_uses_observable_table_frequency_bins(self) -> None:
         capture_key = "OV13b10_AG8_ET5500_deadleaf_12M_40"

--- a/tests/test_build_intrinsic_after_issue111_quality_loss_boundary_followup.py
+++ b/tests/test_build_intrinsic_after_issue111_quality_loss_boundary_followup.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from algo.build_intrinsic_after_issue111_quality_loss_boundary_followup import (
+    CANDIDATE_LABEL,
+    COMPUTER_MONITOR_QUALITY_LOSS,
+    SELECTED_SLICE_ID,
+    build_payload,
+    render_markdown,
+)
+
+
+class BuildIntrinsicAfterIssue111QualityLossBoundaryFollowupTest(unittest.TestCase):
+    def test_payload_records_computer_monitor_only_boundary(self) -> None:
+        payload = build_payload(
+            self.repo_root(),
+            issue108_summary_path=Path(
+                "artifacts/intrinsic_phase_retained_pr30_observed_bundle_benchmark.json"
+            ),
+            issue111_summary_path=Path("artifacts/intrinsic_after_issue108_next_slice_benchmark.json"),
+            acutance_artifact_path=Path(
+                "artifacts/issue114_computer_monitor_quality_loss_boundary_acutance_benchmark.json"
+            ),
+            psd_artifact_path=Path(
+                "artifacts/issue114_computer_monitor_quality_loss_boundary_psd_benchmark.json"
+            ),
+        )
+
+        self.assertEqual(payload["issue"], 114)
+        self.assertEqual(
+            payload["summary_kind"],
+            "intrinsic_after_issue111_quality_loss_boundary_followup",
+        )
+        self.assertEqual(payload["selected_slice_id"], SELECTED_SLICE_ID)
+        self.assertTrue(payload["acceptance"]["selected_slice_matches_issue111"])
+        self.assertTrue(payload["acceptance"]["computer_monitor_quality_loss_improved_vs_issue108"])
+        self.assertTrue(payload["acceptance"]["overall_quality_loss_improved_vs_issue108"])
+        self.assertTrue(payload["acceptance"]["reported_mtf_equal_to_issue108"])
+        self.assertTrue(payload["acceptance"]["only_computer_monitor_quality_loss_input_overridden"])
+        self.assertTrue(payload["acceptance"]["quality_loss_coefficients_preserved"])
+        self.assertTrue(payload["acceptance"]["all_issue114_gates_pass"])
+
+        delta = payload["comparisons"]["candidate_vs_issue108"]["delta"]
+        self.assertLess(delta["quality_loss_preset_mae"][COMPUTER_MONITOR_QUALITY_LOSS], -0.65)
+        self.assertLess(delta["overall_quality_loss_mae_mean"], -0.13)
+        for preset, value in delta["quality_loss_preset_mae"].items():
+            if preset != COMPUTER_MONITOR_QUALITY_LOSS:
+                self.assertEqual(value, 0.0)
+
+        candidate = payload["profiles"][CANDIDATE_LABEL]
+        self.assertEqual(
+            candidate["analysis_pipeline"]["quality_loss_preset_input_profile_overrides"],
+            {
+                COMPUTER_MONITOR_QUALITY_LOSS: (
+                    "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_"
+                    "curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json"
+                )
+            },
+        )
+        for path in payload["storage"]["new_fitted_artifact_paths"]:
+            self.assertFalse(path.startswith("20260318_deadleaf_13b10"))
+            self.assertFalse(
+                path.startswith("release/deadleaf_13b10_release/data/20260318_deadleaf_13b10")
+            )
+            self.assertFalse(path.startswith("release/deadleaf_13b10_release/config"))
+
+    def test_markdown_mentions_scope_result_and_storage(self) -> None:
+        payload = build_payload(
+            self.repo_root(),
+            issue108_summary_path=Path(
+                "artifacts/intrinsic_phase_retained_pr30_observed_bundle_benchmark.json"
+            ),
+            issue111_summary_path=Path("artifacts/intrinsic_after_issue108_next_slice_benchmark.json"),
+            acutance_artifact_path=Path(
+                "artifacts/issue114_computer_monitor_quality_loss_boundary_acutance_benchmark.json"
+            ),
+            psd_artifact_path=Path(
+                "artifacts/issue114_computer_monitor_quality_loss_boundary_psd_benchmark.json"
+            ),
+        )
+        markdown = render_markdown(payload)
+
+        self.assertIn("# Intrinsic After Issue 111 Quality Loss Boundary", markdown)
+        self.assertIn("Issue `#114`", markdown)
+        self.assertIn("Computer Monitor Quality Loss", markdown)
+        self.assertIn("reported-MTF", markdown)
+        self.assertIn("Quality Loss coefficients", markdown)
+        self.assertIn("Storage Separation", markdown)
+
+    @staticmethod
+    def repo_root() -> Path:
+        return Path(__file__).resolve().parents[1]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Refs #114
Refs #29
Context from #111
Context from #112
Context from #113

Implements the issue #111 selected slice for issue #114: isolate only the `Computer Monitor Quality Loss` preset-family input boundary while preserving the issue #108 reported-MTF/readout path and intrinsic main-acutance path.

## What Changed

- Added profile support for `quality_loss_preset_input_profile_overrides`, allowing one Quality Loss preset to source its downstream acutance input from a different profile without changing other presets.
- Added the issue #114 candidate profile, which keeps the issue #108 branch but routes only `Computer Monitor Quality Loss` through the PR #30-compatible acutance-only / noise-share anchor input.
- Added checked-in acutance and PSD benchmark artifacts plus a summary artifact and note for the issue #114 comparison.
- Added regression coverage for target-only Quality Loss input substitution and the issue #114 artifact summary gates.

## Measured Result

- `Computer Monitor Quality Loss` improves versus issue #108: `3.56493 -> 2.90611`.
- `overall_quality_loss_mae_mean` improves versus issue #108: `1.40663 -> 1.27487`.
- `curve_mae_mean` remains unchanged versus issue #108: `0.03280`.
- `focus_preset_acutance_mae_mean` remains unchanged versus issue #108: `0.02892`.
- `mtf_abs_signed_rel_mean`, `mtf20`, `mtf30`, and `mtf50` remain equal to issue #108 in the generated PSD artifact.
- The candidate remains a positive partial result, not a new current-best branch: it still trails PR #30 on `overall_quality_loss_mae_mean` by about `+0.05337` in the summary artifact.

## Validation

- `python3 -m py_compile algo/benchmark_parity_acutance_quality_loss.py algo/benchmark_parity_psd_mtf.py algo/build_intrinsic_after_issue111_quality_loss_boundary_followup.py`
- `python3 -m pytest tests/test_benchmark_parity_acutance_quality_loss.py -q`
- `python3 -m algo.benchmark_parity_acutance_quality_loss 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_profile.json algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_computer_monitor_pr30_input_profile.json --output artifacts/issue114_computer_monitor_quality_loss_boundary_acutance_benchmark.json`
- `python3 -m algo.benchmark_parity_psd_mtf 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_profile.json algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_computer_monitor_pr30_input_profile.json --output artifacts/issue114_computer_monitor_quality_loss_boundary_psd_benchmark.json`
- `python3 -m algo.build_intrinsic_after_issue111_quality_loss_boundary_followup`
- `python3 -m pytest tests/test_build_intrinsic_after_issue111_quality_loss_boundary_followup.py tests/test_benchmark_parity_acutance_quality_loss.py tests/test_benchmark_parity_psd_mtf.py -q`
