### PR TITLE
Issue #124: isolate high-mixup curve boundary

### DIFF
--- a/algo/benchmark_parity_acutance_quality_loss.py
+++ b/algo/benchmark_parity_acutance_quality_loss.py
@@ -133,6 +133,7 @@ class Profile:
     matched_ori_acutance_preset_correction_delta_power_values: tuple[float, ...] | None = None
     matched_ori_acutance_preset_strength_curve_relative_scales: tuple[float, ...] | None = None
     matched_ori_acutance_preset_strength_curve_values: tuple[float, ...] | None = None
+    curve_only_acutance_anchor_mixups: tuple[str, ...] | None = None
     frequency_bin_source: str = "reference_bins"
     frequency_scale: float = 1.0
     readout_smoothing_window: int = 1
@@ -314,6 +315,7 @@ def build_quality_loss_input_override_records(
 ) -> dict[str, dict[str, float]]:
     overrides = profile.quality_loss_preset_input_profile_overrides or {}
     records_by_preset: dict[str, dict[str, float]] = {}
+    override_payloads: dict[str, dict[str, object]] = {}
     for quality_loss_preset, override_profile_path_text in overrides.items():
         override_profile_path = resolve_profile_override_path(
             profile_path,
@@ -325,15 +327,17 @@ def build_quality_loss_input_override_records(
                 "Recursive quality-loss input profile override detected for "
                 f"{override_profile_path_text!r}"
             )
-        override_payload = summarize_profile(
-            dataset_root=dataset_root,
-            profile_path=override_profile_path,
-            profile=load_profile(override_profile_path),
-            width=width,
-            height=height,
-            include_quality_loss_records=True,
-            override_stack=override_stack | {override_key},
-        )
+        if override_key not in override_payloads:
+            override_payloads[override_key] = summarize_profile(
+                dataset_root=dataset_root,
+                profile_path=override_profile_path,
+                profile=load_profile(override_profile_path),
+                width=width,
+                height=height,
+                include_quality_loss_records=True,
+                override_stack=override_stack | {override_key},
+            )
+        override_payload = override_payloads[override_key]
         preset_records = {
             str(record["csv_path"]): float(record["predicted_acutance"])
             for record in override_payload["quality_loss_records"]
@@ -992,6 +996,15 @@ def summarize_profile(
             pixels_along_picture_height=estimate.roi.height,
             presets=presets,
         )
+        mixup_key = classify_csv(csv_path, dataset_root)
+        curve_only_anchor_mixups = frozenset(profile.curve_only_acutance_anchor_mixups or ())
+        if mixup_key in curve_only_anchor_mixups:
+            curve, _ = maybe_anchor_acutance_results(
+                capture_key=capture_key,
+                curve=curve,
+                acutance=acutance,
+                roi_height=estimate.roi.height,
+            )
         if (
             profile.intrinsic_full_reference_scope
             not in {
@@ -1052,9 +1065,7 @@ def summarize_profile(
         curve_cmp = compare_acutance_curves(curve, reference.acutance_table)
         if curve_cmp.get("count", 0):
             curve_mae.append(float(curve_cmp["mae"]))
-            by_mixup_curve_mae.setdefault(classify_csv(csv_path, dataset_root), []).append(
-                float(curve_cmp["mae"])
-            )
+            by_mixup_curve_mae.setdefault(mixup_key, []).append(float(curve_cmp["mae"]))
         if include_acutance_records:
             ref_curve_map = {
                 (point.print_height_cm, point.viewing_distance_cm): float(point.acutance)
@@ -1188,6 +1199,7 @@ def summarize_profile(
             "matched_ori_acutance_preset_correction_delta_power_values": profile.matched_ori_acutance_preset_correction_delta_power_values,
             "matched_ori_acutance_preset_strength_curve_relative_scales": profile.matched_ori_acutance_preset_strength_curve_relative_scales,
             "matched_ori_acutance_preset_strength_curve_values": profile.matched_ori_acutance_preset_strength_curve_values,
+            "curve_only_acutance_anchor_mixups": profile.curve_only_acutance_anchor_mixups,
             "quality_loss_om_ceiling": profile.quality_loss_om_ceiling,
             "quality_loss_coefficients": profile.quality_loss_coefficients,
             "quality_loss_preset_overrides": profile.quality_loss_preset_overrides,

--- a/algo/benchmark_parity_psd_mtf.py
+++ b/algo/benchmark_parity_psd_mtf.py
@@ -119,6 +119,7 @@ class Profile:
     matched_ori_acutance_preset_correction_delta_power_values: tuple[float, ...] | None = None
     matched_ori_acutance_preset_strength_curve_relative_scales: tuple[float, ...] | None = None
     matched_ori_acutance_preset_strength_curve_values: tuple[float, ...] | None = None
+    curve_only_acutance_anchor_mixups: tuple[str, ...] | None = None
     frequency_bin_source: str = "reference_bins"
     frequency_scale: float = 1.0
     readout_smoothing_window: int = 1
@@ -820,6 +821,7 @@ def profile_payload(
             "matched_ori_acutance_preset_correction_delta_power_values": profile.matched_ori_acutance_preset_correction_delta_power_values,
             "matched_ori_acutance_preset_strength_curve_relative_scales": profile.matched_ori_acutance_preset_strength_curve_relative_scales,
             "matched_ori_acutance_preset_strength_curve_values": profile.matched_ori_acutance_preset_strength_curve_values,
+            "curve_only_acutance_anchor_mixups": profile.curve_only_acutance_anchor_mixups,
             "frequency_scale": profile.frequency_scale,
             "readout_smoothing_window": profile.readout_smoothing_window,
             "readout_interpolation": profile.readout_interpolation,

--- a/algo/build_issue124_curve_only_high_mixup_ori_summary.py
+++ b/algo/build_issue124_curve_only_high_mixup_ori_summary.py
@@ -1,0 +1,426 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+ISSUE = 124
+UMBRELLA_ISSUE = 29
+CURRENT_BEST_ISSUE = 118
+CURRENT_BEST_PR = 119
+BASELINE_PR = 30
+SUMMARY_KIND = "issue124_curve_only_high_mixup_ori_summary"
+CANDIDATE_LABEL = "issue124_curve_only_high_mixup_ori_candidate"
+RESULT_KIND = "positive_partial_not_promotable"
+README_GATES = {
+    "curve_mae_mean": 0.020,
+    "focus_preset_acutance_mae_mean": 0.030,
+    "overall_quality_loss_mae_mean": 1.30,
+    "non_phone_acutance_preset_mae_max": 0.030,
+    '5.5" Phone Display Acutance': 0.050,
+}
+PHONE_PRESET = '5.5" Phone Display Acutance'
+HIGH_MIXUP_KEYS = ("0.8", "ori")
+GOLDEN_REFERENCE_ROOTS = (
+    "20260318_deadleaf_13b10",
+    "release/deadleaf_13b10_release/data/20260318_deadleaf_13b10",
+    "release/deadleaf_13b10_release/config",
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build issue-124 curve-only summary.")
+    parser.add_argument("--repo-root", type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument(
+        "--issue120-summary",
+        type=Path,
+        default=Path("artifacts/issue120_current_best_readme_gate_summary.json"),
+    )
+    parser.add_argument(
+        "--issue122-summary",
+        type=Path,
+        default=Path("artifacts/intrinsic_after_issue120_next_slice_benchmark.json"),
+    )
+    parser.add_argument(
+        "--candidate-acutance",
+        type=Path,
+        default=Path("artifacts/issue124_curve_only_high_mixup_ori_acutance_benchmark.json"),
+    )
+    parser.add_argument(
+        "--candidate-psd",
+        type=Path,
+        default=Path("artifacts/issue124_curve_only_high_mixup_ori_psd_benchmark.json"),
+    )
+    parser.add_argument(
+        "--output-json",
+        type=Path,
+        default=Path("artifacts/issue124_curve_only_high_mixup_ori_summary.json"),
+    )
+    parser.add_argument(
+        "--output-md",
+        type=Path,
+        default=Path("docs/issue124_curve_only_high_mixup_ori_summary.md"),
+    )
+    return parser
+
+
+def resolve_path(repo_root: Path, path: Path) -> Path:
+    return path if path.is_absolute() else repo_root / path
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def select_single_profile(payload: dict[str, Any]) -> dict[str, Any]:
+    profiles = payload["profiles"]
+    if len(profiles) != 1:
+        raise ValueError(f"Expected exactly one profile, found {len(profiles)}")
+    return profiles[0]
+
+
+def readme_gate_summary(metrics: dict[str, Any]) -> dict[str, Any]:
+    acutance = metrics["acutance_preset_mae"]
+    non_phone = {key: value for key, value in acutance.items() if key != PHONE_PRESET}
+    worst_preset, worst_value = max(non_phone.items(), key=lambda item: item[1])
+    gates = {
+        "curve_mae_mean": gate(metrics["curve_mae_mean"], README_GATES["curve_mae_mean"]),
+        "focus_preset_acutance_mae_mean": gate(
+            metrics["acutance_focus_preset_mae_mean"],
+            README_GATES["focus_preset_acutance_mae_mean"],
+        ),
+        "overall_quality_loss_mae_mean": gate(
+            metrics["overall_quality_loss_mae_mean"],
+            README_GATES["overall_quality_loss_mae_mean"],
+        ),
+        "non_phone_acutance_preset_mae_max": {
+            **gate(worst_value, README_GATES["non_phone_acutance_preset_mae_max"]),
+            "worst_preset": worst_preset,
+            "by_preset": {key: float(value) for key, value in sorted(non_phone.items())},
+        },
+        PHONE_PRESET: gate(acutance[PHONE_PRESET], README_GATES[PHONE_PRESET]),
+    }
+    return {
+        "all_readme_gates_pass": all(row["pass"] for row in gates.values()),
+        "failed_gates": [name for name, row in gates.items() if not row["pass"]],
+        "gates": gates,
+    }
+
+
+def gate(value: float, threshold: float) -> dict[str, Any]:
+    value = float(value)
+    return {
+        "value": value,
+        "threshold": threshold,
+        "operator": "<=",
+        "pass": value <= threshold,
+        "delta_to_gate": value - threshold,
+    }
+
+
+def metric_delta(candidate: dict[str, Any], baseline: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "curve_mae_mean": float(candidate["curve_mae_mean"] - baseline["curve_mae_mean"]),
+        "focus_preset_acutance_mae_mean": float(
+            candidate["acutance_focus_preset_mae_mean"]
+            - baseline["focus_preset_acutance_mae_mean"]
+        ),
+        "overall_quality_loss_mae_mean": float(
+            candidate["overall_quality_loss_mae_mean"]
+            - baseline["overall_quality_loss_mae_mean"]
+        ),
+        "mtf_abs_signed_rel_mean": float(
+            candidate["mtf_abs_signed_rel_mean"] - baseline["mtf_abs_signed_rel_mean"]
+        ),
+        "mtf_threshold_mae": {
+            key: float(candidate["mtf_threshold_mae"][key] - baseline["mtf_threshold_mae"][key])
+            for key in candidate["mtf_threshold_mae"]
+        },
+        "acutance_preset_mae": {
+            key: float(
+                candidate["acutance_preset_mae"][key] - baseline["acutance_preset_mae"][key]
+            )
+            for key in candidate["acutance_preset_mae"]
+        },
+    }
+
+
+def is_close(left: float, right: float, *, tolerance: float = 1e-12) -> bool:
+    return abs(float(left) - float(right)) <= tolerance
+
+
+def collect_candidate_metrics(
+    *,
+    candidate_acutance: dict[str, Any],
+    candidate_psd: dict[str, Any],
+) -> dict[str, Any]:
+    acutance_overall = candidate_acutance["overall"]
+    psd_overall = candidate_psd["overall"]
+    return {
+        "curve_mae_mean": float(acutance_overall["curve_mae_mean"]),
+        "acutance_focus_preset_mae_mean": float(
+            acutance_overall["acutance_focus_preset_mae_mean"]
+        ),
+        "overall_quality_loss_mae_mean": float(
+            acutance_overall["overall_quality_loss_mae_mean"]
+        ),
+        "mtf_abs_signed_rel_mean": float(psd_overall["mtf_abs_signed_rel_mean"]),
+        "mtf_threshold_mae": {
+            key: float(value) for key, value in psd_overall["mtf_threshold_mae"].items()
+        },
+        "acutance_preset_mae": {
+            key: float(value) for key, value in acutance_overall["acutance_preset_mae"].items()
+        },
+        "quality_loss_preset_mae": {
+            key: float(value)
+            for key, value in acutance_overall["quality_loss_preset_mae"].items()
+        },
+    }
+
+
+def build_payload(
+    repo_root: Path,
+    *,
+    issue120_summary_path: Path,
+    issue122_summary_path: Path,
+    candidate_acutance_path: Path,
+    candidate_psd_path: Path,
+) -> dict[str, Any]:
+    issue120 = load_json(resolve_path(repo_root, issue120_summary_path))
+    issue122 = load_json(resolve_path(repo_root, issue122_summary_path))
+    candidate_acutance = select_single_profile(load_json(resolve_path(repo_root, candidate_acutance_path)))
+    candidate_psd = select_single_profile(load_json(resolve_path(repo_root, candidate_psd_path)))
+    current_best = issue120["current_best"]
+    pr30 = issue120["baseline"]
+    baseline_metrics = current_best["metrics"]
+    candidate_metrics = collect_candidate_metrics(
+        candidate_acutance=candidate_acutance,
+        candidate_psd=candidate_psd,
+    )
+    gate_summary = readme_gate_summary(candidate_metrics)
+    candidate_vs_pr119 = metric_delta(candidate_metrics, baseline_metrics)
+    candidate_vs_pr30 = metric_delta(candidate_metrics, pr30["metrics"])
+    by_mixup_before = issue122["residual_curve_evidence"]["by_mixup"]
+    by_mixup_after = candidate_acutance["by_mixup_curve_mae_mean"]
+    by_mixup_delta = {
+        key: float(by_mixup_after[key] - by_mixup_before[key]["current_best_curve_mae"])
+        for key in by_mixup_after
+    }
+    high_mixup_after_weighted = sum(
+        by_mixup_after[key] * by_mixup_before[key]["record_fraction"]
+        for key in HIGH_MIXUP_KEYS
+    )
+    weighted_curve_after = sum(
+        by_mixup_after[key] * by_mixup_before[key]["record_fraction"]
+        for key in by_mixup_after
+    )
+    candidate_path = candidate_acutance["profile_path"]
+    source_artifacts = [
+        str(candidate_acutance_path),
+        str(candidate_psd_path),
+        str(issue120_summary_path),
+        str(issue122_summary_path),
+    ]
+    payload = {
+        "issue": ISSUE,
+        "summary_kind": SUMMARY_KIND,
+        "result_kind": RESULT_KIND,
+        "candidate": {
+            "label": CANDIDATE_LABEL,
+            "profile_path": candidate_path,
+            "curve_only_acutance_anchor_mixups": list(HIGH_MIXUP_KEYS),
+            "source_artifacts": source_artifacts,
+            "metrics": candidate_metrics,
+        },
+        "baseline_current_best": current_best,
+        "baseline_pr30": pr30,
+        "readme_gate_summary": gate_summary,
+        "comparisons": {
+            "candidate_vs_pr119": {"delta": candidate_vs_pr119},
+            "candidate_vs_pr30": {"delta": candidate_vs_pr30},
+        },
+        "curve_tail_result": {
+            "selected_mixups": list(HIGH_MIXUP_KEYS),
+            "by_mixup_before": {
+                key: float(row["current_best_curve_mae"])
+                for key, row in sorted(by_mixup_before.items())
+            },
+            "by_mixup_after": {key: float(value) for key, value in sorted(by_mixup_after.items())},
+            "by_mixup_delta": {key: float(value) for key, value in sorted(by_mixup_delta.items())},
+            "high_mixup_weighted_curve_mae_after": float(high_mixup_after_weighted),
+            "weighted_curve_mae_after": float(weighted_curve_after),
+            "weighted_curve_mae_matches_candidate": is_close(
+                weighted_curve_after,
+                candidate_metrics["curve_mae_mean"],
+            ),
+        },
+        "acceptance": {
+            "curve_mae_reduced_vs_pr119": candidate_vs_pr119["curve_mae_mean"] < 0.0,
+            "reported_mtf_preserved": (
+                is_close(candidate_vs_pr119["mtf_abs_signed_rel_mean"], 0.0)
+                and all(
+                    is_close(value, 0.0)
+                    for value in candidate_vs_pr119["mtf_threshold_mae"].values()
+                )
+            ),
+            "overall_quality_loss_preserved": is_close(
+                candidate_vs_pr119["overall_quality_loss_mae_mean"],
+                0.0,
+            ),
+            "focus_preset_acutance_gate_pass": gate_summary["gates"][
+                "focus_preset_acutance_mae_mean"
+            ]["pass"],
+            "small_print_acutance_preserved": is_close(
+                candidate_vs_pr119["acutance_preset_mae"]["Small Print Acutance"],
+                0.0,
+            ),
+            "all_readme_gates_pass": gate_summary["all_readme_gates_pass"],
+        },
+        "next_result": {
+            "summary": (
+                "The high-mixup/ori curve-only anchor is a positive partial result: it "
+                "materially lowers curve MAE while preserving reported-MTF, preset "
+                "Acutance, and Quality Loss, but the README curve gate still misses."
+            ),
+            "remaining_misses": gate_summary["failed_gates"],
+            "recommended_follow_up": (
+                "Do not broaden this issue into Small Print preset work. If PM splits "
+                "another engineering pass, target the remaining curve residual now "
+                "visible in `ori`, `0.15`, and `0.25`, while preserving the issue #124 "
+                "curve-only isolation."
+            ),
+        },
+        "release_separation": {
+            "candidate_is_release_config": False,
+            "golden_reference_roots": list(GOLDEN_REFERENCE_ROOTS),
+            "rules": [
+                "The candidate profile is canonical-target research only.",
+                "No fitted outputs are written under golden/reference data roots.",
+                "No release-facing config is promoted in this issue.",
+            ],
+        },
+        "refs": {
+            "umbrella_issue": UMBRELLA_ISSUE,
+            "current_issue": ISSUE,
+            "current_best_issue": CURRENT_BEST_ISSUE,
+            "current_best_pr": CURRENT_BEST_PR,
+            "baseline_pr": BASELINE_PR,
+        },
+    }
+    assert_storage_separation(payload)
+    return payload
+
+
+def assert_storage_separation(payload: dict[str, Any]) -> None:
+    paths = [payload["candidate"]["profile_path"], *payload["candidate"]["source_artifacts"]]
+    for path in paths:
+        if path.startswith(GOLDEN_REFERENCE_ROOTS):
+            raise ValueError(f"candidate path entered golden/release root: {path}")
+
+
+def format_metric(value: float) -> str:
+    return f"{float(value):.5f}"
+
+
+def render_markdown(payload: dict[str, Any]) -> str:
+    metrics = payload["candidate"]["metrics"]
+    pr119 = payload["baseline_current_best"]["metrics"]
+    delta = payload["comparisons"]["candidate_vs_pr119"]["delta"]
+    gates = payload["readme_gate_summary"]["gates"]
+    curve_tail = payload["curve_tail_result"]
+    return "\n".join(
+        [
+            "# Issue 124 Curve-Only High-Mixup/Ori Summary",
+            "",
+            f"- Result: `{payload['result_kind']}`.",
+            f"- Candidate profile: `{payload['candidate']['profile_path']}`",
+            "- Scoped boundary: only the main Acutance curve is anchored for mixups "
+            "`0.8` and `ori`; preset Acutance, Quality Loss, and reported-MTF/readout "
+            "paths stay unchanged.",
+            "",
+            "## Metrics",
+            "",
+            "| Metric | PR #119 | Issue #124 | Delta | Gate |",
+            "| --- | ---: | ---: | ---: | --- |",
+            f"| curve_mae_mean | {format_metric(pr119['curve_mae_mean'])} | "
+            f"{format_metric(metrics['curve_mae_mean'])} | "
+            f"{format_metric(delta['curve_mae_mean'])} | "
+            f"<= 0.020 ({'pass' if gates['curve_mae_mean']['pass'] else 'miss'}) |",
+            f"| focus_preset_acutance_mae_mean | "
+            f"{format_metric(pr119['focus_preset_acutance_mae_mean'])} | "
+            f"{format_metric(metrics['acutance_focus_preset_mae_mean'])} | "
+            f"{format_metric(delta['focus_preset_acutance_mae_mean'])} | "
+            f"<= 0.030 ({'pass' if gates['focus_preset_acutance_mae_mean']['pass'] else 'miss'}) |",
+            f"| overall_quality_loss_mae_mean | "
+            f"{format_metric(pr119['overall_quality_loss_mae_mean'])} | "
+            f"{format_metric(metrics['overall_quality_loss_mae_mean'])} | "
+            f"{format_metric(delta['overall_quality_loss_mae_mean'])} | "
+            f"<= 1.30 ({'pass' if gates['overall_quality_loss_mae_mean']['pass'] else 'miss'}) |",
+            f"| mtf_abs_signed_rel_mean | {format_metric(pr119['mtf_abs_signed_rel_mean'])} | "
+            f"{format_metric(metrics['mtf_abs_signed_rel_mean'])} | "
+            f"{format_metric(delta['mtf_abs_signed_rel_mean'])} | preserve |",
+            f"| Small Print Acutance | "
+            f"{format_metric(pr119['acutance_preset_mae']['Small Print Acutance'])} | "
+            f"{format_metric(metrics['acutance_preset_mae']['Small Print Acutance'])} | "
+            f"{format_metric(delta['acutance_preset_mae']['Small Print Acutance'])} | "
+            f"<= 0.030 ({'pass' if gates['non_phone_acutance_preset_mae_max']['pass'] else 'miss'}) |",
+            "",
+            "## Curve Tail",
+            "",
+            "| Mixup | Before | After | Delta |",
+            "| --- | ---: | ---: | ---: |",
+            *[
+                f"| {key} | {format_metric(curve_tail['by_mixup_before'][key])} | "
+                f"{format_metric(curve_tail['by_mixup_after'][key])} | "
+                f"{format_metric(curve_tail['by_mixup_delta'][key])} |"
+                for key in sorted(curve_tail["by_mixup_after"])
+            ],
+            "",
+            "The selected high-mixup/ori intervention reduces `0.8` and `ori` curve error, "
+            "but the remaining README curve miss is now spread across `ori`, `0.15`, "
+            "and `0.25` rather than being solved by this slice alone.",
+            "",
+            "## Acceptance",
+            "",
+            f"- Curve MAE reduced versus PR #119: `{payload['acceptance']['curve_mae_reduced_vs_pr119']}`.",
+            f"- Reported-MTF preserved: `{payload['acceptance']['reported_mtf_preserved']}`.",
+            f"- Overall Quality Loss preserved: `{payload['acceptance']['overall_quality_loss_preserved']}`.",
+            f"- Small Print Acutance preserved: `{payload['acceptance']['small_print_acutance_preserved']}`.",
+            f"- All README gates pass: `{payload['acceptance']['all_readme_gates_pass']}`.",
+            "",
+            "## Next Result",
+            "",
+            payload["next_result"]["summary"],
+            "",
+            payload["next_result"]["recommended_follow_up"],
+            "",
+            "## Release Separation",
+            "",
+            "This remains canonical-target research, not a release-facing config promotion. "
+            "No fitted outputs are written under golden/reference data roots or release configs.",
+        ]
+    )
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    repo_root = args.repo_root
+    payload = build_payload(
+        repo_root,
+        issue120_summary_path=args.issue120_summary,
+        issue122_summary_path=args.issue122_summary,
+        candidate_acutance_path=args.candidate_acutance,
+        candidate_psd_path=args.candidate_psd,
+    )
+    output_json = resolve_path(repo_root, args.output_json)
+    output_md = resolve_path(repo_root, args.output_md)
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    output_md.parent.mkdir(parents=True, exist_ok=True)
+    output_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    output_md.write_text(render_markdown(payload) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_computer_monitor_small_print_large_print_pr30_input_curve_only_high_mixup_ori_profile.json
+++ b/algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_computer_monitor_small_print_large_print_pr30_input_curve_only_high_mixup_ori_profile.json
@@ -1,0 +1,193 @@
+{
+  "name": "deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_computer_monitor_small_print_large_print_pr30_input_curve_only_high_mixup_ori",
+  "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+  "gamma": 0.5,
+  "linearization_mode": "toe_power",
+  "linearization_toe": 0.12,
+  "roi_source": "reference_refined",
+  "roi_width": 1655,
+  "roi_height": 1673,
+  "roi_refine_percentile": 45.0,
+  "roi_refine_sigma": 5.0,
+  "roi_refine_min_border_margin": 8,
+  "roi_refine_search_radius": 4,
+  "roi_refine_step": 2,
+  "roi_refine_area_tolerance": 0.98,
+  "intrinsic_full_reference_mode": "paired_ori_transfer",
+  "intrinsic_full_reference_scope": "reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only",
+  "intrinsic_full_reference_clip_lo": 0.5,
+  "intrinsic_full_reference_clip_hi": 1.5,
+  "intrinsic_full_reference_registration_mode": "phase_correlation",
+  "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+  "matched_ori_reference_anchor": true,
+  "matched_ori_correction_clip_lo": 0.5,
+  "matched_ori_correction_clip_hi": 2.0,
+  "matched_ori_anchor_mode": "all",
+  "matched_ori_strength_curve_frequencies": [
+    0.0,
+    0.12,
+    0.22,
+    0.35,
+    0.5
+  ],
+  "matched_ori_strength_curve_values": [
+    1.0,
+    1.0,
+    0.82,
+    0.95,
+    1.0
+  ],
+  "matched_ori_acutance_reference_anchor": true,
+  "matched_ori_acutance_correction_clip_lo": 0.9,
+  "matched_ori_acutance_correction_clip_hi": 1.1,
+  "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+  "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+    0.0,
+    0.25,
+    0.6,
+    0.8,
+    1.6,
+    2.5
+  ],
+  "matched_ori_acutance_curve_correction_clip_hi_values": [
+    1.02,
+    1.03,
+    0.895,
+    0.895,
+    1.05,
+    1.06
+  ],
+  "matched_ori_acutance_strength_curve_relative_scales": [
+    0.0,
+    0.2,
+    0.8,
+    1.6,
+    2.5
+  ],
+  "matched_ori_acutance_strength_curve_values": [
+    0.7,
+    0.69,
+    0.64,
+    0.62,
+    0.6
+  ],
+  "matched_ori_acutance_correction_delta_power": 1.0,
+  "matched_ori_acutance_curve_correction_delta_power": 0.95,
+  "matched_ori_acutance_preset_correction_delta_power": null,
+  "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+    0.0,
+    4.5,
+    5.8,
+    6.2
+  ],
+  "matched_ori_acutance_preset_correction_delta_power_values": [
+    1.05,
+    1.05,
+    1.85,
+    1.85
+  ],
+  "matched_ori_acutance_preset_strength_curve_relative_scales": [
+    0.0,
+    3.0,
+    4.5,
+    5.8,
+    6.2
+  ],
+  "matched_ori_acutance_preset_strength_curve_values": [
+    1.0,
+    1.0,
+    0.85,
+    0.45,
+    0.45
+  ],
+  "curve_only_acutance_anchor_mixups": [
+    "0.8",
+    "ori"
+  ],
+  "frequency_scale": 1.0,
+  "normalization_band_lo": 0.01,
+  "normalization_band_hi": 0.03,
+  "normalization_mode": "max",
+  "acutance_band_lo": 0.017,
+  "acutance_band_hi": 0.035,
+  "acutance_band_mode": "mean",
+  "noise_psd_model": "empirical",
+  "noise_psd_scale": 1.0,
+  "quality_loss_om_ceiling": 0.8851,
+  "quality_loss_coefficients": [
+    37.240228358776136,
+    26.54550669779819,
+    0.4538662637619741
+  ],
+  "quality_loss_preset_overrides": {
+    "Computer Monitor Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        5677361.198044325,
+        -16715685.9524707,
+        20317567.326582585,
+        -13046703.33912079,
+        4667794.619228022,
+        -882296.9160375095,
+        68863.59709647154
+      ]
+    },
+    "5.5\" Phone Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        -110912321.41149135,
+        50461107.51563171,
+        -9079490.127807735,
+        815148.8697247265,
+        -37712.984407641874,
+        854.6941149036079,
+        -6.261149027919645
+      ]
+    },
+    "UHDTV Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        1783462.6221675149,
+        -3813432.5606394163,
+        3326218.4642961356,
+        -1514886.1959663907,
+        380334.163146246,
+        -49956.87092015135,
+        2692.9566508574017
+      ]
+    },
+    "Small Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        6690980.837239251,
+        -12955277.716404187,
+        10300283.291740375,
+        -4303759.200708971,
+        996904.2653558743,
+        -121409.71509269004,
+        6084.6471373306085
+      ]
+    },
+    "Large Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        2355074.475971866,
+        -5276146.244338096,
+        4846781.143787682,
+        -2336594.295523967,
+        623766.4933095274,
+        -87476.30712136331,
+        5049.882965558553
+      ]
+    }
+  },
+  "quality_loss_preset_input_profile_overrides": {
+    "Computer Monitor Quality Loss": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json",
+    "Small Print Quality Loss": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json",
+    "Large Print Quality Loss": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json"
+  },
+  "mtf_compensation_mode": "sensor_aperture_sinc",
+  "sensor_fill_factor": 1.5,
+  "texture_support_scale": true,
+  "high_frequency_guard_start_cpp": 0.36
+}

