### PR TITLE
Issue #132: isolate Small Print Acutance boundary

### DIFF
--- a/algo/benchmark_parity_acutance_quality_loss.py
+++ b/algo/benchmark_parity_acutance_quality_loss.py
@@ -175,6 +175,7 @@ class Profile:
     quality_loss_coefficients: tuple[float, float, float] = (64.99250542, 9.37974246, 0.72233291)
     quality_loss_preset_overrides: dict[str, dict[str, object]] | None = None
     quality_loss_preset_input_profile_overrides: dict[str, str] | None = None
+    acutance_preset_input_profile_overrides: dict[str, str] | None = None
     acutance_preset_overrides: dict[str, dict[str, float | str | None]] | None = None
     texture_support_scale: bool = False
     mtf_compensation_mode: str = "none"
@@ -352,6 +353,54 @@ def build_quality_loss_input_override_records(
     return records_by_preset
 
 
+def build_acutance_input_override_records(
+    *,
+    dataset_root: Path,
+    profile_path: Path,
+    profile: Profile,
+    width: int,
+    height: int,
+    override_stack: frozenset[str],
+) -> dict[str, dict[str, float]]:
+    overrides = profile.acutance_preset_input_profile_overrides or {}
+    records_by_preset: dict[str, dict[str, float]] = {}
+    override_payloads: dict[str, dict[str, object]] = {}
+    for acutance_preset, override_profile_path_text in overrides.items():
+        override_profile_path = resolve_profile_override_path(
+            profile_path,
+            override_profile_path_text,
+        )
+        override_key = str(override_profile_path)
+        if override_key in override_stack:
+            raise ValueError(
+                "Recursive Acutance input profile override detected for "
+                f"{override_profile_path_text!r}"
+            )
+        if override_key not in override_payloads:
+            override_payloads[override_key] = summarize_profile(
+                dataset_root=dataset_root,
+                profile_path=override_profile_path,
+                profile=load_profile(override_profile_path),
+                width=width,
+                height=height,
+                include_acutance_records=True,
+                override_stack=override_stack | {override_key},
+            )
+        override_payload = override_payloads[override_key]
+        preset_records = {
+            str(record["csv_path"]): float(record["predicted_acutance"])
+            for record in override_payload["acutance_records"]
+            if record["record_type"] == "preset" and record["preset_name"] == acutance_preset
+        }
+        if not preset_records:
+            raise ValueError(
+                f"Acutance preset {acutance_preset!r} not found in "
+                f"override profile {override_profile_path_text!r}"
+            )
+        records_by_preset[acutance_preset] = preset_records
+    return records_by_preset
+
+
 def summarize_profile(
     *,
     dataset_root: Path,
@@ -387,6 +436,14 @@ def summarize_profile(
     acutance_records: list[dict[str, object]] = []
     quality_loss_records: list[dict[str, object]] = []
     quality_loss_input_override_records = build_quality_loss_input_override_records(
+        dataset_root=dataset_root,
+        profile_path=profile_path,
+        profile=profile,
+        width=width,
+        height=height,
+        override_stack=override_stack | {str(profile_path)},
+    )
+    acutance_input_override_records = build_acutance_input_override_records(
         dataset_root=dataset_root,
         profile_path=profile_path,
         profile=profile,
@@ -1062,6 +1119,11 @@ def summarize_profile(
                 continue
             acutance_preset = quality_loss_preset.replace("Quality Loss", "Acutance")
             quality_loss_acutance[acutance_preset] = override_acutance
+        for acutance_preset, override_records in acutance_input_override_records.items():
+            override_acutance = override_records.get(str(csv_path))
+            if override_acutance is None:
+                continue
+            acutance[acutance_preset] = override_acutance
         curve_cmp = compare_acutance_curves(curve, reference.acutance_table)
         if curve_cmp.get("count", 0):
             curve_mae.append(float(curve_cmp["mae"]))
@@ -1205,6 +1267,9 @@ def summarize_profile(
             "quality_loss_preset_overrides": profile.quality_loss_preset_overrides,
             "quality_loss_preset_input_profile_overrides": (
                 profile.quality_loss_preset_input_profile_overrides
+            ),
+            "acutance_preset_input_profile_overrides": (
+                profile.acutance_preset_input_profile_overrides
             ),
             "frequency_scale": profile.frequency_scale,
             "readout_smoothing_window": profile.readout_smoothing_window,

--- a/algo/benchmark_parity_psd_mtf.py
+++ b/algo/benchmark_parity_psd_mtf.py
@@ -169,6 +169,7 @@ class Profile:
     quality_loss_coefficients: tuple[float, float, float] = (64.99250542, 9.37974246, 0.72233291)
     quality_loss_preset_overrides: dict[str, dict[str, object]] | None = None
     quality_loss_preset_input_profile_overrides: dict[str, str] | None = None
+    acutance_preset_input_profile_overrides: dict[str, str] | None = None
     acutance_preset_overrides: dict[str, dict[str, float | str | None]] | None = None
 
 
@@ -835,6 +836,9 @@ def profile_payload(
             "sensor_fill_factor": profile.sensor_fill_factor,
             "quality_loss_preset_input_profile_overrides": (
                 profile.quality_loss_preset_input_profile_overrides
+            ),
+            "acutance_preset_input_profile_overrides": (
+                profile.acutance_preset_input_profile_overrides
             ),
             "readout_mtf_compensation_mode": readout_mtf_compensation_mode,
             "readout_sensor_fill_factor": readout_sensor_fill_factor,

--- a/algo/build_issue132_small_print_acutance_summary.py
+++ b/algo/build_issue132_small_print_acutance_summary.py
@@ -1,0 +1,483 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+ISSUE = 132
+UMBRELLA_ISSUE = 29
+CURRENT_BEST_ISSUE = 124
+CURRENT_BEST_PR = 125
+DISCOVERY_ISSUE = 130
+DISCOVERY_PR = 131
+BASELINE_PR = 30
+SUMMARY_KIND = "issue132_small_print_acutance_boundary_summary"
+RESULT_KIND = "positive_targeted_not_full_canonical"
+TARGET_PRESET = "Small Print Acutance"
+PHONE_PRESET = '5.5" Phone Display Acutance'
+CURVE_GATE = 0.020
+FOCUS_PRESET_GATE = 0.030
+QUALITY_LOSS_GATE = 1.30
+NON_PHONE_ACUTANCE_GATE = 0.030
+GOLDEN_REFERENCE_ROOTS = (
+    "20260318_deadleaf_13b10",
+    "release/deadleaf_13b10_release/data/20260318_deadleaf_13b10",
+    "release/deadleaf_13b10_release/config",
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build issue-132 Small Print summary.")
+    parser.add_argument("--repo-root", type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument(
+        "--issue124-summary",
+        type=Path,
+        default=Path("artifacts/issue124_curve_only_high_mixup_ori_summary.json"),
+    )
+    parser.add_argument(
+        "--issue130-discovery",
+        type=Path,
+        default=Path("artifacts/issue130_next_slice_discovery.json"),
+    )
+    parser.add_argument(
+        "--candidate-profile",
+        type=Path,
+        default=Path("algo/issue132_small_print_acutance_parity_input_profile.json"),
+    )
+    parser.add_argument(
+        "--baseline-profile",
+        type=Path,
+        default=Path(
+            "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_computer_monitor_small_print_large_print_pr30_input_curve_only_high_mixup_ori_profile.json"
+        ),
+    )
+    parser.add_argument(
+        "--candidate-acutance",
+        type=Path,
+        default=Path("artifacts/issue132_small_print_acutance_boundary_acutance_benchmark.json"),
+    )
+    parser.add_argument(
+        "--candidate-psd",
+        type=Path,
+        default=Path("artifacts/issue132_small_print_acutance_boundary_psd_benchmark.json"),
+    )
+    parser.add_argument(
+        "--output-json",
+        type=Path,
+        default=Path("artifacts/issue132_small_print_acutance_boundary_summary.json"),
+    )
+    parser.add_argument(
+        "--output-md",
+        type=Path,
+        default=Path("docs/issue132_small_print_acutance_boundary_summary.md"),
+    )
+    return parser
+
+
+def resolve_path(repo_root: Path, path: Path) -> Path:
+    return path if path.is_absolute() else repo_root / path
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def select_single_profile(payload: dict[str, Any]) -> dict[str, Any]:
+    profiles = payload["profiles"]
+    if len(profiles) != 1:
+        raise ValueError(f"Expected one profile, found {len(profiles)}")
+    return profiles[0]
+
+
+def gate(value: float, threshold: float) -> dict[str, Any]:
+    value = float(value)
+    return {
+        "value": value,
+        "threshold": threshold,
+        "operator": "<=",
+        "pass": value <= threshold,
+        "delta_to_gate": value - threshold,
+    }
+
+
+def readme_gate_summary(metrics: dict[str, Any]) -> dict[str, Any]:
+    non_phone = {
+        key: value for key, value in metrics["acutance_preset_mae"].items() if key != PHONE_PRESET
+    }
+    worst_preset, worst_value = max(non_phone.items(), key=lambda item: item[1])
+    gates = {
+        "curve_mae_mean": gate(metrics["curve_mae_mean"], CURVE_GATE),
+        "focus_preset_acutance_mae_mean": gate(
+            metrics["acutance_focus_preset_mae_mean"],
+            FOCUS_PRESET_GATE,
+        ),
+        "overall_quality_loss_mae_mean": gate(
+            metrics["overall_quality_loss_mae_mean"],
+            QUALITY_LOSS_GATE,
+        ),
+        "non_phone_acutance_preset_mae_max": {
+            **gate(worst_value, NON_PHONE_ACUTANCE_GATE),
+            "worst_preset": worst_preset,
+            "by_preset": {key: float(value) for key, value in sorted(non_phone.items())},
+        },
+        PHONE_PRESET: gate(metrics["acutance_preset_mae"][PHONE_PRESET], 0.050),
+    }
+    return {
+        "all_readme_gates_pass": all(row["pass"] for row in gates.values()),
+        "failed_gates": [key for key, row in gates.items() if not row["pass"]],
+        "gates": gates,
+    }
+
+
+def collect_candidate_metrics(
+    *,
+    candidate_acutance: dict[str, Any],
+    candidate_psd: dict[str, Any],
+) -> dict[str, Any]:
+    acutance = candidate_acutance["overall"]
+    psd = candidate_psd["overall"]
+    return {
+        "curve_mae_mean": float(acutance["curve_mae_mean"]),
+        "acutance_focus_preset_mae_mean": float(acutance["acutance_focus_preset_mae_mean"]),
+        "overall_quality_loss_mae_mean": float(acutance["overall_quality_loss_mae_mean"]),
+        "mtf_abs_signed_rel_mean": float(psd["mtf_abs_signed_rel_mean"]),
+        "mtf_threshold_mae": {
+            key: float(value) for key, value in psd["mtf_threshold_mae"].items()
+        },
+        "acutance_preset_mae": {
+            key: float(value) for key, value in acutance["acutance_preset_mae"].items()
+        },
+        "quality_loss_preset_mae": {
+            key: float(value) for key, value in acutance["quality_loss_preset_mae"].items()
+        },
+    }
+
+
+def metric_delta(candidate: dict[str, Any], baseline: dict[str, Any]) -> dict[str, Any]:
+    baseline_focus_key = (
+        "acutance_focus_preset_mae_mean"
+        if "acutance_focus_preset_mae_mean" in baseline
+        else "focus_preset_acutance_mae_mean"
+    )
+    return {
+        "curve_mae_mean": float(candidate["curve_mae_mean"] - baseline["curve_mae_mean"]),
+        "focus_preset_acutance_mae_mean": float(
+            candidate["acutance_focus_preset_mae_mean"] - baseline[baseline_focus_key]
+        ),
+        "overall_quality_loss_mae_mean": float(
+            candidate["overall_quality_loss_mae_mean"]
+            - baseline["overall_quality_loss_mae_mean"]
+        ),
+        "mtf_abs_signed_rel_mean": float(
+            candidate["mtf_abs_signed_rel_mean"] - baseline["mtf_abs_signed_rel_mean"]
+        ),
+        "mtf_threshold_mae": {
+            key: float(candidate["mtf_threshold_mae"][key] - baseline["mtf_threshold_mae"][key])
+            for key in candidate["mtf_threshold_mae"]
+        },
+        "acutance_preset_mae": {
+            key: float(
+                candidate["acutance_preset_mae"][key] - baseline["acutance_preset_mae"][key]
+            )
+            for key in candidate["acutance_preset_mae"]
+        },
+        "quality_loss_preset_mae": {
+            key: float(
+                candidate["quality_loss_preset_mae"][key]
+                - baseline["quality_loss_preset_mae"][key]
+            )
+            for key in candidate["quality_loss_preset_mae"]
+        },
+    }
+
+
+def is_close(left: float, right: float, *, tolerance: float = 1e-12) -> bool:
+    return abs(float(left) - float(right)) <= tolerance
+
+
+def is_release_path(path: str) -> bool:
+    return path.startswith(GOLDEN_REFERENCE_ROOTS)
+
+
+def profile_scope_delta(
+    *,
+    baseline_profile: dict[str, Any],
+    candidate_profile: dict[str, Any],
+) -> dict[str, Any]:
+    ignored = {"name"}
+    changed_keys = sorted(
+        key
+        for key in set(baseline_profile) | set(candidate_profile)
+        if key not in ignored and baseline_profile.get(key) != candidate_profile.get(key)
+    )
+    return {
+        "changed_keys": changed_keys,
+        "only_acutance_preset_input_override_added": changed_keys
+        == ["acutance_preset_input_profile_overrides"],
+        "acutance_preset_input_profile_overrides": candidate_profile.get(
+            "acutance_preset_input_profile_overrides"
+        ),
+        "quality_loss_preset_input_profile_overrides_preserved": (
+            candidate_profile.get("quality_loss_preset_input_profile_overrides")
+            == baseline_profile.get("quality_loss_preset_input_profile_overrides")
+        ),
+        "curve_only_acutance_anchor_mixups_preserved": (
+            candidate_profile.get("curve_only_acutance_anchor_mixups")
+            == baseline_profile.get("curve_only_acutance_anchor_mixups")
+        ),
+        "reported_mtf_readout_fields_preserved": all(
+            candidate_profile.get(key) == baseline_profile.get(key)
+            for key in (
+                "mtf_compensation_mode",
+                "sensor_fill_factor",
+                "matched_ori_reference_anchor",
+                "matched_ori_anchor_mode",
+                "intrinsic_full_reference_scope",
+            )
+        ),
+        "quality_loss_coefficients_preserved": (
+            candidate_profile.get("quality_loss_coefficients")
+            == baseline_profile.get("quality_loss_coefficients")
+            and candidate_profile.get("quality_loss_preset_overrides")
+            == baseline_profile.get("quality_loss_preset_overrides")
+        ),
+    }
+
+
+def build_payload(
+    repo_root: Path,
+    *,
+    issue124_summary_path: Path,
+    issue130_discovery_path: Path,
+    candidate_profile_path: Path,
+    baseline_profile_path: Path,
+    candidate_acutance_path: Path,
+    candidate_psd_path: Path,
+) -> dict[str, Any]:
+    issue124 = load_json(resolve_path(repo_root, issue124_summary_path))
+    issue130 = load_json(resolve_path(repo_root, issue130_discovery_path))
+    baseline_profile = load_json(resolve_path(repo_root, baseline_profile_path))
+    candidate_profile = load_json(resolve_path(repo_root, candidate_profile_path))
+    candidate_acutance = select_single_profile(
+        load_json(resolve_path(repo_root, candidate_acutance_path))
+    )
+    candidate_psd = select_single_profile(load_json(resolve_path(repo_root, candidate_psd_path)))
+    baseline = issue124["candidate"]["metrics"]
+    candidate = collect_candidate_metrics(
+        candidate_acutance=candidate_acutance,
+        candidate_psd=candidate_psd,
+    )
+    delta = metric_delta(candidate, baseline)
+    scope = profile_scope_delta(
+        baseline_profile=baseline_profile,
+        candidate_profile=candidate_profile,
+    )
+    payload = {
+        "issue": ISSUE,
+        "summary_kind": SUMMARY_KIND,
+        "result_kind": RESULT_KIND,
+        "candidate": {
+            "label": "issue132_small_print_acutance_parity_input",
+            "profile_path": str(candidate_profile_path),
+            "source_artifacts": [
+                str(candidate_acutance_path),
+                str(candidate_psd_path),
+                str(issue124_summary_path),
+                str(issue130_discovery_path),
+            ],
+            "metrics": candidate,
+        },
+        "baseline_pr125": {
+            "issue": CURRENT_BEST_ISSUE,
+            "pr": CURRENT_BEST_PR,
+            "profile_path": str(baseline_profile_path),
+            "metrics": baseline,
+        },
+        "readme_gate_summary": readme_gate_summary(candidate),
+        "comparisons": {
+            "candidate_vs_pr125": {"delta": delta},
+            "issue130_selected_slice": issue130["selected_next_slice"],
+        },
+        "small_print_result": {
+            "target_preset": TARGET_PRESET,
+            "baseline_value": float(baseline["acutance_preset_mae"][TARGET_PRESET]),
+            "candidate_value": float(candidate["acutance_preset_mae"][TARGET_PRESET]),
+            "delta_vs_pr125": float(delta["acutance_preset_mae"][TARGET_PRESET]),
+            "gate": NON_PHONE_ACUTANCE_GATE,
+            "candidate_delta_to_gate": float(
+                candidate["acutance_preset_mae"][TARGET_PRESET] - NON_PHONE_ACUTANCE_GATE
+            ),
+            "override_source_profile": candidate_profile[
+                "acutance_preset_input_profile_overrides"
+            ][TARGET_PRESET],
+        },
+        "profile_scope_delta": scope,
+        "acceptance": {
+            "small_print_gate_pass": (
+                candidate["acutance_preset_mae"][TARGET_PRESET] <= NON_PHONE_ACUTANCE_GATE
+            ),
+            "focus_preset_acutance_gate_pass": (
+                candidate["acutance_focus_preset_mae_mean"] <= FOCUS_PRESET_GATE
+            ),
+            "curve_mae_preserved_vs_pr125": is_close(delta["curve_mae_mean"], 0.0),
+            "reported_mtf_preserved_vs_pr125": (
+                is_close(delta["mtf_abs_signed_rel_mean"], 0.0)
+                and all(is_close(value, 0.0) for value in delta["mtf_threshold_mae"].values())
+            ),
+            "overall_quality_loss_gate_pass": (
+                candidate["overall_quality_loss_mae_mean"] <= QUALITY_LOSS_GATE
+            ),
+            "overall_quality_loss_preserved_vs_pr125": is_close(
+                delta["overall_quality_loss_mae_mean"],
+                0.0,
+            ),
+            "quality_loss_inputs_preserved": (
+                scope["quality_loss_preset_input_profile_overrides_preserved"]
+                and scope["quality_loss_coefficients_preserved"]
+            ),
+            "only_small_print_acutance_input_added": (
+                scope["only_acutance_preset_input_override_added"]
+                and scope["acutance_preset_input_profile_overrides"]
+                == {TARGET_PRESET: "algo/deadleaf_13b10_parity_psd_mtf_profile.json"}
+            ),
+            "release_separation_preserved": True,
+            "full_readme_gate_pass": readme_gate_summary(candidate)["all_readme_gates_pass"],
+        },
+        "next_result": {
+            "summary": (
+                "The Small Print Acutance preset-only boundary passes the targeted "
+                "non-Phone Acutance gate while preserving PR #125 curve MAE, reported-MTF, "
+                "overall Quality Loss, Quality Loss inputs, and release separation."
+            ),
+            "remaining_miss": (
+                "The full canonical README target still misses only `curve_mae_mean <= 0.020`; "
+                "future curve work remains gated on a separate `0.15` improvement preflight."
+            ),
+        },
+        "release_separation": {
+            "candidate_is_release_config": False,
+            "golden_reference_roots": list(GOLDEN_REFERENCE_ROOTS),
+            "rules": [
+                "The candidate profile is canonical-target research only.",
+                "No fitted outputs are written under golden/reference data roots.",
+                "No release-facing config is promoted in this issue.",
+            ],
+        },
+        "refs": {
+            "umbrella_issue": UMBRELLA_ISSUE,
+            "current_issue": ISSUE,
+            "current_best_issue": CURRENT_BEST_ISSUE,
+            "current_best_pr": CURRENT_BEST_PR,
+            "discovery_issue": DISCOVERY_ISSUE,
+            "discovery_pr": DISCOVERY_PR,
+            "baseline_pr": BASELINE_PR,
+        },
+    }
+    assert_storage_separation(payload)
+    return payload
+
+
+def assert_storage_separation(payload: dict[str, Any]) -> None:
+    paths = [
+        payload["candidate"]["profile_path"],
+        *payload["candidate"]["source_artifacts"],
+    ]
+    for path in paths:
+        if is_release_path(path):
+            raise ValueError(f"candidate path entered golden/release root: {path}")
+
+
+def format_metric(value: float) -> str:
+    return f"{float(value):.5f}"
+
+
+def render_markdown(payload: dict[str, Any]) -> str:
+    candidate = payload["candidate"]
+    metrics = candidate["metrics"]
+    pr125 = payload["baseline_pr125"]["metrics"]
+    delta = payload["comparisons"]["candidate_vs_pr125"]["delta"]
+    gates = payload["readme_gate_summary"]["gates"]
+    small = payload["small_print_result"]
+    acceptance = payload["acceptance"]
+    return "\n".join(
+        [
+            "# Issue 132 Small Print Acutance Boundary Summary",
+            "",
+            f"- Result: `{payload['result_kind']}`.",
+            f"- Candidate profile: `{candidate['profile_path']}`.",
+            f"- Target preset: `{small['target_preset']}`.",
+            f"- Override source profile: `{small['override_source_profile']}`.",
+            "",
+            "## Metrics",
+            "",
+            "| Metric | PR #125 | Issue #132 | Delta | Gate |",
+            "| --- | ---: | ---: | ---: | --- |",
+            f"| curve_mae_mean | {format_metric(pr125['curve_mae_mean'])} | "
+            f"{format_metric(metrics['curve_mae_mean'])} | "
+            f"{format_metric(delta['curve_mae_mean'])} | "
+            f"<= 0.020 ({'pass' if gates['curve_mae_mean']['pass'] else 'miss'}) |",
+            f"| focus_preset_acutance_mae_mean | "
+            f"{format_metric(pr125['acutance_focus_preset_mae_mean'])} | "
+            f"{format_metric(metrics['acutance_focus_preset_mae_mean'])} | "
+            f"{format_metric(delta['focus_preset_acutance_mae_mean'])} | "
+            f"<= 0.030 ({'pass' if gates['focus_preset_acutance_mae_mean']['pass'] else 'miss'}) |",
+            f"| overall_quality_loss_mae_mean | "
+            f"{format_metric(pr125['overall_quality_loss_mae_mean'])} | "
+            f"{format_metric(metrics['overall_quality_loss_mae_mean'])} | "
+            f"{format_metric(delta['overall_quality_loss_mae_mean'])} | "
+            f"<= 1.30 ({'pass' if gates['overall_quality_loss_mae_mean']['pass'] else 'miss'}) |",
+            f"| mtf_abs_signed_rel_mean | {format_metric(pr125['mtf_abs_signed_rel_mean'])} | "
+            f"{format_metric(metrics['mtf_abs_signed_rel_mean'])} | "
+            f"{format_metric(delta['mtf_abs_signed_rel_mean'])} | preserve |",
+            f"| Small Print Acutance | "
+            f"{format_metric(small['baseline_value'])} | "
+            f"{format_metric(small['candidate_value'])} | "
+            f"{format_metric(small['delta_vs_pr125'])} | "
+            f"<= 0.030 ({'pass' if acceptance['small_print_gate_pass'] else 'miss'}) |",
+            "",
+            "## Scope",
+            "",
+            f"- Changed profile keys: `{', '.join(payload['profile_scope_delta']['changed_keys'])}`.",
+            f"- Only Small Print Acutance input override added: `{acceptance['only_small_print_acutance_input_added']}`.",
+            f"- Quality Loss inputs preserved: `{acceptance['quality_loss_inputs_preserved']}`.",
+            f"- Reported-MTF preserved: `{acceptance['reported_mtf_preserved_vs_pr125']}`.",
+            f"- Curve MAE preserved versus PR #125: `{acceptance['curve_mae_preserved_vs_pr125']}`.",
+            "",
+            "## Result",
+            "",
+            payload["next_result"]["summary"],
+            "",
+            payload["next_result"]["remaining_miss"],
+            "",
+            "## Release Separation",
+            "",
+            "This remains canonical-target research, not a release-facing config promotion. "
+            "No fitted outputs are written under golden/reference data roots or release configs.",
+        ]
+    )
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    repo_root = args.repo_root
+    payload = build_payload(
+        repo_root,
+        issue124_summary_path=args.issue124_summary,
+        issue130_discovery_path=args.issue130_discovery,
+        candidate_profile_path=args.candidate_profile,
+        baseline_profile_path=args.baseline_profile,
+        candidate_acutance_path=args.candidate_acutance,
+        candidate_psd_path=args.candidate_psd,
+    )
+    output_json = resolve_path(repo_root, args.output_json)
+    output_md = resolve_path(repo_root, args.output_md)
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    output_md.parent.mkdir(parents=True, exist_ok=True)
+    output_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    output_md.write_text(render_markdown(payload) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/algo/issue132_small_print_acutance_parity_input_profile.json
+++ b/algo/issue132_small_print_acutance_parity_input_profile.json
@@ -1,0 +1,196 @@
+{
+  "name": "issue132_small_print_acutance_parity_input",
+  "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+  "gamma": 0.5,
+  "linearization_mode": "toe_power",
+  "linearization_toe": 0.12,
+  "roi_source": "reference_refined",
+  "roi_width": 1655,
+  "roi_height": 1673,
+  "roi_refine_percentile": 45.0,
+  "roi_refine_sigma": 5.0,
+  "roi_refine_min_border_margin": 8,
+  "roi_refine_search_radius": 4,
+  "roi_refine_step": 2,
+  "roi_refine_area_tolerance": 0.98,
+  "intrinsic_full_reference_mode": "paired_ori_transfer",
+  "intrinsic_full_reference_scope": "reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only",
+  "intrinsic_full_reference_clip_lo": 0.5,
+  "intrinsic_full_reference_clip_hi": 1.5,
+  "intrinsic_full_reference_registration_mode": "phase_correlation",
+  "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+  "matched_ori_reference_anchor": true,
+  "matched_ori_correction_clip_lo": 0.5,
+  "matched_ori_correction_clip_hi": 2.0,
+  "matched_ori_anchor_mode": "all",
+  "matched_ori_strength_curve_frequencies": [
+    0.0,
+    0.12,
+    0.22,
+    0.35,
+    0.5
+  ],
+  "matched_ori_strength_curve_values": [
+    1.0,
+    1.0,
+    0.82,
+    0.95,
+    1.0
+  ],
+  "matched_ori_acutance_reference_anchor": true,
+  "matched_ori_acutance_correction_clip_lo": 0.9,
+  "matched_ori_acutance_correction_clip_hi": 1.1,
+  "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+  "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+    0.0,
+    0.25,
+    0.6,
+    0.8,
+    1.6,
+    2.5
+  ],
+  "matched_ori_acutance_curve_correction_clip_hi_values": [
+    1.02,
+    1.03,
+    0.895,
+    0.895,
+    1.05,
+    1.06
+  ],
+  "matched_ori_acutance_strength_curve_relative_scales": [
+    0.0,
+    0.2,
+    0.8,
+    1.6,
+    2.5
+  ],
+  "matched_ori_acutance_strength_curve_values": [
+    0.7,
+    0.69,
+    0.64,
+    0.62,
+    0.6
+  ],
+  "matched_ori_acutance_correction_delta_power": 1.0,
+  "matched_ori_acutance_curve_correction_delta_power": 0.95,
+  "matched_ori_acutance_preset_correction_delta_power": null,
+  "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+    0.0,
+    4.5,
+    5.8,
+    6.2
+  ],
+  "matched_ori_acutance_preset_correction_delta_power_values": [
+    1.05,
+    1.05,
+    1.85,
+    1.85
+  ],
+  "matched_ori_acutance_preset_strength_curve_relative_scales": [
+    0.0,
+    3.0,
+    4.5,
+    5.8,
+    6.2
+  ],
+  "matched_ori_acutance_preset_strength_curve_values": [
+    1.0,
+    1.0,
+    0.85,
+    0.45,
+    0.45
+  ],
+  "curve_only_acutance_anchor_mixups": [
+    "0.8",
+    "ori"
+  ],
+  "frequency_scale": 1.0,
+  "normalization_band_lo": 0.01,
+  "normalization_band_hi": 0.03,
+  "normalization_mode": "max",
+  "acutance_band_lo": 0.017,
+  "acutance_band_hi": 0.035,
+  "acutance_band_mode": "mean",
+  "noise_psd_model": "empirical",
+  "noise_psd_scale": 1.0,
+  "quality_loss_om_ceiling": 0.8851,
+  "quality_loss_coefficients": [
+    37.240228358776136,
+    26.54550669779819,
+    0.4538662637619741
+  ],
+  "quality_loss_preset_overrides": {
+    "Computer Monitor Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        5677361.198044325,
+        -16715685.9524707,
+        20317567.326582585,
+        -13046703.33912079,
+        4667794.619228022,
+        -882296.9160375095,
+        68863.59709647154
+      ]
+    },
+    "5.5\" Phone Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        -110912321.41149135,
+        50461107.51563171,
+        -9079490.127807735,
+        815148.8697247265,
+        -37712.984407641874,
+        854.6941149036079,
+        -6.261149027919645
+      ]
+    },
+    "UHDTV Display Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        1783462.6221675149,
+        -3813432.5606394163,
+        3326218.4642961356,
+        -1514886.1959663907,
+        380334.163146246,
+        -49956.87092015135,
+        2692.9566508574017
+      ]
+    },
+    "Small Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        6690980.837239251,
+        -12955277.716404187,
+        10300283.291740375,
+        -4303759.200708971,
+        996904.2653558743,
+        -121409.71509269004,
+        6084.6471373306085
+      ]
+    },
+    "Large Print Quality Loss": {
+      "om_ceiling": 0.8851,
+      "coefficients": [
+        2355074.475971866,
+        -5276146.244338096,
+        4846781.143787682,
+        -2336594.295523967,
+        623766.4933095274,
+        -87476.30712136331,
+        5049.882965558553
+      ]
+    }
+  },
+  "quality_loss_preset_input_profile_overrides": {
+    "Computer Monitor Quality Loss": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json",
+    "Small Print Quality Loss": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json",
+    "Large Print Quality Loss": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json"
+  },
+  "acutance_preset_input_profile_overrides": {
+    "Small Print Acutance": "algo/deadleaf_13b10_parity_psd_mtf_profile.json"
+  },
+  "mtf_compensation_mode": "sensor_aperture_sinc",
+  "sensor_fill_factor": 1.5,
+  "texture_support_scale": true,
+  "high_frequency_guard_start_cpp": 0.36
+}

