### PR TITLE
Issue #128: test ori/0.15 curve boundary

### DIFF
--- a/algo/build_issue128_ori_015_curve_shape_summary.py
+++ b/algo/build_issue128_ori_015_curve_shape_summary.py
@@ -1,0 +1,437 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+ISSUE = 128
+UMBRELLA_ISSUE = 29
+CURRENT_BEST_ISSUE = 124
+CURRENT_BEST_PR = 125
+DISCOVERY_ISSUE = 126
+DISCOVERY_PR = 127
+BASELINE_PR = 30
+SUMMARY_KIND = "issue128_ori_015_curve_shape_summary"
+RESULT_KIND = "bounded_negative_not_promotable"
+TARGET_MIXUPS = ("ori", "0.15")
+DEFERRED_MIXUPS = ("0.25",)
+CURVE_GATE = 0.020
+FOCUS_PRESET_GATE = 0.030
+QUALITY_LOSS_GATE = 1.30
+NON_PHONE_ACUTANCE_GATE = 0.030
+PHONE_PRESET = '5.5" Phone Display Acutance'
+SMALL_PRINT_PRESET = "Small Print Acutance"
+GOLDEN_REFERENCE_ROOTS = (
+    "20260318_deadleaf_13b10",
+    "release/deadleaf_13b10_release/data/20260318_deadleaf_13b10",
+    "release/deadleaf_13b10_release/config",
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build issue-128 curve-shape summary.")
+    parser.add_argument("--repo-root", type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument(
+        "--issue124-summary",
+        type=Path,
+        default=Path("artifacts/issue124_curve_only_high_mixup_ori_summary.json"),
+    )
+    parser.add_argument(
+        "--issue126-discovery",
+        type=Path,
+        default=Path("artifacts/issue126_residual_curve_discovery.json"),
+    )
+    parser.add_argument(
+        "--candidate-acutance",
+        type=Path,
+        default=Path("artifacts/issue128_ori_015_curve_shape_acutance_benchmark.json"),
+    )
+    parser.add_argument(
+        "--candidate-psd",
+        type=Path,
+        default=Path("artifacts/issue128_ori_015_curve_shape_psd_benchmark.json"),
+    )
+    parser.add_argument(
+        "--output-json",
+        type=Path,
+        default=Path("artifacts/issue128_ori_015_curve_shape_summary.json"),
+    )
+    parser.add_argument(
+        "--output-md",
+        type=Path,
+        default=Path("docs/issue128_ori_015_curve_shape_summary.md"),
+    )
+    return parser
+
+
+def resolve_path(repo_root: Path, path: Path) -> Path:
+    return path if path.is_absolute() else repo_root / path
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def select_single_profile(payload: dict[str, Any]) -> dict[str, Any]:
+    profiles = payload["profiles"]
+    if len(profiles) != 1:
+        raise ValueError(f"Expected one profile, found {len(profiles)}")
+    return profiles[0]
+
+
+def gate(value: float, threshold: float) -> dict[str, Any]:
+    value = float(value)
+    return {
+        "value": value,
+        "threshold": threshold,
+        "operator": "<=",
+        "pass": value <= threshold,
+        "delta_to_gate": value - threshold,
+    }
+
+
+def readme_gate_summary(metrics: dict[str, Any]) -> dict[str, Any]:
+    non_phone = {
+        key: value for key, value in metrics["acutance_preset_mae"].items() if key != PHONE_PRESET
+    }
+    worst_preset, worst_value = max(non_phone.items(), key=lambda item: item[1])
+    gates = {
+        "curve_mae_mean": gate(metrics["curve_mae_mean"], CURVE_GATE),
+        "focus_preset_acutance_mae_mean": gate(
+            metrics["acutance_focus_preset_mae_mean"],
+            FOCUS_PRESET_GATE,
+        ),
+        "overall_quality_loss_mae_mean": gate(
+            metrics["overall_quality_loss_mae_mean"],
+            QUALITY_LOSS_GATE,
+        ),
+        "non_phone_acutance_preset_mae_max": {
+            **gate(worst_value, NON_PHONE_ACUTANCE_GATE),
+            "worst_preset": worst_preset,
+            "by_preset": {key: float(value) for key, value in sorted(non_phone.items())},
+        },
+        PHONE_PRESET: gate(metrics["acutance_preset_mae"][PHONE_PRESET], 0.050),
+    }
+    return {
+        "all_readme_gates_pass": all(row["pass"] for row in gates.values()),
+        "failed_gates": [key for key, row in gates.items() if not row["pass"]],
+        "gates": gates,
+    }
+
+
+def collect_candidate_metrics(
+    *,
+    candidate_acutance: dict[str, Any],
+    candidate_psd: dict[str, Any],
+) -> dict[str, Any]:
+    acutance = candidate_acutance["overall"]
+    psd = candidate_psd["overall"]
+    return {
+        "curve_mae_mean": float(acutance["curve_mae_mean"]),
+        "acutance_focus_preset_mae_mean": float(acutance["acutance_focus_preset_mae_mean"]),
+        "overall_quality_loss_mae_mean": float(acutance["overall_quality_loss_mae_mean"]),
+        "mtf_abs_signed_rel_mean": float(psd["mtf_abs_signed_rel_mean"]),
+        "mtf_threshold_mae": {
+            key: float(value) for key, value in psd["mtf_threshold_mae"].items()
+        },
+        "acutance_preset_mae": {
+            key: float(value) for key, value in acutance["acutance_preset_mae"].items()
+        },
+        "quality_loss_preset_mae": {
+            key: float(value) for key, value in acutance["quality_loss_preset_mae"].items()
+        },
+    }
+
+
+def metric_delta(candidate: dict[str, Any], baseline: dict[str, Any]) -> dict[str, Any]:
+    baseline_focus_key = (
+        "acutance_focus_preset_mae_mean"
+        if "acutance_focus_preset_mae_mean" in baseline
+        else "focus_preset_acutance_mae_mean"
+    )
+    return {
+        "curve_mae_mean": float(candidate["curve_mae_mean"] - baseline["curve_mae_mean"]),
+        "focus_preset_acutance_mae_mean": float(
+            candidate["acutance_focus_preset_mae_mean"]
+            - baseline[baseline_focus_key]
+        ),
+        "overall_quality_loss_mae_mean": float(
+            candidate["overall_quality_loss_mae_mean"]
+            - baseline["overall_quality_loss_mae_mean"]
+        ),
+        "mtf_abs_signed_rel_mean": float(
+            candidate["mtf_abs_signed_rel_mean"] - baseline["mtf_abs_signed_rel_mean"]
+        ),
+        "mtf_threshold_mae": {
+            key: float(candidate["mtf_threshold_mae"][key] - baseline["mtf_threshold_mae"][key])
+            for key in candidate["mtf_threshold_mae"]
+        },
+        "acutance_preset_mae": {
+            key: float(
+                candidate["acutance_preset_mae"][key] - baseline["acutance_preset_mae"][key]
+            )
+            for key in candidate["acutance_preset_mae"]
+        },
+    }
+
+
+def is_close(left: float, right: float, *, tolerance: float = 1e-12) -> bool:
+    return abs(float(left) - float(right)) <= tolerance
+
+
+def is_release_path(path: str) -> bool:
+    return path.startswith(GOLDEN_REFERENCE_ROOTS)
+
+
+def build_payload(
+    repo_root: Path,
+    *,
+    issue124_summary_path: Path,
+    issue126_discovery_path: Path,
+    candidate_acutance_path: Path,
+    candidate_psd_path: Path,
+) -> dict[str, Any]:
+    issue124 = load_json(resolve_path(repo_root, issue124_summary_path))
+    issue126 = load_json(resolve_path(repo_root, issue126_discovery_path))
+    candidate_acutance = select_single_profile(
+        load_json(resolve_path(repo_root, candidate_acutance_path))
+    )
+    candidate_psd = select_single_profile(load_json(resolve_path(repo_root, candidate_psd_path)))
+    baseline = issue124["candidate"]["metrics"]
+    pr30 = issue124["baseline_pr30"]["metrics"]
+    candidate = collect_candidate_metrics(
+        candidate_acutance=candidate_acutance,
+        candidate_psd=candidate_psd,
+    )
+    delta_vs_pr125 = metric_delta(candidate, baseline)
+    delta_vs_pr30 = metric_delta(candidate, pr30)
+    by_mixup_baseline = issue124["curve_tail_result"]["by_mixup_after"]
+    by_mixup_candidate = candidate_acutance["by_mixup_curve_mae_mean"]
+    by_mixup_delta = {
+        key: float(by_mixup_candidate[key] - by_mixup_baseline[key])
+        for key in by_mixup_candidate
+    }
+    payload = {
+        "issue": ISSUE,
+        "summary_kind": SUMMARY_KIND,
+        "result_kind": RESULT_KIND,
+        "candidate": {
+            "label": "issue128_ori_015_curve_shape_candidate",
+            "profile_path": candidate_acutance["profile_path"],
+            "curve_only_acutance_anchor_mixups": list(
+                candidate_acutance["analysis_pipeline"]["curve_only_acutance_anchor_mixups"]
+            ),
+            "target_mixups": list(TARGET_MIXUPS),
+            "deferred_mixups": list(DEFERRED_MIXUPS),
+            "source_artifacts": [
+                str(candidate_acutance_path),
+                str(candidate_psd_path),
+                str(issue124_summary_path),
+                str(issue126_discovery_path),
+            ],
+            "metrics": candidate,
+        },
+        "baseline_pr125": {
+            "issue": CURRENT_BEST_ISSUE,
+            "pr": CURRENT_BEST_PR,
+            "profile_path": issue124["candidate"]["profile_path"],
+            "metrics": baseline,
+        },
+        "baseline_pr30": issue124["baseline_pr30"],
+        "readme_gate_summary": readme_gate_summary(candidate),
+        "comparisons": {
+            "candidate_vs_pr125": {"delta": delta_vs_pr125},
+            "candidate_vs_pr30": {"delta": delta_vs_pr30},
+        },
+        "curve_shape_result": {
+            "selected_slice_id": issue126["selected_next_slice"]["slice_id"],
+            "candidate_boundary": (
+                "Adds `0.15` to the existing issue #124 curve-only Acutance anchor mask; "
+                "`0.25` and preset Acutance remain untouched."
+            ),
+            "by_mixup_baseline": {
+                key: float(value) for key, value in sorted(by_mixup_baseline.items())
+            },
+            "by_mixup_candidate": {
+                key: float(value) for key, value in sorted(by_mixup_candidate.items())
+            },
+            "by_mixup_delta": {key: float(value) for key, value in sorted(by_mixup_delta.items())},
+            "target_mixups": list(TARGET_MIXUPS),
+            "deferred_mixups": list(DEFERRED_MIXUPS),
+        },
+        "acceptance": {
+            "curve_gate_pass": candidate["curve_mae_mean"] <= CURVE_GATE,
+            "curve_improved_vs_pr125": delta_vs_pr125["curve_mae_mean"] < 0.0,
+            "reported_mtf_preserved": (
+                is_close(delta_vs_pr125["mtf_abs_signed_rel_mean"], 0.0)
+                and all(
+                    is_close(value, 0.0)
+                    for value in delta_vs_pr125["mtf_threshold_mae"].values()
+                )
+            ),
+            "focus_preset_acutance_preserved": is_close(
+                delta_vs_pr125["focus_preset_acutance_mae_mean"],
+                0.0,
+            ),
+            "overall_quality_loss_preserved": is_close(
+                delta_vs_pr125["overall_quality_loss_mae_mean"],
+                0.0,
+            ),
+            "small_print_acutance_preserved": is_close(
+                delta_vs_pr125["acutance_preset_mae"][SMALL_PRINT_PRESET],
+                0.0,
+            ),
+            "release_separation_preserved": True,
+        },
+        "next_result": {
+            "summary": (
+                "The bounded ori/0.15 curve-shape candidate is not promotable: it preserves "
+                "reported-MTF, preset Acutance, overall Quality Loss, and release separation, "
+                "but worsens the aggregate curve MAE because the current matched-ori curve "
+                "shape moves `0.15` in the wrong direction."
+            ),
+            "recommended_follow_up": (
+                "Do not continue broadening the issue #124 curve-only anchor mask. If PM "
+                "splits another curve follow-up, it should require a per-mixup or shape-family "
+                "variant that proves `0.15` improves before committing to a full benchmark; "
+                "otherwise split the deferred Small Print Acutance preset-only miss."
+            ),
+        },
+        "release_separation": {
+            "candidate_is_release_config": False,
+            "golden_reference_roots": list(GOLDEN_REFERENCE_ROOTS),
+            "rules": [
+                "The candidate profile is canonical-target research only.",
+                "No fitted outputs are written under golden/reference data roots.",
+                "No release-facing config is promoted in this issue.",
+            ],
+        },
+        "refs": {
+            "umbrella_issue": UMBRELLA_ISSUE,
+            "current_issue": ISSUE,
+            "current_best_issue": CURRENT_BEST_ISSUE,
+            "current_best_pr": CURRENT_BEST_PR,
+            "discovery_issue": DISCOVERY_ISSUE,
+            "discovery_pr": DISCOVERY_PR,
+            "baseline_pr": BASELINE_PR,
+        },
+    }
+    assert_storage_separation(payload)
+    return payload
+
+
+def assert_storage_separation(payload: dict[str, Any]) -> None:
+    paths = [
+        payload["candidate"]["profile_path"],
+        *payload["candidate"]["source_artifacts"],
+    ]
+    for path in paths:
+        if is_release_path(path):
+            raise ValueError(f"candidate path entered golden/release root: {path}")
+
+
+def format_metric(value: float) -> str:
+    return f"{float(value):.5f}"
+
+
+def render_markdown(payload: dict[str, Any]) -> str:
+    candidate = payload["candidate"]
+    metrics = candidate["metrics"]
+    pr125 = payload["baseline_pr125"]["metrics"]
+    delta = payload["comparisons"]["candidate_vs_pr125"]["delta"]
+    gates = payload["readme_gate_summary"]["gates"]
+    curve = payload["curve_shape_result"]
+    return "\n".join(
+        [
+            "# Issue 128 Ori/0.15 Curve-Shape Summary",
+            "",
+            f"- Result: `{payload['result_kind']}`.",
+            f"- Candidate profile: `{candidate['profile_path']}`",
+            "- Scoped boundary: add `0.15` to the existing issue #124 curve-only Acutance "
+            "anchor mask; keep `0.25`, preset Acutance, Quality Loss, and reported-MTF/readout untouched.",
+            "",
+            "## Metrics",
+            "",
+            "| Metric | PR #125 | Issue #128 | Delta | Gate |",
+            "| --- | ---: | ---: | ---: | --- |",
+            f"| curve_mae_mean | {format_metric(pr125['curve_mae_mean'])} | "
+            f"{format_metric(metrics['curve_mae_mean'])} | "
+            f"{format_metric(delta['curve_mae_mean'])} | "
+            f"<= 0.020 ({'pass' if gates['curve_mae_mean']['pass'] else 'miss'}) |",
+            f"| focus_preset_acutance_mae_mean | "
+            f"{format_metric(pr125['acutance_focus_preset_mae_mean'])} | "
+            f"{format_metric(metrics['acutance_focus_preset_mae_mean'])} | "
+            f"{format_metric(delta['focus_preset_acutance_mae_mean'])} | preserve |",
+            f"| overall_quality_loss_mae_mean | "
+            f"{format_metric(pr125['overall_quality_loss_mae_mean'])} | "
+            f"{format_metric(metrics['overall_quality_loss_mae_mean'])} | "
+            f"{format_metric(delta['overall_quality_loss_mae_mean'])} | preserve |",
+            f"| mtf_abs_signed_rel_mean | {format_metric(pr125['mtf_abs_signed_rel_mean'])} | "
+            f"{format_metric(metrics['mtf_abs_signed_rel_mean'])} | "
+            f"{format_metric(delta['mtf_abs_signed_rel_mean'])} | preserve |",
+            f"| Small Print Acutance | "
+            f"{format_metric(pr125['acutance_preset_mae'][SMALL_PRINT_PRESET])} | "
+            f"{format_metric(metrics['acutance_preset_mae'][SMALL_PRINT_PRESET])} | "
+            f"{format_metric(delta['acutance_preset_mae'][SMALL_PRINT_PRESET])} | "
+            f"<= 0.030 ({'pass' if gates['non_phone_acutance_preset_mae_max']['pass'] else 'miss'}) |",
+            "",
+            "## Curve Shape Result",
+            "",
+            "| Mixup | PR #125 | Issue #128 | Delta |",
+            "| --- | ---: | ---: | ---: |",
+            *[
+                f"| {key} | {format_metric(curve['by_mixup_baseline'][key])} | "
+                f"{format_metric(curve['by_mixup_candidate'][key])} | "
+                f"{format_metric(curve['by_mixup_delta'][key])} |"
+                for key in sorted(curve["by_mixup_candidate"])
+            ],
+            "",
+            "The `ori` and `0.8` curve values stay at their issue #124 values, but `0.15` "
+            "worsens from `0.02938` to `0.03546`. The aggregate curve MAE therefore "
+            "moves away from the README gate.",
+            "",
+            "## Acceptance",
+            "",
+            f"- Curve gate pass: `{payload['acceptance']['curve_gate_pass']}`.",
+            f"- Curve improved versus PR #125: `{payload['acceptance']['curve_improved_vs_pr125']}`.",
+            f"- Reported-MTF preserved: `{payload['acceptance']['reported_mtf_preserved']}`.",
+            f"- Focus-preset Acutance preserved: `{payload['acceptance']['focus_preset_acutance_preserved']}`.",
+            f"- Overall Quality Loss preserved: `{payload['acceptance']['overall_quality_loss_preserved']}`.",
+            f"- Small Print Acutance preserved: `{payload['acceptance']['small_print_acutance_preserved']}`.",
+            "",
+            "## Next Result",
+            "",
+            payload["next_result"]["summary"],
+            "",
+            payload["next_result"]["recommended_follow_up"],
+            "",
+            "## Release Separation",
+            "",
+            "This remains canonical-target research, not a release-facing config promotion. "
+            "No fitted outputs are written under golden/reference data roots or release configs.",
+        ]
+    )
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    repo_root = args.repo_root
+    payload = build_payload(
+        repo_root,
+        issue124_summary_path=args.issue124_summary,
+        issue126_discovery_path=args.issue126_discovery,
+        candidate_acutance_path=args.candidate_acutance,
+        candidate_psd_path=args.candidate_psd,
+    )
+    output_json = resolve_path(repo_root, args.output_json)
+    output_md = resolve_path(repo_root, args.output_md)
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    output_md.parent.mkdir(parents=True, exist_ok=True)
+    output_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    output_md.write_text(render_markdown(payload) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_computer_monitor_small_print_large_print_pr30_input_curve_only_ori_015_profile.json
+++ b/algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_computer_monitor_small_print_large_print_pr30_input_curve_only_ori_015_profile.json
@@ -1,0 +1,194 @@
+{
+  "acutance_band_hi": 0.035,
+  "acutance_band_lo": 0.017,
+  "acutance_band_mode": "mean",
+  "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+  "curve_only_acutance_anchor_mixups": [
+    "0.15",
+    "0.8",
+    "ori"
+  ],
+  "frequency_scale": 1.0,
+  "gamma": 0.5,
+  "high_frequency_guard_start_cpp": 0.36,
+  "intrinsic_full_reference_clip_hi": 1.5,
+  "intrinsic_full_reference_clip_lo": 0.5,
+  "intrinsic_full_reference_mode": "paired_ori_transfer",
+  "intrinsic_full_reference_registration_mode": "phase_correlation",
+  "intrinsic_full_reference_scope": "reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only",
+  "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+  "linearization_mode": "toe_power",
+  "linearization_toe": 0.12,
+  "matched_ori_acutance_correction_clip_hi": 1.1,
+  "matched_ori_acutance_correction_clip_lo": 0.9,
+  "matched_ori_acutance_correction_delta_power": 1.0,
+  "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+  "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+    0.0,
+    0.25,
+    0.6,
+    0.8,
+    1.6,
+    2.5
+  ],
+  "matched_ori_acutance_curve_correction_clip_hi_values": [
+    1.02,
+    1.03,
+    0.895,
+    0.895,
+    1.05,
+    1.06
+  ],
+  "matched_ori_acutance_curve_correction_delta_power": 0.95,
+  "matched_ori_acutance_preset_correction_delta_power": null,
+  "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+    0.0,
+    4.5,
+    5.8,
+    6.2
+  ],
+  "matched_ori_acutance_preset_correction_delta_power_values": [
+    1.05,
+    1.05,
+    1.85,
+    1.85
+  ],
+  "matched_ori_acutance_preset_strength_curve_relative_scales": [
+    0.0,
+    3.0,
+    4.5,
+    5.8,
+    6.2
+  ],
+  "matched_ori_acutance_preset_strength_curve_values": [
+    1.0,
+    1.0,
+    0.85,
+    0.45,
+    0.45
+  ],
+  "matched_ori_acutance_reference_anchor": true,
+  "matched_ori_acutance_strength_curve_relative_scales": [
+    0.0,
+    0.2,
+    0.8,
+    1.6,
+    2.5
+  ],
+  "matched_ori_acutance_strength_curve_values": [
+    0.7,
+    0.69,
+    0.64,
+    0.62,
+    0.6
+  ],
+  "matched_ori_anchor_mode": "all",
+  "matched_ori_correction_clip_hi": 2.0,
+  "matched_ori_correction_clip_lo": 0.5,
+  "matched_ori_reference_anchor": true,
+  "matched_ori_strength_curve_frequencies": [
+    0.0,
+    0.12,
+    0.22,
+    0.35,
+    0.5
+  ],
+  "matched_ori_strength_curve_values": [
+    1.0,
+    1.0,
+    0.82,
+    0.95,
+    1.0
+  ],
+  "mtf_compensation_mode": "sensor_aperture_sinc",
+  "name": "deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_computer_monitor_small_print_large_print_pr30_input_curve_only_ori_015_profile",
+  "noise_psd_model": "empirical",
+  "noise_psd_scale": 1.0,
+  "normalization_band_hi": 0.03,
+  "normalization_band_lo": 0.01,
+  "normalization_mode": "max",
+  "quality_loss_coefficients": [
+    37.240228358776136,
+    26.54550669779819,
+    0.4538662637619741
+  ],
+  "quality_loss_om_ceiling": 0.8851,
+  "quality_loss_preset_input_profile_overrides": {
+    "Computer Monitor Quality Loss": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json",
+    "Large Print Quality Loss": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json",
+    "Small Print Quality Loss": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json"
+  },
+  "quality_loss_preset_overrides": {
+    "5.5\" Phone Display Quality Loss": {
+      "coefficients": [
+        -110912321.41149135,
+        50461107.51563171,
+        -9079490.127807735,
+        815148.8697247265,
+        -37712.984407641874,
+        854.6941149036079,
+        -6.261149027919645
+      ],
+      "om_ceiling": 0.8851
+    },
+    "Computer Monitor Quality Loss": {
+      "coefficients": [
+        5677361.198044325,
+        -16715685.9524707,
+        20317567.326582585,
+        -13046703.33912079,
+        4667794.619228022,
+        -882296.9160375095,
+        68863.59709647154
+      ],
+      "om_ceiling": 0.8851
+    },
+    "Large Print Quality Loss": {
+      "coefficients": [
+        2355074.475971866,
+        -5276146.244338096,
+        4846781.143787682,
+        -2336594.295523967,
+        623766.4933095274,
+        -87476.30712136331,
+        5049.882965558553
+      ],
+      "om_ceiling": 0.8851
+    },
+    "Small Print Quality Loss": {
+      "coefficients": [
+        6690980.837239251,
+        -12955277.716404187,
+        10300283.291740375,
+        -4303759.200708971,
+        996904.2653558743,
+        -121409.71509269004,
+        6084.6471373306085
+      ],
+      "om_ceiling": 0.8851
+    },
+    "UHDTV Display Quality Loss": {
+      "coefficients": [
+        1783462.6221675149,
+        -3813432.5606394163,
+        3326218.4642961356,
+        -1514886.1959663907,
+        380334.163146246,
+        -49956.87092015135,
+        2692.9566508574017
+      ],
+      "om_ceiling": 0.8851
+    }
+  },
+  "roi_height": 1673,
+  "roi_refine_area_tolerance": 0.98,
+  "roi_refine_min_border_margin": 8,
+  "roi_refine_percentile": 45.0,
+  "roi_refine_search_radius": 4,
+  "roi_refine_sigma": 5.0,
+  "roi_refine_step": 2,
+  "roi_source": "reference_refined",
+  "roi_width": 1655,
+  "sensor_fill_factor": 1.5,
+  "texture_support_scale": true
+}