--- a/artifacts/issue124_curve_only_high_mixup_ori_acutance_benchmark.json
+++ b/artifacts/issue124_curve_only_high_mixup_ori_acutance_benchmark.json
@@ -1,0 +1,258 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "curve_only_acutance_anchor_mixups": [
+          "0.8",
+          "ori"
+        ],
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only",
+        "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_input_profile_overrides": {
+          "Computer Monitor Quality Loss": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json",
+          "Large Print Quality Loss": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json",
+          "Small Print Quality Loss": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json"
+        },
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "readout_interpolation": "linear",
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.029378599163150443,
+        "0.25": 0.02479729017929424,
+        "0.4": 0.019363342842858032,
+        "0.65": 0.011953815251775047,
+        "0.8": 0.0188398331534736,
+        "ori": 0.045803234428031414
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 1.1504751574647964,
+        "0.25": 1.2034864496306634,
+        "0.4": 1.1777404619388072,
+        "0.65": 0.49964929220560284,
+        "0.8": 1.0721427077120183,
+        "ori": 2.3362580209958006
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.028920526408725132,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.035256377739795786,
+          "Computer Monitor Acutance": 0.024146307932311834,
+          "Large Print Acutance": 0.028624302638652583,
+          "Small Print Acutance": 0.031726251556383624,
+          "UHDTV Display Acutance": 0.024849392176481848
+        },
+        "curve_mae_mean": 0.024251518035735907,
+        "overall_quality_loss_mae_mean": 1.2043596866693975,
+        "quality_loss_focus_preset_mae_mean": 1.2043596866693975,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 0.23804277891732473,
+          "Computer Monitor Quality Loss": 2.906111784076103,
+          "Large Print Quality Loss": 0.9547911309308169,
+          "Small Print Quality Loss": 0.6076983310559123,
+          "UHDTV Display Quality Loss": 1.3151544083668303
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_computer_monitor_small_print_large_print_pr30_input_curve_only_high_mixup_ori_profile.json"
+    }
+  ]
+}