--- a/artifacts/issue132_small_print_acutance_boundary_acutance_benchmark.json
+++ b/artifacts/issue132_small_print_acutance_boundary_acutance_benchmark.json
@@ -1,0 +1,261 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "acutance_preset_input_profile_overrides": {
+          "Small Print Acutance": "algo/deadleaf_13b10_parity_psd_mtf_profile.json"
+        },
+        "acutance_preset_overrides": null,
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "curve_only_acutance_anchor_mixups": [
+          "0.8",
+          "ori"
+        ],
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only",
+        "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_coefficients": [
+          37.240228358776136,
+          26.54550669779819,
+          0.4538662637619741
+        ],
+        "quality_loss_om_ceiling": 0.8851,
+        "quality_loss_preset_input_profile_overrides": {
+          "Computer Monitor Quality Loss": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json",
+          "Large Print Quality Loss": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json",
+          "Small Print Quality Loss": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json"
+        },
+        "quality_loss_preset_overrides": {
+          "5.5\" Phone Display Quality Loss": {
+            "coefficients": [
+              -110912321.41149135,
+              50461107.51563171,
+              -9079490.127807735,
+              815148.8697247265,
+              -37712.984407641874,
+              854.6941149036079,
+              -6.261149027919645
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Computer Monitor Quality Loss": {
+            "coefficients": [
+              5677361.198044325,
+              -16715685.9524707,
+              20317567.326582585,
+              -13046703.33912079,
+              4667794.619228022,
+              -882296.9160375095,
+              68863.59709647154
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Large Print Quality Loss": {
+            "coefficients": [
+              2355074.475971866,
+              -5276146.244338096,
+              4846781.143787682,
+              -2336594.295523967,
+              623766.4933095274,
+              -87476.30712136331,
+              5049.882965558553
+            ],
+            "om_ceiling": 0.8851
+          },
+          "Small Print Quality Loss": {
+            "coefficients": [
+              6690980.837239251,
+              -12955277.716404187,
+              10300283.291740375,
+              -4303759.200708971,
+              996904.2653558743,
+              -121409.71509269004,
+              6084.6471373306085
+            ],
+            "om_ceiling": 0.8851
+          },
+          "UHDTV Display Quality Loss": {
+            "coefficients": [
+              1783462.6221675149,
+              -3813432.5606394163,
+              3326218.4642961356,
+              -1514886.1959663907,
+              380334.163146246,
+              -49956.87092015135,
+              2692.9566508574017
+            ],
+            "om_ceiling": 0.8851
+          }
+        },
+        "readout_interpolation": "linear",
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.029378599163150443,
+        "0.25": 0.02479729017929424,
+        "0.4": 0.019363342842858032,
+        "0.65": 0.011953815251775047,
+        "0.8": 0.0188398331534736,
+        "ori": 0.045803234428031414
+      },
+      "by_mixup_quality_loss_mae_mean": {
+        "0.15": 1.1504751574647964,
+        "0.25": 1.2034864496306634,
+        "0.4": 1.1777404619388072,
+        "0.65": 0.49964929220560284,
+        "0.8": 1.0721427077120183,
+        "ori": 2.3362580209958006
+      },
+      "overall": {
+        "acutance_focus_preset_mae_mean": 0.028365693596289134,
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.035256377739795786,
+          "Computer Monitor Acutance": 0.024146307932311834,
+          "Large Print Acutance": 0.028624302638652583,
+          "Small Print Acutance": 0.028952087494203603,
+          "UHDTV Display Acutance": 0.024849392176481848
+        },
+        "curve_mae_mean": 0.024251518035735907,
+        "overall_quality_loss_mae_mean": 1.2043596866693975,
+        "quality_loss_focus_preset_mae_mean": 1.2043596866693975,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 0.23804277891732473,
+          "Computer Monitor Quality Loss": 2.906111784076103,
+          "Large Print Quality Loss": 0.9547911309308169,
+          "Small Print Quality Loss": 0.6076983310559123,
+          "UHDTV Display Quality Loss": 1.3151544083668303
+        }
+      },
+      "profile_path": "algo/issue132_small_print_acutance_parity_input_profile.json"
+    }
+  ]
+}