--- a/artifacts/issue128_ori_015_curve_shape_acutance_benchmark.json
+++ b/artifacts/issue128_ori_015_curve_shape_acutance_benchmark.json
@@ -1,0 +1,259 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "curve_only_acutance_anchor_mixups": [
+          "0.15",
+          "0.8",
+          "ori"
+        ],
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only",
+        "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_input_profile_overrides": {
+          "Computer Monitor Quality Loss": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json",
+          "Large Print Quality Loss": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json",
+          "Small Print Quality Loss": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json"
+        },
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "readout_interpolation": "linear",
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.03545614453309601,
+        "0.25": 0.02479729017929424,
+        "0.4": 0.019363342842858032,
+        "0.65": 0.011953815251775047,
+        "0.8": 0.0188398331534736,
+        "ori": 0.045803234428031414
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 1.1504751574647964,
+        "0.25": 1.2034864496306634,
+        "0.4": 1.1777404619388072,
+        "0.65": 0.49964929220560284,
+        "0.8": 1.0721427077120183,
+        "ori": 2.3362580209958006
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.028920526408725132,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.035256377739795786,
+          "Computer Monitor Acutance": 0.024146307932311834,
+          "Large Print Acutance": 0.028624302638652583,
+          "Small Print Acutance": 0.031726251556383624,
+          "UHDTV Display Acutance": 0.024849392176481848
+        },
+        "curve_mae_mean": 0.025467027109725017,
+        "overall_quality_loss_mae_mean": 1.2043596866693975,
+        "quality_loss_focus_preset_mae_mean": 1.2043596866693975,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 0.23804277891732473,
+          "Computer Monitor Quality Loss": 2.906111784076103,
+          "Large Print Quality Loss": 0.9547911309308169,
+          "Small Print Quality Loss": 0.6076983310559123,
+          "UHDTV Display Quality Loss": 1.3151544083668303
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_computer_monitor_small_print_large_print_pr30_input_curve_only_ori_015_profile.json"
+    }
+  ]
+}