--- a/artifacts/issue124_curve_only_high_mixup_ori_psd_benchmark.json
+++ b/artifacts/issue124_curve_only_high_mixup_ori_psd_benchmark.json
@@ -1,0 +1,202 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "curve_only_acutance_anchor_mixups": [
+          "0.8",
+          "ori"
+        ],
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only",
+        "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_preset_input_profile_overrides": {
+          "Computer Monitor Quality Loss": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json",
+          "Large Print Quality Loss": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json",
+          "Small Print Quality Loss": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json"
+        },
+        "readout_interpolation": "linear",
+        "readout_mtf_compensation_mode": "sensor_aperture_sinc",
+        "readout_sensor_fill_factor": 1.5,
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.029378599163150443,
+        "0.25": 0.02479729017929424,
+        "0.4": 0.019363342842858032,
+        "0.65": 0.011953815251775047,
+        "0.8": 0.04482380483621107,
+        "ori": 0.07933816634336006
+      },
+      "overall": {
+        "curve_mae_mean": 0.03280180556381627,
+        "mtf_abs_signed_rel_mean": 0.08671416893394165,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.01764835359892083,
+            "mre_mean": 0.088865357734797,
+            "signed_rel_mean": 0.04982888092128941
+          },
+          "low": {
+            "mae_mean": 0.03704553941403868,
+            "mre_mean": 0.046572470331734825,
+            "signed_rel_mean": 0.0237949421475065
+          },
+          "mid": {
+            "mae_mean": 0.03898616152003224,
+            "mre_mean": 0.12397538768693758,
+            "signed_rel_mean": 0.10965436746685472
+          },
+          "top": {
+            "mae_mean": 0.07374065223652229,
+            "mre_mean": 0.20171750026037474,
+            "signed_rel_mean": -0.16357848520011598
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.03301077142967389,
+          "mtf30": 0.03693639342667963,
+          "mtf50": 0.009332615436071163
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.035256377739795786,
+          "Computer Monitor Acutance": 0.024146307932311834,
+          "Large Print Acutance": 0.028624302638652583,
+          "Small Print Acutance": 0.031726251556383624,
+          "UHDTV Display Acutance": 0.024849392176481848
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_computer_monitor_small_print_large_print_pr30_input_curve_only_high_mixup_ori_profile.json"
+    }
+  ]
+}