--- a/artifacts/issue132_small_print_acutance_boundary_psd_benchmark.json
+++ b/artifacts/issue132_small_print_acutance_boundary_psd_benchmark.json
@@ -1,0 +1,205 @@
+{
+  "dataset_root": "20260318_deadleaf_13b10",
+  "profiles": [
+    {
+      "analysis_pipeline": {
+        "acutance_noise_scale_mode": "fixed",
+        "acutance_preset_input_profile_overrides": {
+          "Small Print Acutance": "algo/deadleaf_13b10_parity_psd_mtf_profile.json"
+        },
+        "bayer_mode": "demosaic_red",
+        "bayer_pattern": "RGGB",
+        "calibration_file": "algo/deadleaf_13b10_psd_calibration_anchored.json",
+        "chart_fill_factor": 1.0,
+        "curve_only_acutance_anchor_mixups": [
+          "0.8",
+          "ori"
+        ],
+        "frequency_scale": 1.0,
+        "gamma": 0.5,
+        "high_frequency_guard_start_cpp": 0.36,
+        "intrinsic_full_reference_clip_hi": 1.5,
+        "intrinsic_full_reference_clip_lo": 0.5,
+        "intrinsic_full_reference_mode": "paired_ori_transfer",
+        "intrinsic_full_reference_registration_mode": "phase_correlation",
+        "intrinsic_full_reference_scope": "reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only",
+        "intrinsic_full_reference_transfer_mode": "radial_real_mean",
+        "linearization_mode": "toe_power",
+        "linearization_toe": 0.12,
+        "matched_ori_acutance_blend_start_relative_scale": 0.0,
+        "matched_ori_acutance_blend_stop_relative_scale": 0.0,
+        "matched_ori_acutance_correction_clip_hi": 1.1,
+        "matched_ori_acutance_correction_clip_lo": 0.9,
+        "matched_ori_acutance_correction_delta_power": 1.0,
+        "matched_ori_acutance_correction_strength": 1.0,
+        "matched_ori_acutance_curve_correction_clip_hi": 1.04,
+        "matched_ori_acutance_curve_correction_clip_hi_relative_scales": [
+          0.0,
+          0.25,
+          0.6,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_curve_correction_clip_hi_values": [
+          1.02,
+          1.03,
+          0.895,
+          0.895,
+          1.05,
+          1.06
+        ],
+        "matched_ori_acutance_curve_correction_clip_lo": null,
+        "matched_ori_acutance_curve_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_curve_correction_clip_lo_values": null,
+        "matched_ori_acutance_curve_correction_delta_power": 0.95,
+        "matched_ori_acutance_preset_correction_clip_hi": null,
+        "matched_ori_acutance_preset_correction_clip_hi_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_hi_values": null,
+        "matched_ori_acutance_preset_correction_clip_lo": null,
+        "matched_ori_acutance_preset_correction_clip_lo_relative_scales": null,
+        "matched_ori_acutance_preset_correction_clip_lo_values": null,
+        "matched_ori_acutance_preset_correction_delta_power": null,
+        "matched_ori_acutance_preset_correction_delta_power_relative_scales": [
+          0.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_correction_delta_power_values": [
+          1.05,
+          1.05,
+          1.85,
+          1.85
+        ],
+        "matched_ori_acutance_preset_strength_curve_relative_scales": [
+          0.0,
+          3.0,
+          4.5,
+          5.8,
+          6.2
+        ],
+        "matched_ori_acutance_preset_strength_curve_values": [
+          1.0,
+          1.0,
+          0.85,
+          0.45,
+          0.45
+        ],
+        "matched_ori_acutance_reference_anchor": true,
+        "matched_ori_acutance_strength_curve_relative_scales": [
+          0.0,
+          0.2,
+          0.8,
+          1.6,
+          2.5
+        ],
+        "matched_ori_acutance_strength_curve_values": [
+          0.7,
+          0.69,
+          0.64,
+          0.62,
+          0.6
+        ],
+        "matched_ori_anchor_mode": "all",
+        "matched_ori_blend_start_cpp": 0.0,
+        "matched_ori_blend_stop_cpp": 0.0,
+        "matched_ori_correction_clip_hi": 2.0,
+        "matched_ori_correction_clip_lo": 0.5,
+        "matched_ori_correction_strength": 1.0,
+        "matched_ori_oecf_quantiles": [
+          0.0,
+          0.1,
+          0.25,
+          0.5,
+          0.75,
+          0.9,
+          1.0
+        ],
+        "matched_ori_oecf_reference": false,
+        "matched_ori_oecf_strength": 1.0,
+        "matched_ori_reference_anchor": true,
+        "matched_ori_strength_curve_frequencies": [
+          0.0,
+          0.12,
+          0.22,
+          0.35,
+          0.5
+        ],
+        "matched_ori_strength_curve_values": [
+          1.0,
+          1.0,
+          0.82,
+          0.95,
+          1.0
+        ],
+        "matched_ori_strength_high": null,
+        "matched_ori_strength_low": null,
+        "matched_ori_strength_ramp_start_cpp": 0.0,
+        "matched_ori_strength_ramp_stop_cpp": 0.0,
+        "mtf_compensation_mode": "sensor_aperture_sinc",
+        "mtf_shape_correction_mode": "none",
+        "quality_loss_preset_input_profile_overrides": {
+          "Computer Monitor Quality Loss": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json",
+          "Large Print Quality Loss": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json",
+          "Small Print Quality Loss": "algo/deadleaf_13b10_imatest_sensor_comp_toe_reference_anchor_acutance_only_curve_preset_qualityfit_allpreset_sextic_curve_midclip0895_profile.json"
+        },
+        "readout_interpolation": "linear",
+        "readout_mtf_compensation_mode": "sensor_aperture_sinc",
+        "readout_sensor_fill_factor": 1.5,
+        "readout_smoothing_window": 1,
+        "roi_source": "reference_refined",
+        "sensor_fill_factor": 1.5,
+        "signal_psd_correction_gain": 0.0,
+        "texture_support_scale": true
+      },
+      "by_mixup_curve_mae_mean": {
+        "0.15": 0.029378599163150443,
+        "0.25": 0.02479729017929424,
+        "0.4": 0.019363342842858032,
+        "0.65": 0.011953815251775047,
+        "0.8": 0.04482380483621107,
+        "ori": 0.07933816634336006
+      },
+      "overall": {
+        "curve_mae_mean": 0.03280180556381627,
+        "mtf_abs_signed_rel_mean": 0.08671416893394165,
+        "mtf_bands": {
+          "high": {
+            "mae_mean": 0.01764835359892083,
+            "mre_mean": 0.088865357734797,
+            "signed_rel_mean": 0.04982888092128941
+          },
+          "low": {
+            "mae_mean": 0.03704553941403868,
+            "mre_mean": 0.046572470331734825,
+            "signed_rel_mean": 0.0237949421475065
+          },
+          "mid": {
+            "mae_mean": 0.03898616152003224,
+            "mre_mean": 0.12397538768693758,
+            "signed_rel_mean": 0.10965436746685472
+          },
+          "top": {
+            "mae_mean": 0.07374065223652229,
+            "mre_mean": 0.20171750026037474,
+            "signed_rel_mean": -0.16357848520011598
+          }
+        },
+        "mtf_threshold_mae": {
+          "mtf20": 0.03301077142967389,
+          "mtf30": 0.03693639342667963,
+          "mtf50": 0.009332615436071163
+        },
+        "preset_mae": {
+          "5.5\" Phone Display Acutance": 0.035256377739795786,
+          "Computer Monitor Acutance": 0.024146307932311834,
+          "Large Print Acutance": 0.028624302638652583,
+          "Small Print Acutance": 0.031726251556383624,
+          "UHDTV Display Acutance": 0.024849392176481848
+        }
+      },
+      "profile_path": "algo/issue132_small_print_acutance_parity_input_profile.json"
+    }
+  ]
+}