--- a/artifacts/issue128_ori_015_curve_shape_psd_benchmark.json
+++ b/artifacts/issue128_ori_015_curve_shape_psd_benchmark.json
@@ -1,0 +1,203 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "curve_only_acutance_anchor_mixups": [
+          "0.15",
+          "0.8",
+          "ori"
+        ],
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only",
+        "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_preset_input_profile_overrides": {
+          "Computer Monitor Quality Loss": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json",
+          "Large Print Quality Loss": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json",
+          "Small Print Quality Loss": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json"
+        },
+        "readout_interpolation": "linear",
+        "readout_mtf_compensation_mode": "sensor_aperture_sinc",
+        "readout_sensor_fill_factor": 1.5,
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.029378599163150443,
+        "0.25": 0.02479729017929424,
+        "0.4": 0.019363342842858032,
+        "0.65": 0.011953815251775047,
+        "0.8": 0.04482380483621107,
+        "ori": 0.07933816634336006
+      },
+      "overall": {
+        "curve_mae_mean": 0.03280180556381627,
+        "mtf_abs_signed_rel_mean": 0.08671416893394165,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.01764835359892083,
+            "mre_mean": 0.088865357734797,
+            "signed_rel_mean": 0.04982888092128941
+          },
+          "low": {
+            "mae_mean": 0.03704553941403868,
+            "mre_mean": 0.046572470331734825,
+            "signed_rel_mean": 0.0237949421475065
+          },
+          "mid": {
+            "mae_mean": 0.03898616152003224,
+            "mre_mean": 0.12397538768693758,
+            "signed_rel_mean": 0.10965436746685472
+          },
+          "top": {
+            "mae_mean": 0.07374065223652229,
+            "mre_mean": 0.20171750026037474,
+            "signed_rel_mean": -0.16357848520011598
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.03301077142967389,
+          "mtf30": 0.03693639342667963,
+          "mtf50": 0.009332615436071163
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.035256377739795786,
+          "Computer Monitor Acutance": 0.024146307932311834,
+          "Large Print Acutance": 0.028624302638652583,
+          "Small Print Acutance": 0.031726251556383624,
+          "UHDTV Display Acutance": 0.024849392176481848
+        }
+      },
+      "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_computer_monitor_small_print_large_print_pr30_input_curve_only_ori_015_profile.json"
+    }
+  ]
+}