--- a/artifacts/issue124_curve_only_high_mixup_ori_summary.json
+++ b/artifacts/issue124_curve_only_high_mixup_ori_summary.json
@@ -1,0 +1,260 @@
+{
+  "acceptance": {
+    "all_readme_gates_pass": false,
+    "curve_mae_reduced_vs_pr119": true,
+    "focus_preset_acutance_gate_pass": true,
+    "overall_quality_loss_preserved": true,
+    "reported_mtf_preserved": true,
+    "small_print_acutance_preserved": true
+  },
+  "baseline_current_best": {
+    "issue": 118,
+    "label": "issue118_large_print_quality_loss_input_boundary_candidate",
+    "merge_commit": "52bbca7",
+    "metrics": {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": 0.035256377739795786,
+        "Computer Monitor Acutance": 0.024146307932311834,
+        "Large Print Acutance": 0.028624302638652583,
+        "Small Print Acutance": 0.031726251556383624,
+        "UHDTV Display Acutance": 0.024849392176481848
+      },
+      "curve_mae_mean": 0.03280180556381627,
+      "focus_preset_acutance_mae_mean": 0.028920526408725132,
+      "mtf_abs_signed_rel_mean": 0.08671416893394165,
+      "mtf_threshold_mae": {
+        "mtf20": 0.03301077142967389,
+        "mtf30": 0.03693639342667963,
+        "mtf50": 0.009332615436071163
+      },
+      "overall_quality_loss_mae_mean": 1.2043596866693975
+    },
+    "pr": 119,
+    "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_computer_monitor_small_print_large_print_pr30_input_profile.json",
+    "source_artifacts": [
+      "artifacts/intrinsic_after_issue116_quality_loss_boundary_benchmark.json",
+      "artifacts/issue118_large_print_quality_loss_boundary_acutance_benchmark.json",
+      "artifacts/issue118_large_print_quality_loss_boundary_psd_benchmark.json"
+    ]
+  },
+  "baseline_pr30": {
+    "issue": 29,
+    "label": "current_best_pr30_branch",
+    "metrics": {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": 0.013802247905288301,
+        "Computer Monitor Acutance": 0.052665183748573804,
+        "Large Print Acutance": 0.05132586418527154,
+        "Small Print Acutance": 0.046702107662187464,
+        "UHDTV Display Acutance": 0.04793875259218785
+      },
+      "curve_mae_mean": 0.03678903166100513,
+      "focus_preset_acutance_mae_mean": 0.042486831218701795,
+      "mtf_abs_signed_rel_mean": 0.08671416893394165,
+      "mtf_threshold_mae": {
+        "mtf20": 0.03301077142967389,
+        "mtf30": 0.03693639342667963,
+        "mtf50": 0.009332615436071163
+      },
+      "overall_quality_loss_mae_mean": 1.2214989544377113
+    },
+    "pr": 30,
+    "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_profile.json"
+  },
+  "candidate": {
+    "curve_only_acutance_anchor_mixups": [
+      "0.8",
+      "ori"
+    ],
+    "label": "issue124_curve_only_high_mixup_ori_candidate",
+    "metrics": {
+      "acutance_focus_preset_mae_mean": 0.028920526408725132,
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": 0.035256377739795786,
+        "Computer Monitor Acutance": 0.024146307932311834,
+        "Large Print Acutance": 0.028624302638652583,
+        "Small Print Acutance": 0.031726251556383624,
+        "UHDTV Display Acutance": 0.024849392176481848
+      },
+      "curve_mae_mean": 0.024251518035735907,
+      "mtf_abs_signed_rel_mean": 0.08671416893394165,
+      "mtf_threshold_mae": {
+        "mtf20": 0.03301077142967389,
+        "mtf30": 0.03693639342667963,
+        "mtf50": 0.009332615436071163
+      },
+      "overall_quality_loss_mae_mean": 1.2043596866693975,
+      "quality_loss_preset_mae": {
+        "5.5\" Phone Display Quality Loss": 0.23804277891732473,
+        "Computer Monitor Quality Loss": 2.906111784076103,
+        "Large Print Quality Loss": 0.9547911309308169,
+        "Small Print Quality Loss": 0.6076983310559123,
+        "UHDTV Display Quality Loss": 1.3151544083668303
+      }
+    },
+    "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_computer_monitor_small_print_large_print_pr30_input_curve_only_high_mixup_ori_profile.json",
+    "source_artifacts": [
+      "artifacts/issue124_curve_only_high_mixup_ori_acutance_benchmark.json",
+      "artifacts/issue124_curve_only_high_mixup_ori_psd_benchmark.json",
+      "artifacts/issue120_current_best_readme_gate_summary.json",
+      "artifacts/intrinsic_after_issue120_next_slice_benchmark.json"
+    ]
+  },
+  "comparisons": {
+    "candidate_vs_pr119": {
+      "delta": {
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.0,
+          "Computer Monitor Acutance": 0.0,
+          "Large Print Acutance": 0.0,
+          "Small Print Acutance": 0.0,
+          "UHDTV Display Acutance": 0.0
+        },
+        "curve_mae_mean": -0.00855028752808036,
+        "focus_preset_acutance_mae_mean": 0.0,
+        "mtf_abs_signed_rel_mean": 0.0,
+        "mtf_threshold_mae": {
+          "mtf20": 0.0,
+          "mtf30": 0.0,
+          "mtf50": 0.0
+        },
+        "overall_quality_loss_mae_mean": 0.0
+      }
+    },
+    "candidate_vs_pr30": {
+      "delta": {
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.021454129834507486,
+          "Computer Monitor Acutance": -0.02851887581626197,
+          "Large Print Acutance": -0.022701561546618957,
+          "Small Print Acutance": -0.01497585610580384,
+          "UHDTV Display Acutance": -0.023089360415706
+        },
+        "curve_mae_mean": -0.012537513625269225,
+        "focus_preset_acutance_mae_mean": -0.013566304809976663,
+        "mtf_abs_signed_rel_mean": 0.0,
+        "mtf_threshold_mae": {
+          "mtf20": 0.0,
+          "mtf30": 0.0,
+          "mtf50": 0.0
+        },
+        "overall_quality_loss_mae_mean": -0.01713926776831376
+      }
+    }
+  },
+  "curve_tail_result": {
+    "by_mixup_after": {
+      "0.15": 0.029378599163150443,
+      "0.25": 0.02479729017929424,
+      "0.4": 0.019363342842858032,
+      "0.65": 0.011953815251775047,
+      "0.8": 0.0188398331534736,
+      "ori": 0.045803234428031414
+    },
+    "by_mixup_before": {
+      "0.15": 0.029378599163150443,
+      "0.25": 0.02479729017929424,
+      "0.4": 0.019363342842858032,
+      "0.65": 0.011953815251775047,
+      "0.8": 0.04482380483621107,
+      "ori": 0.07933816634336006
+    },
+    "by_mixup_delta": {
+      "0.15": 0.0,
+      "0.25": 0.0,
+      "0.4": 0.0,
+      "0.65": 0.0,
+      "0.8": -0.02598397168273747,
+      "ori": -0.03353493191532865
+    },
+    "high_mixup_weighted_curve_mae_after": 0.008348290073497862,
+    "selected_mixups": [
+      "0.8",
+      "ori"
+    ],
+    "weighted_curve_mae_after": 0.02425151803573591,
+    "weighted_curve_mae_matches_candidate": true
+  },
+  "issue": 124,
+  "next_result": {
+    "recommended_follow_up": "Do not broaden this issue into Small Print preset work. If PM splits another engineering pass, target the remaining curve residual now visible in `ori`, `0.15`, and `0.25`, while preserving the issue #124 curve-only isolation.",
+    "remaining_misses": [
+      "curve_mae_mean",
+      "non_phone_acutance_preset_mae_max"
+    ],
+    "summary": "The high-mixup/ori curve-only anchor is a positive partial result: it materially lowers curve MAE while preserving reported-MTF, preset Acutance, and Quality Loss, but the README curve gate still misses."
+  },
+  "readme_gate_summary": {
+    "all_readme_gates_pass": false,
+    "failed_gates": [
+      "curve_mae_mean",
+      "non_phone_acutance_preset_mae_max"
+    ],
+    "gates": {
+      "5.5\" Phone Display Acutance": {
+        "delta_to_gate": -0.014743622260204217,
+        "operator": "<=",
+        "pass": true,
+        "threshold": 0.05,
+        "value": 0.035256377739795786
+      },
+      "curve_mae_mean": {
+        "delta_to_gate": 0.0042515180357359066,
+        "operator": "<=",
+        "pass": false,
+        "threshold": 0.02,
+        "value": 0.024251518035735907
+      },
+      "focus_preset_acutance_mae_mean": {
+        "delta_to_gate": -0.0010794735912748668,
+        "operator": "<=",
+        "pass": true,
+        "threshold": 0.03,
+        "value": 0.028920526408725132
+      },
+      "non_phone_acutance_preset_mae_max": {
+        "by_preset": {
+          "Computer Monitor Acutance": 0.024146307932311834,
+          "Large Print Acutance": 0.028624302638652583,
+          "Small Print Acutance": 0.031726251556383624,
+          "UHDTV Display Acutance": 0.024849392176481848
+        },
+        "delta_to_gate": 0.0017262515563836248,
+        "operator": "<=",
+        "pass": false,
+        "threshold": 0.03,
+        "value": 0.031726251556383624,
+        "worst_preset": "Small Print Acutance"
+      },
+      "overall_quality_loss_mae_mean": {
+        "delta_to_gate": -0.09564031333060252,
+        "operator": "<=",
+        "pass": true,
+        "threshold": 1.3,
+        "value": 1.2043596866693975
+      }
+    }
+  },
+  "refs": {
+    "baseline_pr": 30,
+    "current_best_issue": 118,
+    "current_best_pr": 119,
+    "current_issue": 124,
+    "umbrella_issue": 29
+  },
+  "release_separation": {
+    "candidate_is_release_config": false,
+    "golden_reference_roots": [
+      "20260318_deadleaf_13b10",
+      "release/deadleaf_13b10_release/data/20260318_deadleaf_13b10",
+      "release/deadleaf_13b10_release/config"
+    ],
+    "rules": [
+      "The candidate profile is canonical-target research only.",
+      "No fitted outputs are written under golden/reference data roots.",
+      "No release-facing config is promoted in this issue."
+    ]
+  },
+  "result_kind": "positive_partial_not_promotable",
+  "summary_kind": "issue124_curve_only_high_mixup_ori_summary"
+}