--- a/artifacts/issue132_small_print_acutance_boundary_summary.json
+++ b/artifacts/issue132_small_print_acutance_boundary_summary.json
@@ -1,0 +1,252 @@
+{
+  "acceptance": {
+    "curve_mae_preserved_vs_pr125": true,
+    "focus_preset_acutance_gate_pass": true,
+    "full_readme_gate_pass": false,
+    "only_small_print_acutance_input_added": true,
+    "overall_quality_loss_gate_pass": true,
+    "overall_quality_loss_preserved_vs_pr125": true,
+    "quality_loss_inputs_preserved": true,
+    "release_separation_preserved": true,
+    "reported_mtf_preserved_vs_pr125": true,
+    "small_print_gate_pass": true
+  },
+  "baseline_pr125": {
+    "issue": 124,
+    "metrics": {
+      "acutance_focus_preset_mae_mean": 0.028920526408725132,
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": 0.035256377739795786,
+        "Computer Monitor Acutance": 0.024146307932311834,
+        "Large Print Acutance": 0.028624302638652583,
+        "Small Print Acutance": 0.031726251556383624,
+        "UHDTV Display Acutance": 0.024849392176481848
+      },
+      "curve_mae_mean": 0.024251518035735907,
+      "mtf_abs_signed_rel_mean": 0.08671416893394165,
+      "mtf_threshold_mae": {
+        "mtf20": 0.03301077142967389,
+        "mtf30": 0.03693639342667963,
+        "mtf50": 0.009332615436071163
+      },
+      "overall_quality_loss_mae_mean": 1.2043596866693975,
+      "quality_loss_preset_mae": {
+        "5.5\" Phone Display Quality Loss": 0.23804277891732473,
+        "Computer Monitor Quality Loss": 2.906111784076103,
+        "Large Print Quality Loss": 0.9547911309308169,
+        "Small Print Quality Loss": 0.6076983310559123,
+        "UHDTV Display Quality Loss": 1.3151544083668303
+      }
+    },
+    "pr": 125,
+    "profile_path": "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_computer_monitor_small_print_large_print_pr30_input_curve_only_high_mixup_ori_profile.json"
+  },
+  "candidate": {
+    "label": "issue132_small_print_acutance_parity_input",
+    "metrics": {
+      "acutance_focus_preset_mae_mean": 0.028365693596289134,
+      "acutance_preset_mae": {
+        "5.5\" Phone Display Acutance": 0.035256377739795786,
+        "Computer Monitor Acutance": 0.024146307932311834,
+        "Large Print Acutance": 0.028624302638652583,
+        "Small Print Acutance": 0.028952087494203603,
+        "UHDTV Display Acutance": 0.024849392176481848
+      },
+      "curve_mae_mean": 0.024251518035735907,
+      "mtf_abs_signed_rel_mean": 0.08671416893394165,
+      "mtf_threshold_mae": {
+        "mtf20": 0.03301077142967389,
+        "mtf30": 0.03693639342667963,
+        "mtf50": 0.009332615436071163
+      },
+      "overall_quality_loss_mae_mean": 1.2043596866693975,
+      "quality_loss_preset_mae": {
+        "5.5\" Phone Display Quality Loss": 0.23804277891732473,
+        "Computer Monitor Quality Loss": 2.906111784076103,
+        "Large Print Quality Loss": 0.9547911309308169,
+        "Small Print Quality Loss": 0.6076983310559123,
+        "UHDTV Display Quality Loss": 1.3151544083668303
+      }
+    },
+    "profile_path": "algo/issue132_small_print_acutance_parity_input_profile.json",
+    "source_artifacts": [
+      "artifacts/issue132_small_print_acutance_boundary_acutance_benchmark.json",
+      "artifacts/issue132_small_print_acutance_boundary_psd_benchmark.json",
+      "artifacts/issue124_curve_only_high_mixup_ori_summary.json",
+      "artifacts/issue130_next_slice_discovery.json"
+    ]
+  },
+  "comparisons": {
+    "candidate_vs_pr125": {
+      "delta": {
+        "acutance_preset_mae": {
+          "5.5\" Phone Display Acutance": 0.0,
+          "Computer Monitor Acutance": 0.0,
+          "Large Print Acutance": 0.0,
+          "Small Print Acutance": -0.0027741640621800207,
+          "UHDTV Display Acutance": 0.0
+        },
+        "curve_mae_mean": 0.0,
+        "focus_preset_acutance_mae_mean": -0.0005548328124359986,
+        "mtf_abs_signed_rel_mean": 0.0,
+        "mtf_threshold_mae": {
+          "mtf20": 0.0,
+          "mtf30": 0.0,
+          "mtf50": 0.0
+        },
+        "overall_quality_loss_mae_mean": 0.0,
+        "quality_loss_preset_mae": {
+          "5.5\" Phone Display Quality Loss": 0.0,
+          "Computer Monitor Quality Loss": 0.0,
+          "Large Print Quality Loss": 0.0,
+          "Small Print Quality Loss": 0.0,
+          "UHDTV Display Quality Loss": 0.0
+        }
+      }
+    },
+    "issue130_selected_slice": {
+      "expected_preservation": {
+        "curve_mae_mean": "preserve_pr125",
+        "focus_preset_acutance_mae_mean": "improve_or_preserve_gate_pass",
+        "overall_quality_loss_mae_mean": "preserve_pr125",
+        "quality_loss_coefficients": "preserve",
+        "release_separation": "preserve",
+        "reported_mtf_parity": "preserve_pr125"
+      },
+      "minimum_implementation_boundary": [
+        "Start from the issue #124 / PR #125 current-best profile.",
+        "Restrict changes to the Small Print Acutance preset readout/input boundary.",
+        "Do not change `curve_only_acutance_anchor_mixups` or any curve-shape branch.",
+        "Do not change reported-MTF compensation/readout settings.",
+        "Do not change Quality Loss coefficients or Quality Loss preset input overrides.",
+        "Keep release-facing configs and golden/reference data untouched."
+      ],
+      "promotion_acceptance": [
+        "`Small Print Acutance <= 0.030`, or record the slice as bounded negative/non-promotable.",
+        "`focus_preset_acutance_mae_mean <= 0.030` remains true.",
+        "`curve_mae_mean` remains equal to PR #125 unless the result is explicitly non-promotable.",
+        "Reported-MTF metrics remain equal to PR #125 / PR #30.",
+        "`overall_quality_loss_mae_mean <= 1.30` remains true and Quality Loss inputs stay unchanged.",
+        "Release-facing configs and golden/reference data roots remain untouched."
+      ],
+      "repo_evidence": [
+        "PR #125 is still the current-best candidate after PR #129.",
+        "PR #129 worsened aggregate curve MAE and `0.15`, so direct anchor-mask broadening is not justified.",
+        "The only non-Phone Acutance preset still above the README gate in PR #125 is Small Print Acutance.",
+        "Small Print Acutance misses the `<= 0.030` gate by about `+0.00173`.",
+        "Issue #126 and issue #128 already deferred Small Print Acutance preset-only work as the alternate bounded path."
+      ],
+      "selected": true,
+      "selected_summary": "Stop direct curve-mask broadening for this handoff and split the deferred Small Print Acutance preset-only miss. The miss is small, isolated to the non-Phone Acutance gate, and can be tested without touching curve, Quality Loss coefficients, reported-MTF/readout, or release-facing configs.",
+      "slice_id": "issue124_small_print_acutance_preset_only_boundary",
+      "slice_type": "Small Print Acutance preset-only boundary",
+      "validation_plan": [
+        "Regenerate the Acutance/Quality Loss benchmark for the candidate profile.",
+        "Regenerate the PSD/MTF benchmark to prove reported-MTF remains unchanged.",
+        "Compare README gates, PR #125 deltas, and Small Print Acutance gate delta in a checked-in summary.",
+        "Run focused summary tests plus `git diff --check`."
+      ]
+    }
+  },
+  "issue": 132,
+  "next_result": {
+    "remaining_miss": "The full canonical README target still misses only `curve_mae_mean <= 0.020`; future curve work remains gated on a separate `0.15` improvement preflight.",
+    "summary": "The Small Print Acutance preset-only boundary passes the targeted non-Phone Acutance gate while preserving PR #125 curve MAE, reported-MTF, overall Quality Loss, Quality Loss inputs, and release separation."
+  },
+  "profile_scope_delta": {
+    "acutance_preset_input_profile_overrides": {
+      "Small Print Acutance": "algo/deadleaf_13b10_parity_psd_mtf_profile.json"
+    },
+    "changed_keys": [
+      "acutance_preset_input_profile_overrides"
+    ],
+    "curve_only_acutance_anchor_mixups_preserved": true,
+    "only_acutance_preset_input_override_added": true,
+    "quality_loss_coefficients_preserved": true,
+    "quality_loss_preset_input_profile_overrides_preserved": true,
+    "reported_mtf_readout_fields_preserved": true
+  },
+  "readme_gate_summary": {
+    "all_readme_gates_pass": false,
+    "failed_gates": [
+      "curve_mae_mean"
+    ],
+    "gates": {
+      "5.5\" Phone Display Acutance": {
+        "delta_to_gate": -0.014743622260204217,
+        "operator": "<=",
+        "pass": true,
+        "threshold": 0.05,
+        "value": 0.035256377739795786
+      },
+      "curve_mae_mean": {
+        "delta_to_gate": 0.0042515180357359066,
+        "operator": "<=",
+        "pass": false,
+        "threshold": 0.02,
+        "value": 0.024251518035735907
+      },
+      "focus_preset_acutance_mae_mean": {
+        "delta_to_gate": -0.0016343064037108654,
+        "operator": "<=",
+        "pass": true,
+        "threshold": 0.03,
+        "value": 0.028365693596289134
+      },
+      "non_phone_acutance_preset_mae_max": {
+        "by_preset": {
+          "Computer Monitor Acutance": 0.024146307932311834,
+          "Large Print Acutance": 0.028624302638652583,
+          "Small Print Acutance": 0.028952087494203603,
+          "UHDTV Display Acutance": 0.024849392176481848
+        },
+        "delta_to_gate": -0.0010479125057963959,
+        "operator": "<=",
+        "pass": true,
+        "threshold": 0.03,
+        "value": 0.028952087494203603,
+        "worst_preset": "Small Print Acutance"
+      },
+      "overall_quality_loss_mae_mean": {
+        "delta_to_gate": -0.09564031333060252,
+        "operator": "<=",
+        "pass": true,
+        "threshold": 1.3,
+        "value": 1.2043596866693975
+      }
+    }
+  },
+  "refs": {
+    "baseline_pr": 30,
+    "current_best_issue": 124,
+    "current_best_pr": 125,
+    "current_issue": 132,
+    "discovery_issue": 130,
+    "discovery_pr": 131,
+    "umbrella_issue": 29
+  },
+  "release_separation": {
+    "candidate_is_release_config": false,
+    "golden_reference_roots": [
+      "20260318_deadleaf_13b10",
+      "release/deadleaf_13b10_release/data/20260318_deadleaf_13b10",
+      "release/deadleaf_13b10_release/config"
+    ],
+    "rules": [
+      "The candidate profile is canonical-target research only.",
+      "No fitted outputs are written under golden/reference data roots.",
+      "No release-facing config is promoted in this issue."
+    ]
+  },
+  "result_kind": "positive_targeted_not_full_canonical",
+  "small_print_result": {
+    "baseline_value": 0.031726251556383624,
+    "candidate_delta_to_gate": -0.0010479125057963959,
+    "candidate_value": 0.028952087494203603,
+    "delta_vs_pr125": -0.0027741640621800207,
+    "gate": 0.03,
+    "override_source_profile": "algo/deadleaf_13b10_parity_psd_mtf_profile.json",
+    "target_preset": "Small Print Acutance"
+  },
+  "summary_kind": "issue132_small_print_acutance_boundary_summary"
+}