--- a/artifacts/issue128_ori_015_curve_shape_summary.json
+++ b/artifacts/issue128_ori_015_curve_shape_summary.json
@@ -1,0 +1,269 @@
+{
+  "acceptance": {
+    "curve_gate_pass": false,
+    "curve_improved_vs_pr125": false,
+    "focus_preset_acutance_preserved": true,
+    "overall_quality_loss_preserved": true,
+    "release_separation_preserved": true,
+    "reported_mtf_preserved": true,
+    "small_print_acutance_preserved": true
+  },
+  "baseline_pr125": {
+    "issue": 124,
+    "metrics": {
+      "acutance_focus_preset_mae_mean": 0.028920526408725132,
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": 0.035256377739795786,
+        "Computer Monitor Acutance": 0.024146307932311834,
+        "Large Print Acutance": 0.028624302638652583,
+        "Small Print Acutance": 0.031726251556383624,
+        "UHDTV Display Acutance": 0.024849392176481848
+      },
+      "curve_mae_mean": 0.024251518035735907,
+      "mtf_abs_signed_rel_mean": 0.08671416893394165,
+      "mtf_threshold_mae": {
+        "mtf20": 0.03301077142967389,
+        "mtf30": 0.03693639342667963,
+        "mtf50": 0.009332615436071163
+      },
+      "overall_quality_loss_mae_mean": 1.2043596866693975,
+      "quality_loss_preset_mae": {
+        "5.5\" Phone Display Quality Loss": 0.23804277891732473,
+        "Computer Monitor Quality Loss": 2.906111784076103,
+        "Large Print Quality Loss": 0.9547911309308169,
+        "Small Print Quality Loss": 0.6076983310559123,
+        "UHDTV Display Quality Loss": 1.3151544083668303
+      }
+    },
+    "pr": 125,
+    "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_computer_monitor_small_print_large_print_pr30_input_curve_only_high_mixup_ori_profile.json"
+  },
+  "baseline_pr30": {
+    "issue": 29,
+    "label": "current_best_pr30_branch",
+    "metrics": {
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": 0.013802247905288301,
+        "Computer Monitor Acutance": 0.052665183748573804,
+        "Large Print Acutance": 0.05132586418527154,
+        "Small Print Acutance": 0.046702107662187464,
+        "UHDTV Display Acutance": 0.04793875259218785
+      },
+      "curve_mae_mean": 0.03678903166100513,
+      "focus_preset_acutance_mae_mean": 0.042486831218701795,
+      "mtf_abs_signed_rel_mean": 0.08671416893394165,
+      "mtf_threshold_mae": {
+        "mtf20": 0.03301077142967389,
+        "mtf30": 0.03693639342667963,
+        "mtf50": 0.009332615436071163
+      },
+      "overall_quality_loss_mae_mean": 1.2214989544377113
+    },
+    "pr": 30,
+    "profile_path": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_anchored_hf_psd_profile.json"
+  },
+  "candidate": {
+    "curve_only_acutance_anchor_mixups": [
+      "0.15",
+      "0.8",
+      "ori"
+    ],
+    "deferred_mixups": [
+      "0.25"
+    ],
+    "label": "issue128_ori_015_curve_shape_candidate",
+    "metrics": {
+      "acutance_focus_preset_mae_mean": 0.028920526408725132,
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": 0.035256377739795786,
+        "Computer Monitor Acutance": 0.024146307932311834,
+        "Large Print Acutance": 0.028624302638652583,
+        "Small Print Acutance": 0.031726251556383624,
+        "UHDTV Display Acutance": 0.024849392176481848
+      },
+      "curve_mae_mean": 0.025467027109725017,
+      "mtf_abs_signed_rel_mean": 0.08671416893394165,
+      "mtf_threshold_mae": {
+        "mtf20": 0.03301077142967389,
+        "mtf30": 0.03693639342667963,
+        "mtf50": 0.009332615436071163
+      },
+      "overall_quality_loss_mae_mean": 1.2043596866693975,
+      "quality_loss_preset_mae": {
+        "5.5\" Phone Display Quality Loss": 0.23804277891732473,
+        "Computer Monitor Quality Loss": 2.906111784076103,
+        "Large Print Quality Loss": 0.9547911309308169,
+        "Small Print Quality Loss": 0.6076983310559123,
+        "UHDTV Display Quality Loss": 1.3151544083668303
+      }
+    },
+    "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_computer_monitor_small_print_large_print_pr30_input_curve_only_ori_015_profile.json",
+    "source_artifacts": [
+      "artifacts/issue128_ori_015_curve_shape_acutance_benchmark.json",
+      "artifacts/issue128_ori_015_curve_shape_psd_benchmark.json",
+      "artifacts/issue124_curve_only_high_mixup_ori_summary.json",
+      "artifacts/issue126_residual_curve_discovery.json"
+    ],
+    "target_mixups": [
+      "ori",
+      "0.15"
+    ]
+  },
+  "comparisons": {
+    "candidate_vs_pr125": {
+      "delta": {
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.0,
+          "Computer Monitor Acutance": 0.0,
+          "Large Print Acutance": 0.0,
+          "Small Print Acutance": 0.0,
+          "UHDTV Display Acutance": 0.0
+        },
+        "curve_mae_mean": 0.00121550907398911,
+        "focus_preset_acutance_mae_mean": 0.0,
+        "mtf_abs_signed_rel_mean": 0.0,
+        "mtf_threshold_mae": {
+          "mtf20": 0.0,
+          "mtf30": 0.0,
+          "mtf50": 0.0
+        },
+        "overall_quality_loss_mae_mean": 0.0
+      }
+    },
+    "candidate_vs_pr30": {
+      "delta": {
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.021454129834507486,
+          "Computer Monitor Acutance": -0.02851887581626197,
+          "Large Print Acutance": -0.022701561546618957,
+          "Small Print Acutance": -0.01497585610580384,
+          "UHDTV Display Acutance": -0.023089360415706
+        },
+        "curve_mae_mean": -0.011322004551280115,
+        "focus_preset_acutance_mae_mean": -0.013566304809976663,
+        "mtf_abs_signed_rel_mean": 0.0,
+        "mtf_threshold_mae": {
+          "mtf20": 0.0,
+          "mtf30": 0.0,
+          "mtf50": 0.0
+        },
+        "overall_quality_loss_mae_mean": -0.01713926776831376
+      }
+    }
+  },
+  "curve_shape_result": {
+    "by_mixup_baseline": {
+      "0.15": 0.029378599163150443,
+      "0.25": 0.02479729017929424,
+      "0.4": 0.019363342842858032,
+      "0.65": 0.011953815251775047,
+      "0.8": 0.0188398331534736,
+      "ori": 0.045803234428031414
+    },
+    "by_mixup_candidate": {
+      "0.15": 0.03545614453309601,
+      "0.25": 0.02479729017929424,
+      "0.4": 0.019363342842858032,
+      "0.65": 0.011953815251775047,
+      "0.8": 0.0188398331534736,
+      "ori": 0.045803234428031414
+    },
+    "by_mixup_delta": {
+      "0.15": 0.006077545369945564,
+      "0.25": 0.0,
+      "0.4": 0.0,
+      "0.65": 0.0,
+      "0.8": 0.0,
+      "ori": 0.0
+    },
+    "candidate_boundary": "Adds `0.15` to the existing issue #124 curve-only Acutance anchor mask; `0.25` and preset Acutance remain untouched.",
+    "deferred_mixups": [
+      "0.25"
+    ],
+    "selected_slice_id": "issue124_residual_curve_ori_015_curve_only_shape_boundary",
+    "target_mixups": [
+      "ori",
+      "0.15"
+    ]
+  },
+  "issue": 128,
+  "next_result": {
+    "recommended_follow_up": "Do not continue broadening the issue #124 curve-only anchor mask. If PM splits another curve follow-up, it should require a per-mixup or shape-family variant that proves `0.15` improves before committing to a full benchmark; otherwise split the deferred Small Print Acutance preset-only miss.",
+    "summary": "The bounded ori/0.15 curve-shape candidate is not promotable: it preserves reported-MTF, preset Acutance, overall Quality Loss, and release separation, but worsens the aggregate curve MAE because the current matched-ori curve shape moves `0.15` in the wrong direction."
+  },
+  "readme_gate_summary": {
+    "all_readme_gates_pass": false,
+    "failed_gates": [
+      "curve_mae_mean",
+      "non_phone_acutance_preset_mae_max"
+    ],
+    "gates": {
+      "5.5\" Phone Display Acutance": {
+        "delta_to_gate": -0.014743622260204217,
+        "operator": "<=",
+        "pass": true,
+        "threshold": 0.05,
+        "value": 0.035256377739795786
+      },
+      "curve_mae_mean": {
+        "delta_to_gate": 0.005467027109725017,
+        "operator": "<=",
+        "pass": false,
+        "threshold": 0.02,
+        "value": 0.025467027109725017
+      },
+      "focus_preset_acutance_mae_mean": {
+        "delta_to_gate": -0.0010794735912748668,
+        "operator": "<=",
+        "pass": true,
+        "threshold": 0.03,
+        "value": 0.028920526408725132
+      },
+      "non_phone_acutance_preset_mae_max": {
+        "by_preset": {
+          "Computer Monitor Acutance": 0.024146307932311834,
+          "Large Print Acutance": 0.028624302638652583,
+          "Small Print Acutance": 0.031726251556383624,
+          "UHDTV Display Acutance": 0.024849392176481848
+        },
+        "delta_to_gate": 0.0017262515563836248,
+        "operator": "<=",
+        "pass": false,
+        "threshold": 0.03,
+        "value": 0.031726251556383624,
+        "worst_preset": "Small Print Acutance"
+      },
+      "overall_quality_loss_mae_mean": {
+        "delta_to_gate": -0.09564031333060252,
+        "operator": "<=",
+        "pass": true,
+        "threshold": 1.3,
+        "value": 1.2043596866693975
+      }
+    }
+  },
+  "refs": {
+    "baseline_pr": 30,
+    "current_best_issue": 124,
+    "current_best_pr": 125,
+    "current_issue": 128,
+    "discovery_issue": 126,
+    "discovery_pr": 127,
+    "umbrella_issue": 29
+  },
+  "release_separation": {
+    "candidate_is_release_config": false,
+    "golden_reference_roots": [
+      "20260318_deadleaf_13b10",
+      "release/deadleaf_13b10_release/data/20260318_deadleaf_13b10",
+      "release/deadleaf_13b10_release/config"
+    ],
+    "rules": [
+      "The candidate profile is canonical-target research only.",
+      "No fitted outputs are written under golden/reference data roots.",
+      "No release-facing config is promoted in this issue."
+    ]
+  },
+  "result_kind": "bounded_negative_not_promotable",
+  "summary_kind": "issue128_ori_015_curve_shape_summary"
+}