--- a/docs/issue124_curve_only_high_mixup_ori_summary.md
+++ b/docs/issue124_curve_only_high_mixup_ori_summary.md
@@ -1,0 +1,46 @@
+# Issue 124 Curve-Only High-Mixup/Ori Summary
+
+- Result: `positive_partial_not_promotable`.
+- Candidate profile: `algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_computer_monitor_small_print_large_print_pr30_input_curve_only_high_mixup_ori_profile.json`
+- Scoped boundary: only the main Acutance curve is anchored for mixups `0.8` and `ori`; preset Acutance, Quality Loss, and reported-MTF/readout paths stay unchanged.
+
+## Metrics
+
+| Metric | PR #119 | Issue #124 | Delta | Gate |
+| --- | ---: | ---: | ---: | --- |
+| curve_mae_mean | 0.03280 | 0.02425 | -0.00855 | <= 0.020 (miss) |
+| focus_preset_acutance_mae_mean | 0.02892 | 0.02892 | 0.00000 | <= 0.030 (pass) |
+| overall_quality_loss_mae_mean | 1.20436 | 1.20436 | 0.00000 | <= 1.30 (pass) |
+| mtf_abs_signed_rel_mean | 0.08671 | 0.08671 | 0.00000 | preserve |
+| Small Print Acutance | 0.03173 | 0.03173 | 0.00000 | <= 0.030 (miss) |
+
+## Curve Tail
+
+| Mixup | Before | After | Delta |
+| --- | ---: | ---: | ---: |
+| 0.15 | 0.02938 | 0.02938 | 0.00000 |
+| 0.25 | 0.02480 | 0.02480 | 0.00000 |
+| 0.4 | 0.01936 | 0.01936 | 0.00000 |
+| 0.65 | 0.01195 | 0.01195 | 0.00000 |
+| 0.8 | 0.04482 | 0.01884 | -0.02598 |
+| ori | 0.07934 | 0.04580 | -0.03353 |
+
+The selected high-mixup/ori intervention reduces `0.8` and `ori` curve error, but the remaining README curve miss is now spread across `ori`, `0.15`, and `0.25` rather than being solved by this slice alone.
+
+## Acceptance
+
+- Curve MAE reduced versus PR #119: `True`.
+- Reported-MTF preserved: `True`.
+- Overall Quality Loss preserved: `True`.
+- Small Print Acutance preserved: `True`.
+- All README gates pass: `False`.
+
+## Next Result
+
+The high-mixup/ori curve-only anchor is a positive partial result: it materially lowers curve MAE while preserving reported-MTF, preset Acutance, and Quality Loss, but the README curve gate still misses.
+
+Do not broaden this issue into Small Print preset work. If PM splits another engineering pass, target the remaining curve residual now visible in `ori`, `0.15`, and `0.25`, while preserving the issue #124 curve-only isolation.
+
+## Release Separation
+
+This remains canonical-target research, not a release-facing config promotion. No fitted outputs are written under golden/reference data roots or release configs.