--- a/docs/issue132_small_print_acutance_boundary_summary.md
+++ b/docs/issue132_small_print_acutance_boundary_summary.md
@@ -1,0 +1,34 @@
+# Issue 132 Small Print Acutance Boundary Summary
+
+- Result: `positive_targeted_not_full_canonical`.
+- Candidate profile: `algo/issue132_small_print_acutance_parity_input_profile.json`.
+- Target preset: `Small Print Acutance`.
+- Override source profile: `algo/deadleaf_13b10_parity_psd_mtf_profile.json`.
+
+## Metrics
+
+| Metric | PR #125 | Issue #132 | Delta | Gate |
+| --- | ---: | ---: | ---: | --- |
+| curve_mae_mean | 0.02425 | 0.02425 | 0.00000 | <= 0.020 (miss) |
+| focus_preset_acutance_mae_mean | 0.02892 | 0.02837 | -0.00055 | <= 0.030 (pass) |
+| overall_quality_loss_mae_mean | 1.20436 | 1.20436 | 0.00000 | <= 1.30 (pass) |
+| mtf_abs_signed_rel_mean | 0.08671 | 0.08671 | 0.00000 | preserve |
+| Small Print Acutance | 0.03173 | 0.02895 | -0.00277 | <= 0.030 (pass) |
+
+## Scope
+
+- Changed profile keys: `acutance_preset_input_profile_overrides`.
+- Only Small Print Acutance input override added: `True`.
+- Quality Loss inputs preserved: `True`.
+- Reported-MTF preserved: `True`.
+- Curve MAE preserved versus PR #125: `True`.
+
+## Result
+
+The Small Print Acutance preset-only boundary passes the targeted non-Phone Acutance gate while preserving PR #125 curve MAE, reported-MTF, overall Quality Loss, Quality Loss inputs, and release separation.
+
+The full canonical README target still misses only `curve_mae_mean <= 0.020`; future curve work remains gated on a separate `0.15` improvement preflight.
+
+## Release Separation
+
+This remains canonical-target research, not a release-facing config promotion. No fitted outputs are written under golden/reference data roots or release configs.