--- a/docs/issue128_ori_015_curve_shape_summary.md
+++ b/docs/issue128_ori_015_curve_shape_summary.md
@@ -1,0 +1,47 @@
+# Issue 128 Ori/0.15 Curve-Shape Summary
+
+- Result: `bounded_negative_not_promotable`.
+- Candidate profile: `algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_computer_monitor_small_print_large_print_pr30_input_curve_only_ori_015_profile.json`
+- Scoped boundary: add `0.15` to the existing issue #124 curve-only Acutance anchor mask; keep `0.25`, preset Acutance, Quality Loss, and reported-MTF/readout untouched.
+
+## Metrics
+
+| Metric | PR #125 | Issue #128 | Delta | Gate |
+| --- | ---: | ---: | ---: | --- |
+| curve_mae_mean | 0.02425 | 0.02547 | 0.00122 | <= 0.020 (miss) |
+| focus_preset_acutance_mae_mean | 0.02892 | 0.02892 | 0.00000 | preserve |
+| overall_quality_loss_mae_mean | 1.20436 | 1.20436 | 0.00000 | preserve |
+| mtf_abs_signed_rel_mean | 0.08671 | 0.08671 | 0.00000 | preserve |
+| Small Print Acutance | 0.03173 | 0.03173 | 0.00000 | <= 0.030 (miss) |
+
+## Curve Shape Result
+
+| Mixup | PR #125 | Issue #128 | Delta |
+| --- | ---: | ---: | ---: |
+| 0.15 | 0.02938 | 0.03546 | 0.00608 |
+| 0.25 | 0.02480 | 0.02480 | 0.00000 |
+| 0.4 | 0.01936 | 0.01936 | 0.00000 |
+| 0.65 | 0.01195 | 0.01195 | 0.00000 |
+| 0.8 | 0.01884 | 0.01884 | 0.00000 |
+| ori | 0.04580 | 0.04580 | 0.00000 |
+
+The `ori` and `0.8` curve values stay at their issue #124 values, but `0.15` worsens from `0.02938` to `0.03546`. The aggregate curve MAE therefore moves away from the README gate.
+
+## Acceptance
+
+- Curve gate pass: `False`.
+- Curve improved versus PR #125: `False`.
+- Reported-MTF preserved: `True`.
+- Focus-preset Acutance preserved: `True`.
+- Overall Quality Loss preserved: `True`.
+- Small Print Acutance preserved: `True`.
+
+## Next Result
+
+The bounded ori/0.15 curve-shape candidate is not promotable: it preserves reported-MTF, preset Acutance, overall Quality Loss, and release separation, but worsens the aggregate curve MAE because the current matched-ori curve shape moves `0.15` in the wrong direction.
+
+Do not continue broadening the issue #124 curve-only anchor mask. If PM splits another curve follow-up, it should require a per-mixup or shape-family variant that proves `0.15` improves before committing to a full benchmark; otherwise split the deferred Small Print Acutance preset-only miss.
+
+## Release Separation
+
+This remains canonical-target research, not a release-facing config promotion. No fitted outputs are written under golden/reference data roots or release configs.