--- a/tests/test_build_issue124_curve_only_high_mixup_ori_summary.py
+++ b/tests/test_build_issue124_curve_only_high_mixup_ori_summary.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from algo.build_issue124_curve_only_high_mixup_ori_summary import (
+    RESULT_KIND,
+    build_payload,
+    render_markdown,
+)
+
+
+class BuildIssue124CurveOnlyHighMixupOriSummaryTest(unittest.TestCase):
+    def test_payload_records_positive_partial_and_preservation(self) -> None:
+        payload = build_payload(
+            self.repo_root(),
+            issue120_summary_path=Path("artifacts/issue120_current_best_readme_gate_summary.json"),
+            issue122_summary_path=Path(
+                "artifacts/intrinsic_after_issue120_next_slice_benchmark.json"
+            ),
+            candidate_acutance_path=Path(
+                "artifacts/issue124_curve_only_high_mixup_ori_acutance_benchmark.json"
+            ),
+            candidate_psd_path=Path(
+                "artifacts/issue124_curve_only_high_mixup_ori_psd_benchmark.json"
+            ),
+        )
+
+        self.assertEqual(payload["issue"], 124)
+        self.assertEqual(payload["result_kind"], RESULT_KIND)
+        self.assertEqual(
+            payload["candidate"]["curve_only_acutance_anchor_mixups"],
+            ["0.8", "ori"],
+        )
+
+        delta = payload["comparisons"]["candidate_vs_pr119"]["delta"]
+        self.assertLess(delta["curve_mae_mean"], -0.008)
+        self.assertEqual(delta["mtf_abs_signed_rel_mean"], 0.0)
+        self.assertEqual(delta["mtf_threshold_mae"]["mtf20"], 0.0)
+        self.assertEqual(delta["mtf_threshold_mae"]["mtf30"], 0.0)
+        self.assertEqual(delta["mtf_threshold_mae"]["mtf50"], 0.0)
+        self.assertEqual(delta["overall_quality_loss_mae_mean"], 0.0)
+        self.assertEqual(delta["acutance_preset_mae"]["Small Print Acutance"], 0.0)
+
+        gates = payload["readme_gate_summary"]["gates"]
+        self.assertFalse(gates["curve_mae_mean"]["pass"])
+        self.assertTrue(gates["focus_preset_acutance_mae_mean"]["pass"])
+        self.assertTrue(gates["overall_quality_loss_mae_mean"]["pass"])
+        self.assertFalse(gates["non_phone_acutance_preset_mae_max"]["pass"])
+
+        curve_tail = payload["curve_tail_result"]
+        self.assertLess(curve_tail["by_mixup_delta"]["0.8"], -0.025)
+        self.assertLess(curve_tail["by_mixup_delta"]["ori"], -0.033)
+        self.assertEqual(curve_tail["by_mixup_delta"]["0.15"], 0.0)
+        self.assertEqual(curve_tail["by_mixup_delta"]["0.25"], 0.0)
+        self.assertTrue(curve_tail["weighted_curve_mae_matches_candidate"])
+
+        self.assertTrue(payload["acceptance"]["curve_mae_reduced_vs_pr119"])
+        self.assertTrue(payload["acceptance"]["reported_mtf_preserved"])
+        self.assertTrue(payload["acceptance"]["overall_quality_loss_preserved"])
+        self.assertFalse(payload["acceptance"]["all_readme_gates_pass"])
+
+        self.assertFalse(payload["release_separation"]["candidate_is_release_config"])
+        for path in payload["candidate"]["source_artifacts"]:
+            self.assertFalse(path.startswith("release/deadleaf_13b10_release"))
+
+    def test_markdown_mentions_partial_result_and_remaining_misses(self) -> None:
+        payload = build_payload(
+            self.repo_root(),
+            issue120_summary_path=Path("artifacts/issue120_current_best_readme_gate_summary.json"),
+            issue122_summary_path=Path(
+                "artifacts/intrinsic_after_issue120_next_slice_benchmark.json"
+            ),
+            candidate_acutance_path=Path(
+                "artifacts/issue124_curve_only_high_mixup_ori_acutance_benchmark.json"
+            ),
+            candidate_psd_path=Path(
+                "artifacts/issue124_curve_only_high_mixup_ori_psd_benchmark.json"
+            ),
+        )
+        markdown = render_markdown(payload)
+
+        self.assertIn("# Issue 124 Curve-Only High-Mixup/Ori Summary", markdown)
+        self.assertIn("positive_partial_not_promotable", markdown)
+        self.assertIn("curve_mae_mean", markdown)
+        self.assertIn("0.8", markdown)
+        self.assertIn("ori", markdown)
+        self.assertIn("Small Print Acutance", markdown)
+        self.assertIn("Release Separation", markdown)
+
+    @staticmethod
+    def repo_root() -> Path:
+        return Path(__file__).resolve().parents[1]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Refs #124
Refs #29
Refs #118
Refs #120
Refs #122
Context from #123