--- a/tests/test_benchmark_parity_acutance_quality_loss.py
+++ b/tests/test_benchmark_parity_acutance_quality_loss.py
@@ -101,6 +101,19 @@ class BenchmarkParityAcutanceQualityLossTest(unittest.TestCase):
             {"Computer Monitor Quality Loss": "algo/pr30_anchor.json"},
         )
 
+    def test_profile_allows_acutance_preset_input_overrides(self) -> None:
+        profile = Profile(
+            name="test",
+            calibration_file="algo/deadleaf_13b10_psd_calibration.json",
+            acutance_preset_input_profile_overrides={
+                "Small Print Acutance": "algo/pr30_anchor.json",
+            },
+        )
+        self.assertEqual(
+            profile.acutance_preset_input_profile_overrides,
+            {"Small Print Acutance": "algo/pr30_anchor.json"},
+        )
+
     def test_choose_roi_reference_refined_uses_reference_seed(self) -> None:
         image = np.zeros((20, 20), dtype=np.float32)
         reference = SimpleNamespace(lrtb=RoiBounds(left=4, right=9, top=5, bottom=10))
@@ -114,7 +127,7 @@ class BenchmarkParityAcutanceQualityLossTest(unittest.TestCase):
         self.assertEqual(actual, expected)
         self.assertEqual(refine.call_args.kwargs["seed_roi"], reference.lrtb)
 