--- a/tests/test_build_issue128_ori_015_curve_shape_summary.py
+++ b/tests/test_build_issue128_ori_015_curve_shape_summary.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from algo.build_issue128_ori_015_curve_shape_summary import (
+    RESULT_KIND,
+    build_payload,
+    render_markdown,
+)
+
+
+class BuildIssue128Ori015CurveShapeSummaryTest(unittest.TestCase):
+    def test_payload_records_bounded_negative_and_preservation(self) -> None:
+        payload = build_payload(
+            self.repo_root(),
+            issue124_summary_path=Path("artifacts/issue124_curve_only_high_mixup_ori_summary.json"),
+            issue126_discovery_path=Path("artifacts/issue126_residual_curve_discovery.json"),
+            candidate_acutance_path=Path(
+                "artifacts/issue128_ori_015_curve_shape_acutance_benchmark.json"
+            ),
+            candidate_psd_path=Path("artifacts/issue128_ori_015_curve_shape_psd_benchmark.json"),
+        )
+
+        self.assertEqual(payload["issue"], 128)
+        self.assertEqual(payload["result_kind"], RESULT_KIND)
+        self.assertEqual(payload["candidate"]["target_mixups"], ["ori", "0.15"])
+        self.assertEqual(payload["candidate"]["deferred_mixups"], ["0.25"])
+        self.assertEqual(
+            payload["candidate"]["curve_only_acutance_anchor_mixups"],
+            ["0.15", "0.8", "ori"],
+        )
+
+        delta = payload["comparisons"]["candidate_vs_pr125"]["delta"]
+        self.assertGreater(delta["curve_mae_mean"], 0.001)
+        self.assertEqual(delta["focus_preset_acutance_mae_mean"], 0.0)
+        self.assertEqual(delta["overall_quality_loss_mae_mean"], 0.0)
+        self.assertEqual(delta["mtf_abs_signed_rel_mean"], 0.0)
+        self.assertEqual(delta["mtf_threshold_mae"]["mtf20"], 0.0)
+        self.assertEqual(delta["mtf_threshold_mae"]["mtf30"], 0.0)
+        self.assertEqual(delta["mtf_threshold_mae"]["mtf50"], 0.0)
+        self.assertEqual(delta["acutance_preset_mae"]["Small Print Acutance"], 0.0)
+
+        curve = payload["curve_shape_result"]
+        self.assertGreater(curve["by_mixup_delta"]["0.15"], 0.006)
+        self.assertEqual(curve["by_mixup_delta"]["0.25"], 0.0)
+        self.assertEqual(curve["by_mixup_delta"]["0.8"], 0.0)
+        self.assertEqual(curve["by_mixup_delta"]["ori"], 0.0)
+
+        self.assertFalse(payload["acceptance"]["curve_gate_pass"])
+        self.assertFalse(payload["acceptance"]["curve_improved_vs_pr125"])
+        self.assertTrue(payload["acceptance"]["reported_mtf_preserved"])
+        self.assertTrue(payload["acceptance"]["focus_preset_acutance_preserved"])
+        self.assertTrue(payload["acceptance"]["overall_quality_loss_preserved"])
+        self.assertTrue(payload["acceptance"]["small_print_acutance_preserved"])
+        self.assertTrue(payload["acceptance"]["release_separation_preserved"])
+
+    def test_markdown_mentions_negative_result_and_next_step(self) -> None:
+        payload = build_payload(
+            self.repo_root(),
+            issue124_summary_path=Path("artifacts/issue124_curve_only_high_mixup_ori_summary.json"),
+            issue126_discovery_path=Path("artifacts/issue126_residual_curve_discovery.json"),
+            candidate_acutance_path=Path(
+                "artifacts/issue128_ori_015_curve_shape_acutance_benchmark.json"
+            ),
+            candidate_psd_path=Path("artifacts/issue128_ori_015_curve_shape_psd_benchmark.json"),
+        )
+        markdown = render_markdown(payload)
+
+        self.assertIn("# Issue 128 Ori/0.15 Curve-Shape Summary", markdown)
+        self.assertIn("bounded_negative_not_promotable", markdown)
+        self.assertIn("0.15", markdown)
+        self.assertIn("worsens", markdown)
+        self.assertIn("per-mixup or shape-family variant", markdown)
+        self.assertIn("Release Separation", markdown)
+
+    @staticmethod
+    def repo_root() -> Path:
+        return Path(__file__).resolve().parents[1]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Refs #128
Refs #29
Refs #118
Refs #124
Refs #126
Context from #127