- Adds a curve-only Acutance anchor boundary that applies the existing matched-ori Acutance curve correction only to mixups `0.8` and `ori`.
- Keeps preset Acutance, Quality Loss, reported-MTF/readout, Quality Loss input overrides, and release-facing configs unchanged.
- Adds the issue #124 candidate profile, regenerated PSD/MTF and Acutance/Quality Loss artifacts, and a generated summary note/artifact.
- Records the result as `positive_partial_not_promotable`: curve MAE improves from `0.03280` to `0.02425`, but the README curve gate `<= 0.020` still misses.

## Result

- `curve_mae_mean`: `0.03280181 -> 0.02425152` (`-0.00855029`)
- `0.8` curve MAE: `0.04482380 -> 0.01883983`
- `ori` curve MAE: `0.07933817 -> 0.04580323`
- Reported-MTF preserved: `mtf_abs_signed_rel_mean`, `mtf20`, `mtf30`, and `mtf50` deltas are all `0.0`
- Focus-preset Acutance mean preserved at `0.02892053`
- Overall Quality Loss preserved at `1.20435969`
- Small Print Acutance preserved at `0.03172625`

Remaining README misses:

- `curve_mae_mean <= 0.020`
- non-Phone Acutance preset max, still `Small Print Acutance <= 0.030`

## Validation

- `python3 -m py_compile algo/benchmark_parity_acutance_quality_loss.py algo/benchmark_parity_psd_mtf.py algo/build_issue124_curve_only_high_mixup_ori_summary.py`
- `python3 -m pytest tests/test_build_issue124_curve_only_high_mixup_ori_summary.py tests/test_build_intrinsic_after_issue120_next_slice.py tests/test_build_issue120_current_best_gate_summary.py -q`
- `python3 -m algo.benchmark_parity_acutance_quality_loss 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_computer_monitor_small_print_large_print_pr30_input_curve_only_high_mixup_ori_profile.json --output artifacts/issue124_curve_only_high_mixup_ori_acutance_benchmark.json`
- `python3 -m algo.benchmark_parity_psd_mtf 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_computer_monitor_small_print_large_print_pr30_input_curve_only_high_mixup_ori_profile.json --output artifacts/issue124_curve_only_high_mixup_ori_psd_benchmark.json`
- `python3 -m algo.build_issue124_curve_only_high_mixup_ori_summary --output-json /tmp/issue124_summary_check.json --output-md /tmp/issue124_summary_check.md` plus byte comparison
- `git diff --check`