-    def test_quality_loss_preset_input_override_substitutes_only_target_preset(self) -> None:
+    def test_preset_input_overrides_substitute_only_target_metric_family(self) -> None:
         capture_key = "OV13b10_AG8_ET5500_deadleaf_12M_40"
         preset_names = (
             '5.5" Phone Display Acutance',
@@ -169,6 +182,9 @@ class BenchmarkParityAcutanceQualityLossTest(unittest.TestCase):
                 calibration_file="candidate_calibration",
                 quality_loss_preset_input_profile_overrides={
                     "Computer Monitor Quality Loss": str(override_path),
+                },
+                acutance_preset_input_profile_overrides={
+                    "Small Print Acutance": str(override_path),
                 },
             )
             with (
@@ -250,6 +266,14 @@ class BenchmarkParityAcutanceQualityLossTest(unittest.TestCase):
                 1.0,
             )
             self.assertEqual(
+                payload["overall"]["acutance_preset_mae"]["Small Print Acutance"],
+                2.0,
+            )
+            self.assertEqual(
+                payload["overall"]["quality_loss_preset_mae"]["Small Print Quality Loss"],
+                1.0,
+            )
+            self.assertEqual(
                 payload["overall"]["quality_loss_preset_mae"]["Computer Monitor Quality Loss"],
                 2.0,
             )
@@ -260,6 +284,10 @@ class BenchmarkParityAcutanceQualityLossTest(unittest.TestCase):
             self.assertEqual(
                 payload["analysis_pipeline"]["quality_loss_preset_input_profile_overrides"],
                 {"Computer Monitor Quality Loss": str(override_path)},
+            )
+            self.assertEqual(
+                payload["analysis_pipeline"]["acutance_preset_input_profile_overrides"],
+                {"Small Print Acutance": str(override_path)},
             )
 
     def test_summarize_profile_uses_observable_table_frequency_bins(self) -> None:
@@ -776,6 +804,19 @@ class BenchmarkParityAcutanceQualityLossTest(unittest.TestCase):
             matched_ori_anchor_mode="acutance_only",
         )
         self.assertEqual(profile.matched_ori_anchor_mode, "acutance_only")