- Adds the bounded issue #128 candidate profile that keeps the issue #124 curve-only isolation and adds `0.15` to the existing `0.8` / `ori` curve-only Acutance anchor mask.
- Regenerates Acutance/Quality Loss and PSD/MTF artifacts for that candidate.
- Adds a generated summary artifact and note recording the result as `bounded_negative_not_promotable`.
- Preserves reported-MTF, focus-preset Acutance, overall Quality Loss, Small Print Acutance, Quality Loss input overrides, and release-facing config separation.

## Result

- `curve_mae_mean`: `0.02425152 -> 0.02546703` (`+0.00121551`), so the README curve gate still misses and the candidate is worse than PR #125.
- `0.15` curve MAE: `0.02937860 -> 0.03545614`.
- `0.8` curve MAE remains `0.01883983`.
- `ori` curve MAE remains `0.04580323`.
- Reported-MTF metrics remain unchanged versus PR #125 / PR #30.
- Focus-preset Acutance remains `0.02892053`.
- Overall Quality Loss remains `1.20435969`.
- Small Print Acutance remains `0.03172625`.

Interpretation:

- The current matched-ori curve shape moves `0.15` in the wrong direction.
- Do not keep broadening the issue #124 curve-only anchor mask as the next path.
- A later curve follow-up should require a per-mixup or shape-family variant that proves `0.15` improves before committing to a full benchmark, or PM should split the deferred Small Print Acutance preset-only miss.

## Validation

- `python3 -m algo.benchmark_parity_acutance_quality_loss 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_computer_monitor_small_print_large_print_pr30_input_curve_only_ori_015_profile.json --output artifacts/issue128_ori_015_curve_shape_acutance_benchmark.json`
- `python3 -m algo.benchmark_parity_psd_mtf 20260318_deadleaf_13b10 algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_computer_monitor_small_print_large_print_pr30_input_curve_only_ori_015_profile.json --output artifacts/issue128_ori_015_curve_shape_psd_benchmark.json`
- `python3 -m py_compile algo/benchmark_parity_acutance_quality_loss.py algo/benchmark_parity_psd_mtf.py algo/build_issue128_ori_015_curve_shape_summary.py`
- `python3 -m pytest tests/test_build_issue128_ori_015_curve_shape_summary.py tests/test_build_issue126_residual_curve_discovery.py tests/test_build_issue124_curve_only_high_mixup_ori_summary.py -q`
- `git diff --check`