+
+    def test_psd_profile_allows_acutance_preset_input_overrides(self) -> None:
+        profile = PsdProfile(
+            name="test",
+            calibration_file="algo/deadleaf_13b10_psd_calibration.json",
+            acutance_preset_input_profile_overrides={
+                "Small Print Acutance": "algo/pr30_anchor.json",
+            },
+        )
+        self.assertEqual(
+            profile.acutance_preset_input_profile_overrides,
+            {"Small Print Acutance": "algo/pr30_anchor.json"},
+        )
 
     def test_psd_profile_allows_matched_ori_oecf_fields(self) -> None:
         profile = PsdProfile(

--- a/tests/test_build_issue132_small_print_acutance_summary.py
+++ b/tests/test_build_issue132_small_print_acutance_summary.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from algo.build_issue132_small_print_acutance_summary import build_payload, render_markdown
+
+
+class BuildIssue132SmallPrintAcutanceSummaryTest(unittest.TestCase):
+    def test_payload_records_targeted_small_print_boundary(self) -> None:
+        payload = build_payload(
+            self.repo_root(),
+            issue124_summary_path=Path("artifacts/issue124_curve_only_high_mixup_ori_summary.json"),
+            issue130_discovery_path=Path("artifacts/issue130_next_slice_discovery.json"),
+            candidate_profile_path=Path(
+                "algo/issue132_small_print_acutance_parity_input_profile.json"
+            ),
+            baseline_profile_path=Path(
+                "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_computer_monitor_small_print_large_print_pr30_input_curve_only_high_mixup_ori_profile.json"
+            ),
+            candidate_acutance_path=Path(
+                "artifacts/issue132_small_print_acutance_boundary_acutance_benchmark.json"
+            ),
+            candidate_psd_path=Path(
+                "artifacts/issue132_small_print_acutance_boundary_psd_benchmark.json"
+            ),
+        )
+
+        self.assertEqual(payload["issue"], 132)
+        self.assertEqual(payload["result_kind"], "positive_targeted_not_full_canonical")
+        self.assertEqual(
+            payload["candidate"]["profile_path"],
+            "algo/issue132_small_print_acutance_parity_input_profile.json",
+        )
+
+        small = payload["small_print_result"]
+        self.assertEqual(small["target_preset"], "Small Print Acutance")
+        self.assertAlmostEqual(small["baseline_value"], 0.031726251556383624)
+        self.assertAlmostEqual(small["candidate_value"], 0.028952087494203603)
+        self.assertLess(small["delta_vs_pr125"], -0.0027)
+        self.assertLessEqual(small["candidate_value"], 0.030)
+        self.assertEqual(
+            small["override_source_profile"],
+            "algo/deadleaf_13b10_parity_psd_mtf_profile.json",
+        )
+
+        acceptance = payload["acceptance"]
+        self.assertTrue(acceptance["small_print_gate_pass"])
+        self.assertTrue(acceptance["focus_preset_acutance_gate_pass"])
+        self.assertTrue(acceptance["curve_mae_preserved_vs_pr125"])
+        self.assertTrue(acceptance["reported_mtf_preserved_vs_pr125"])
+        self.assertTrue(acceptance["overall_quality_loss_gate_pass"])
+        self.assertTrue(acceptance["overall_quality_loss_preserved_vs_pr125"])
+        self.assertTrue(acceptance["quality_loss_inputs_preserved"])
+        self.assertTrue(acceptance["only_small_print_acutance_input_added"])
+        self.assertTrue(acceptance["release_separation_preserved"])
+        self.assertFalse(acceptance["full_readme_gate_pass"])
+        self.assertEqual(payload["readme_gate_summary"]["failed_gates"], ["curve_mae_mean"])
+
+        scope = payload["profile_scope_delta"]
+        self.assertEqual(scope["changed_keys"], ["acutance_preset_input_profile_overrides"])
+        self.assertEqual(
+            scope["acutance_preset_input_profile_overrides"],
+            {"Small Print Acutance": "algo/deadleaf_13b10_parity_psd_mtf_profile.json"},
+        )
+        self.assertTrue(scope["quality_loss_preset_input_profile_overrides_preserved"])
+        self.assertTrue(scope["reported_mtf_readout_fields_preserved"])
+
+    def test_payload_preserves_non_target_metrics(self) -> None:
+        payload = build_payload(
+            self.repo_root(),
+            issue124_summary_path=Path("artifacts/issue124_curve_only_high_mixup_ori_summary.json"),
+            issue130_discovery_path=Path("artifacts/issue130_next_slice_discovery.json"),
+            candidate_profile_path=Path(
+                "algo/issue132_small_print_acutance_parity_input_profile.json"
+            ),
+            baseline_profile_path=Path(
+                "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_computer_monitor_small_print_large_print_pr30_input_curve_only_high_mixup_ori_profile.json"
+            ),
+            candidate_acutance_path=Path(
+                "artifacts/issue132_small_print_acutance_boundary_acutance_benchmark.json"
+            ),
+            candidate_psd_path=Path(
+                "artifacts/issue132_small_print_acutance_boundary_psd_benchmark.json"
+            ),
+        )
+
+        delta = payload["comparisons"]["candidate_vs_pr125"]["delta"]
+        self.assertEqual(delta["curve_mae_mean"], 0.0)
+        self.assertEqual(delta["overall_quality_loss_mae_mean"], 0.0)
+        self.assertEqual(delta["mtf_abs_signed_rel_mean"], 0.0)
+        self.assertTrue(all(value == 0.0 for value in delta["mtf_threshold_mae"].values()))
+        self.assertEqual(delta["quality_loss_preset_mae"]["Small Print Quality Loss"], 0.0)
+        self.assertLess(delta["focus_preset_acutance_mae_mean"], 0.0)
+
+    def test_markdown_records_result_and_remaining_gate(self) -> None:
+        payload = build_payload(
+            self.repo_root(),
+            issue124_summary_path=Path("artifacts/issue124_curve_only_high_mixup_ori_summary.json"),
+            issue130_discovery_path=Path("artifacts/issue130_next_slice_discovery.json"),
+            candidate_profile_path=Path(
+                "algo/issue132_small_print_acutance_parity_input_profile.json"
+            ),
+            baseline_profile_path=Path(
+                "algo/deadleaf_13b10_imatest_intrinsic_full_reference_phase_retained_real_reported_mtf_disconnect_pr30_observed_bundle_quality_loss_isolation_downstream_matched_ori_only_computer_monitor_small_print_large_print_pr30_input_curve_only_high_mixup_ori_profile.json"
+            ),
+            candidate_acutance_path=Path(
+                "artifacts/issue132_small_print_acutance_boundary_acutance_benchmark.json"
+            ),
+            candidate_psd_path=Path(
+                "artifacts/issue132_small_print_acutance_boundary_psd_benchmark.json"
+            ),
+        )
+        markdown = render_markdown(payload)
+
+        self.assertIn("# Issue 132 Small Print Acutance Boundary Summary", markdown)
+        self.assertIn("Small Print Acutance", markdown)
+        self.assertIn("algo/deadleaf_13b10_parity_psd_mtf_profile.json", markdown)
+        self.assertIn("only `curve_mae_mean <= 0.020`", markdown)
+        self.assertIn("Release Separation", markdown)
+
+    @staticmethod
+    def repo_root() -> Path:
+        return Path(__file__).resolve().parents[1]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs #132
Refs #29
Refs #124
Refs #130
Context from #131

## Summary

- Added `acutance_preset_input_profile_overrides` support so Acutance preset-only input boundaries can be isolated independently from Quality Loss inputs.
- Added the issue #132 candidate profile, scoped to `Small Print Acutance` only, using `algo/deadleaf_13b10_parity_psd_mtf_profile.json` as the preset input source.
- Regenerated Acutance/Quality Loss, PSD/MTF, JSON summary, and Markdown summary artifacts for the candidate.

## Result

- `Small Print Acutance`: `0.03172625` -> `0.02895209`, passing `<= 0.030`.
- `focus_preset_acutance_mae_mean`: `0.02892053` -> `0.02836569`, still passing `<= 0.030`.
- `curve_mae_mean`: unchanged at `0.02425152`, still the only README gate miss.
- `overall_quality_loss_mae_mean`: unchanged at `1.20435969`, still passing `<= 1.30`.
- Reported-MTF preserved: `mtf_abs_signed_rel_mean = 0.08671417`, `mtf20 = 0.03301077`, `mtf30 = 0.03693639`, `mtf50 = 0.00933262`.

## Validation

- `python3 -m py_compile algo/benchmark_parity_acutance_quality_loss.py algo/benchmark_parity_psd_mtf.py algo/build_issue132_small_print_acutance_summary.py`
- `python3 -m pytest tests/test_benchmark_parity_acutance_quality_loss.py tests/test_build_issue132_small_print_acutance_summary.py tests/test_build_issue130_next_slice_discovery.py -q`
- `python3 -m algo.benchmark_parity_acutance_quality_loss 20260318_deadleaf_13b10 algo/issue132_small_print_acutance_parity_input_profile.json --output artifacts/issue132_small_print_acutance_boundary_acutance_benchmark.json`
- `python3 -m algo.benchmark_parity_psd_mtf 20260318_deadleaf_13b10 algo/issue132_small_print_acutance_parity_input_profile.json --output artifacts/issue132_small_print_acutance_boundary_psd_benchmark.json`
- `python3 -m algo.build_issue132_small_print_acutance_summary --output-json /tmp/issue132_summary_check.json --output-md /tmp/issue132_summary_check.md && cmp -s artifacts/issue132_small_print_acutance_boundary_summary.json /tmp/issue132_summary_check.json && cmp -s docs/issue132_small_print_acutance_boundary_summary.md /tmp/issue132_summary_check.md`
- `git diff --check`
